### PR TITLE
Add padding to bottom of buttons

### DIFF
--- a/cps/static/css/style.css
+++ b/cps/static/css/style.css
@@ -43,7 +43,7 @@ span.glyphicon.glyphicon-tags {padding-right: 5px;color: #999;vertical-align: te
 .btn-file {position: relative; overflow: hidden;}
 .btn-file input[type=file] {position: absolute; top: 0; right: 0; min-width: 100%; min-height: 100%; font-size: 100px; text-align: right; filter: alpha(opacity=0); opacity: 0; outline: none; background: white; cursor: inherit; display: block;}
 
-.btn-toolbar .btn { margin-bottom: 5px; }
+.btn-toolbar .btn,.discover .btn { margin-bottom: 5px; }
 
 .btn-primary:hover, .btn-primary:focus, .btn-primary:active, .btn-primary.active, .open .dropdown-toggle.btn-primary{ background-color: #1C5484; }
 .btn-primary.disabled, .btn-primary[disabled], fieldset[disabled] .btn-primary, .btn-primary.disabled:hover, .btn-primary[disabled]:hover, fieldset[disabled] .btn-primary:hover, .btn-primary.disabled:focus, .btn-primary[disabled]:focus, fieldset[disabled] .btn-primary:focus, .btn-primary.disabled:active, .btn-primary[disabled]:active, fieldset[disabled] .btn-primary:active, .btn-primary.disabled.active, .btn-primary[disabled].active, fieldset[disabled] .btn-primary.active { background-color: #89B9E2; }


### PR DESCRIPTION
This adds some space between the buttons when viewing them on a mobile device. It affects the buttons on every page that has the `.discover` class wrapping the contents, including the shelf, admin, SMTP, and profile pages.

With the style change, this

![screen shot 2017-07-06 at 7 33 47 am](https://user-images.githubusercontent.com/999845/27916655-96b2c2e4-621e-11e7-9130-9fa56d8e0188.png)

becomes this

![screen shot 2017-07-06 at 7 33 27 am](https://user-images.githubusercontent.com/999845/27916660-9dac3120-621e-11e7-9719-7b40a3439820.png)

Please let me know what feedback you have.