### PR TITLE
More detecting cover when uploading epub file

### DIFF
--- a/cps/epub.py
+++ b/cps/epub.py
@@ -54,7 +54,17 @@ def get_epub_info(tmp_file_path, original_file_name, original_file_extension):
     else:
         coversection = tree.xpath("/pkg:package/pkg:manifest/pkg:item[@id='cover']/@href", namespaces=ns)
         if len(coversection) > 0:
-            coverfile = extractCover(zip, coversection[0], coverpath, tmp_file_path)
+        filetype = coversection[0].rsplit('.',1)[-1]
+            if filetype == "xhtml" or filetype == "html": #if cover is (x)html format
+                markup = zip.read(os.path.join(coverpath,coversection[0]))
+                markupTree = etree.fromstring(markup)
+                #no matter xhtml or html with no namespace
+                imgsrc = markupTree.xpath( "//*[local-name() = 'img']/@src")
+                #imgsrc maybe startwith "../"" so fullpath join then relpath to cwd
+                filename = os.path.relpath(os.path.join(os.path.dirname(os.path.join(coverpath,coversection[0])),imgsrc[0]))
+                coverfile = extractCover(zip, filename, "", tmp_file_path)        
+            else:
+                coverfile = extractCover(zip, coversection[0], coverpath, tmp_file_path)
         else:
             coverfile = None
 

--- a/cps/epub.py
+++ b/cps/epub.py
@@ -54,7 +54,7 @@ def get_epub_info(tmp_file_path, original_file_name, original_file_extension):
     else:
         coversection = tree.xpath("/pkg:package/pkg:manifest/pkg:item[@id='cover']/@href", namespaces=ns)
         if len(coversection) > 0:
-        filetype = coversection[0].rsplit('.',1)[-1]
+            filetype = coversection[0].rsplit('.',1)[-1]
             if filetype == "xhtml" or filetype == "html": #if cover is (x)html format
                 markup = zip.read(os.path.join(coverpath,coversection[0]))
                 markupTree = etree.fromstring(markup)
@@ -66,7 +66,13 @@ def get_epub_info(tmp_file_path, original_file_name, original_file_extension):
             else:
                 coverfile = extractCover(zip, coversection[0], coverpath, tmp_file_path)
         else:
-            coverfile = None
+            meta_cover = tree.xpath("/pkg:package/pkg:metadata/pkg:meta[@name='cover']/@content", namespaces=ns)
+            if len(meta_cover) > 0:
+                meta_cover_content = tree.xpath("/pkg:package/pkg:manifest/pkg:item[@id='"+meta_cover[0]+"']/@href",namespaces=ns)
+                if len(meta_cover_content) > 0:
+                    coverfile = extractCover(zip, meta_cover_content[0], coverpath, tmp_file_path)
+            else:
+                coverfile = None
 
     if epub_metadata['title'] is None:
         title = original_file_name


### PR DESCRIPTION
Scenario 1.
   Read img tag of cover file if cover is (x)html
   for example
   `<item id="cover" href="Text/cover.xhtml" media-type="application/xhtml+xml”/>`
Scenario 2.
   situation when opf file content is
   `<meta name="cover" content="cover.jpg"/>.`
   then
   `<item id="cover.jpg" href="Images/cover.jpg" media-type="image/jpeg"/>`
   before patch, only check id="cover" no according to meta instruction 
