### PR TITLE
Add sort options when viewing books

### DIFF
--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -121,7 +121,19 @@
           <nav class="navigation">
             <ul class="list-unstyled" id="scnd-nav" intent in-standard-append="nav.navigation" in-mobile-after="#main-nav" in-mobile-class="nav navbar-nav">
               <li class="nav-head hidden-xs">{{_('Browse')}}</li>
-              <li id="nav_new"><a href="{{url_for('index')}}"><span class="glyphicon glyphicon-book"></span> {{_('New Books')}}</a></li>
+              <li id="nav_new"><a href="{{url_for('index')}}"><span class="glyphicon glyphicon-book"></span> {{_('Recently Added')}}</a></li>
+              <li class="dropdown">
+                <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+                  <span class="glyphicon glyphicon-sort-by-attributes"></span> {{_('Sorted Books')}}
+                  <span class="caret"></span>
+                </a>
+                <ul class="dropdown-menu">
+                  <li><a href="{{url_for('newest_books')}}">{{_('Sort By')}} {{_('Newest')}}</a></li>
+                  <li><a href="{{url_for('oldest_books')}}">{{_('Sort By')}} {{_('Oldest')}}</a></li>
+                  <li><a href="{{url_for('titles_ascending')}}">{{_('Sort By')}} {{_('Title')}} ({{_('Ascending')}})</a></li>
+                  <li><a href="{{url_for('titles_descending')}}">{{_('Sort By')}} {{_('Title')}}  ({{_('Descending')}})</a></li>
+                </ul>
+              </li>
               {% if g.user.show_hot_books() %}
               <li id="nav_hot"><a href="{{url_for('hot_books')}}"><span class="glyphicon glyphicon-fire"></span> {{_('Hot Books')}}</a></li>
               {%endif%}

--- a/cps/web.py
+++ b/cps/web.py
@@ -998,7 +998,43 @@ def get_matching_tags():
 def index(page):
     entries, random, pagination = fill_indexpage(page, db.Books, True, db.Books.timestamp.desc())
     return render_title_template('index.html', random=random, entries=entries, pagination=pagination,
-                                 title=_(u"Latest Books"))
+                                 title=_(u"Recently Added Books"))
+
+
+@app.route('/books/newest', defaults={'page': 1})
+@app.route('/books/newest/page/<int:page>')
+@login_required_if_no_ano
+def newest_books(page):
+    entries, random, pagination = fill_indexpage(page, db.Books, True, db.Books.pubdate.desc())
+    return render_title_template('index.html', random=random, entries=entries, pagination=pagination,
+                                 title=_(u"Newest Books"))
+
+
+@app.route('/books/oldest', defaults={'page': 1})
+@app.route('/books/oldest/page/<int:page>')
+@login_required_if_no_ano
+def oldest_books(page):
+    entries, random, pagination = fill_indexpage(page, db.Books, True, db.Books.pubdate)
+    return render_title_template('index.html', random=random, entries=entries, pagination=pagination,
+                                 title=_(u"Oldest Books"))
+
+
+@app.route('/books/a-z', defaults={'page': 1})
+@app.route('/books/a-z/page/<int:page>')
+@login_required_if_no_ano
+def titles_ascending(page):
+    entries, random, pagination = fill_indexpage(page, db.Books, True, db.Books.sort)
+    return render_title_template('index.html', random=random, entries=entries, pagination=pagination,
+                                 title=_(u"Books (A-Z)"))
+
+
+@app.route('/books/z-a', defaults={'page': 1})
+@app.route('/books/z-a/page/<int:page>')
+@login_required_if_no_ano
+def titles_descending(page):
+    entries, random, pagination = fill_indexpage(page, db.Books, True, db.Books.sort.desc())
+    return render_title_template('index.html', random=random, entries=entries, pagination=pagination,
+                                 title=_(u"Books (Z-A)"))
 
 
 @app.route("/hot", defaults={'page': 1})


### PR DESCRIPTION
Default view still shows the latest books, but includes ability to show oldest books, and books sorted alphabetically (ascending & descending).

I did not include translations for the next text, but they are split up for easy translating and are otherwise ready for translating.

![screen shot 2017-07-06 at 9 31 10 pm](https://user-images.githubusercontent.com/999845/27943284-a5b54e32-6292-11e7-9427-cd384c603f4e.png)

Please let me know if there's any configuration that you would like me to include or any feedback you have.