### PR TITLE
Send mail from the FROM address instead of the login

### DIFF
--- a/cps/helper.py
+++ b/cps/helper.py
@@ -176,7 +176,7 @@ def send_raw_email(kindle_mail, msg):
 
         if settings["mail_password"]:
             mailserver.login(settings["mail_login"], settings["mail_password"])
-        mailserver.sendmail(settings["mail_login"], kindle_mail, msg)
+        mailserver.sendmail(settings["mail_from"], kindle_mail, msg)
         mailserver.quit()
 
         smtplib.stderr = org_stderr


### PR DESCRIPTION
When SMTP is configured to use a service that doesn't use an email address to log in – e.g. AWS SES or Postmark – the sendmail request fails saying the FROM address is invalid.

With this change, I was able to send using both Gmail and AWS SES. Previously, AWS SES failed saying "Invalid MAIL FROM address provided" because the IAM user access key is not an email address.