### PR TITLE
[Fix] Download Name format

### DIFF
--- a/cps/web.py
+++ b/cps/web.py
@@ -1275,7 +1275,7 @@ def get_download_link(book_id, format):
             helper.update_download(book_id, int(current_user.id))
         file_name = book.title
         if len(book.authors) > 0:
-            file_name = book.authors[0].name + '-' + file_name
+            file_name = book.authors[0].name + '_' + file_name
         file_name = helper.get_valid_filename(file_name)
         response = make_response(
             send_from_directory(os.path.join(config.config_calibre_dir, book.path), data.name + "." + format))


### PR DESCRIPTION
Expected
author-title.ext
But now "-" is sanitized at helper class.
As a Result,
authortitle.ext
Now fix it with following format
author_title.ext