### PR TITLE
Fixed epub upload metadata reading 

### DIFF
--- a/cps/epub.py
+++ b/cps/epub.py
@@ -11,7 +11,10 @@ def extractCover(zip, coverFile, tmp_file_name):
     if coverFile is None:
         return None
     else:
-        cf = zip.read("OPS/" + coverFile)
+        try:
+            cf = zip.read("OPS/" + coverFile)
+        except KeyError, e:
+            cf = zip.read(coverFile)
         prefix = os.path.splitext(tmp_file_name)[0]
         tmp_cover_name = prefix + "." + coverFile
         image = open(tmp_cover_name, 'wb')


### PR DESCRIPTION
I raised an issue (#122), but thought I would just rebase my master and create a pull request for you (I am a bit new to using GitHub, trying to learn the ropes). 

Basically, you currently search for the cover.jpg in the OPS folder, but that doesn't seem to be the location of the covers for a few new books I tried to upload, then are just in the root. 