### PR TITLE
Split event listener and selector string

### DIFF
--- a/cps/static/js/edit_books.js
+++ b/cps/static/js/edit_books.js
@@ -162,7 +162,7 @@ var promiseLanguages = languages.initialize();
             });
     });
 
-$("form").on("change input typeahead:selected", function(data){
+$("form").on("change", "input.typeahead:selected", function(){
     var form = $("form").serialize();
     $.getJSON( getPath()+"/get_matching_tags", form, function( data ) {
       $(".tags_click").each(function() {


### PR DESCRIPTION
Event and selectors appear to have been accidentally combined. The result is that typing in any input triggers a call to the `/get_matching_tags` route. We can probably limit the selector farther to only fire when `#tags` is typed into.