### PR TITLE
Update Google Font protocol to HTTPS

### DIFF
--- a/cps/static/css/colors.css
+++ b/cps/static/css/colors.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Libre+Baskerville:400,700);
+@import url(https://fonts.googleapis.com/css?family=Libre+Baskerville:400,700);
 
 
 body{

--- a/cps/static/css/style.css
+++ b/cps/static/css/style.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Grand+Hotel);
+@import url(https://fonts.googleapis.com/css?family=Grand+Hotel);
 body{background:#f2f2f2}body h2{font-weight:normal;color:#444}
 a{color: #45b29d}a:hover{color: #444;}
 .navigation .nav-head{text-transform:uppercase;color:#999;margin:20px 0}.navigation .nav-head:nth-child(1n+2){border-top:1px solid #ccc;padding-top:20px}


### PR DESCRIPTION
Google Font urls now default to HTTPS which is good practice, plus it will fix the below error for servers using SSL.

![screen shot 2016-07-18 at 11 13 00 am](https://cloud.githubusercontent.com/assets/172217/16925549/a3e2bf88-4cd9-11e6-8f41-744e450624e9.png)
