### PR TITLE
[Fix] Associate label with correct input

### DIFF
--- a/cps/templates/user_edit.html
+++ b/cps/templates/user_edit.html
@@ -110,7 +110,7 @@
         </div>
         <div class="form-group">
           <input type="checkbox" name="edit_shelf_role" id="edit_shelf_role" {% if content.role_edit_shelfs() %}checked{% endif %}>
-          <label for="passwd_role">{{_('Allow Editing Public Shelfs')}}</label>
+          <label for="edit_shelf_role">{{_('Allow Editing Public Shelfs')}}</label>
         </div>
       {% endif %}
     {% endif %}


### PR DESCRIPTION
Same fix made with 92f634b6a6a2bcabaa4263ba4ec4e353f1b4bc26, different template.