### PR TITLE
Show book details in modal dialog

### DIFF
--- a/cps/static/js/main.js
+++ b/cps/static/js/main.js
@@ -121,6 +121,17 @@ $(function() {
         });
     });
 
+    $('#bookDetailsModal')
+      .on('show.bs.modal', function(e) {
+        var $modalBody = $(this).find('.modal-body');
+        $.get(e.relatedTarget.href).done(function(content) {
+          $modalBody.html(content);
+        });
+      })
+      .on('hidden.bs.modal', function() {
+        $(this).find('.modal-body').html('...');
+      });
+
     $(window).resize(function(event) {
         $(".discover .row").isotope("reLayout");
     });

--- a/cps/static/js/main.js
+++ b/cps/static/js/main.js
@@ -121,15 +121,15 @@ $(function() {
         });
     });
 
-    $('#bookDetailsModal')
-      .on('show.bs.modal', function(e) {
-        var $modalBody = $(this).find('.modal-body');
+    $("#bookDetailsModal")
+      .on("show.bs.modal", function(e) {
+        var $modalBody = $(this).find(".modal-body");
         $.get(e.relatedTarget.href).done(function(content) {
           $modalBody.html(content);
         });
       })
-      .on('hidden.bs.modal', function() {
-        $(this).find('.modal-body').html('...');
+      .on("hidden.bs.modal", function() {
+        $(this).find(".modal-body").html("...");
       });
 
     $(window).resize(function(event) {

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -235,7 +235,6 @@
 {% endblock %}
 
 {% block js %}
-<script src="{{ url_for('static', filename='js/libs/jquery.form.js') }}"></script>
 <script>
   $( document ).ready(function() {
     $('#have_read_form').ajaxForm();

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends is_xhr|yesno("fragment.html", "layout.html") %}
 {% block body %}
 <div class="single">
   <div class="row">

--- a/cps/templates/discover.html
+++ b/cps/templates/discover.html
@@ -8,7 +8,7 @@
     <div class="col-sm-3 col-lg-2 col-xs-6 book">
       <div class="cover">
         {% if entry.has_cover is defined %}
-          <a href="{{ url_for('show_book', book_id=entry.id) }}">
+          <a href="{{ url_for('show_book', book_id=entry.id) }}" data-toggle="modal" data-target="#bookDetailsModal" data-remote="false">
             <img src="{{ url_for('get_cover', cover_path=entry.path.replace('\\','/')) }}" />
           </a>
         {% endif %}

--- a/cps/templates/fragment.html
+++ b/cps/templates/fragment.html
@@ -1,0 +1,4 @@
+<div class="container-fluid">
+  {% block body %}{% endblock %}
+</div>
+{% block js %}{% endblock %}

--- a/cps/templates/index.html
+++ b/cps/templates/index.html
@@ -8,7 +8,7 @@
     {% for entry in random %}
     <div id="books_rand" class="col-sm-3 col-lg-2 col-xs-6 book">
       <div class="cover">
-          <a href="{{ url_for('show_book', book_id=entry.id) }}">
+          <a href="{{ url_for('show_book', book_id=entry.id) }}" data-toggle="modal" data-target="#bookDetailsModal" data-remote="false">
             {% if entry.has_cover %}
               <img src="{{ url_for('get_cover', cover_path=entry.path.replace('\\','/')) }}" />
             {% else %}
@@ -44,7 +44,7 @@
     {% for entry in entries %}
     <div id="books" class="col-sm-3 col-lg-2 col-xs-6 book">
       <div class="cover">
-          <a href="{{ url_for('show_book', book_id=entry.id) }}">
+          <a href="{{ url_for('show_book', book_id=entry.id) }}" data-toggle="modal" data-target="#bookDetailsModal" data-remote="false">
             {% if entry.has_cover %}
               <img src="{{ url_for('get_cover', cover_path=entry.path.replace('\\','/')) }}" />
             {% else %}

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -28,6 +28,7 @@
     <script src="{{ url_for('static', filename='js/libs/intention.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/libs/context.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/libs/plugins.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/libs/jquery.form.js') }}"></script>
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>
 
     {% block header %}{% endblock %}

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -188,6 +188,20 @@
         </div>
       </div>
     </div>
+    <div class="modal fade" id="bookDetailsModal" tabindex="-1" role="dialog" aria-labelledby="bookDetailsModalLabel">
+      <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            <h4 class="modal-title" id="bookDetailsModalLabel">{{_('Book Details')}}</h4>
+          </div>
+          <div class="modal-body">...</div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-default" data-dismiss="modal">{{_('Close')}}</button>
+          </div>
+        </div>
+      </div>
+    </div>
     {% block modal %}{% endblock %}
     {% block js %}{% endblock %}
   </body>

--- a/cps/templates/search.html
+++ b/cps/templates/search.html
@@ -15,7 +15,7 @@
     <div class="col-sm-3 col-lg-2 col-xs-6 book">
       <div class="cover">
         {% if entry.has_cover is defined %}
-           <a href="{{ url_for('show_book', book_id=entry.id) }}">
+           <a href="{{ url_for('show_book', book_id=entry.id) }}" data-toggle="modal" data-target="#bookDetailsModal" data-remote="false">
             <img src="{{ url_for('get_cover', cover_path=entry.path.replace('\\','/')) }}" />
           </a>
         {% endif %}

--- a/cps/templates/shelf.html
+++ b/cps/templates/shelf.html
@@ -15,7 +15,7 @@
     <div class="col-sm-3 col-lg-2 col-xs-6 book">
       <div class="cover">
         {% if entry.has_cover is defined %}
-          <a href="{{ url_for('show_book', book_id=entry.id) }}">
+          <a href="{{ url_for('show_book', book_id=entry.id) }}" data-toggle="modal" data-target="#bookDetailsModal" data-remote="false">
             <img src="{{ url_for('get_cover', cover_path=entry.path.replace('\\','/')) }}" />
           </a>
         {% endif %}

--- a/cps/web.py
+++ b/cps/web.py
@@ -411,6 +411,11 @@ def timestamptodate(date, fmt=None):
     return native.strftime(time_format)
 
 
+@app.template_filter('yesno')
+def yesno(str, yes, no):
+    return yes if str else no
+
+
 def admin_required(f):
     """
     Checks if current_user.role == 1
@@ -1233,7 +1238,7 @@ def show_book(book_id):
         else:
             have_read = None
 
-        return render_title_template('detail.html', entry=entries, cc=cc,
+        return render_title_template('detail.html', entry=entries, cc=cc, is_xhr=request.is_xhr,
                                      title=entries.title, books_shelfs=book_in_shelfs, have_read=have_read)
     else:
         flash(_(u"Error opening eBook. File does not exist or file is not accessible:"), category="error")

--- a/cps/web.py
+++ b/cps/web.py
@@ -412,8 +412,8 @@ def timestamptodate(date, fmt=None):
 
 
 @app.template_filter('yesno')
-def yesno(str, yes, no):
-    return yes if str else no
+def yesno(value, yes, no):
+    return yes if value else no
 
 
 def admin_required(f):


### PR DESCRIPTION
With them shown in a modal, you don't lose your place in the pagination. If the request comes via Ajax, the minimal layout is used. If via a normal request, the full layout is used. That lets you open the details in a new tab and have the full experience, but if you're clicking through the results of a search, you can view many without losing your place.

While I was going through my library, marking everything that I'd read, I was annoyed by the need to open the books in a new tab or risk losing my place in the pagination.

Please let me know what feedback you have. Thanks!

![screen shot 2017-07-06 at 9 25 25 am](https://user-images.githubusercontent.com/999845/27921591-13ad781c-622d-11e7-82e4-cbb9c1b82e00.png)