### PR TITLE
Read dbpath from $CALIBRE_DBPATH if present

### DIFF
--- a/cps/ub.py
+++ b/cps/ub.py
@@ -13,7 +13,7 @@ from flask_babel import gettext as _
 import json
 #from builtins import str
 
-dbpath = os.path.join(os.path.normpath(os.path.dirname(os.path.realpath(__file__)) + os.sep + ".." + os.sep), "app.db")
+dbpath = os.path.join(os.path.normpath(os.getenv("CALIBRE_DBPATH", os.path.dirname(os.path.realpath(__file__)) + os.sep + ".." + os.sep)), "app.db")
 engine = create_engine('sqlite:///{0}'.format(dbpath), echo=False)
 Base = declarative_base()
 


### PR DESCRIPTION
This change allows us to run multiple libraries without needing multiple instances of the engine.

Since app config is all in the db, we get no port conflicts and be able to run multiple instances of this app with no issues.

Using os.getenv instead of os.environ.get allows us to provide CALIBRE_DBPATH inline with the invocation of the file (`CALIBRE_DBPATH=/foo/bar/` python cps.py)