### PR TITLE
Use SECRET_KEY from environment variable

### DIFF
--- a/cps/web.py
+++ b/cps/web.py
@@ -218,7 +218,7 @@ lm = LoginManager(app)
 lm.init_app(app)
 lm.login_view = 'login'
 lm.anonymous_user = ub.Anonymous
-app.secret_key = 'A0Zr98j/3yX R~XHH!jmN]LWX/,?RT'
+app.secret_key = os.getenv('SECRET_KEY', 'A0Zr98j/3yX R~XHH!jmN]LWX/,?RT')
 db.setup_db()
 
 if config.config_log_level == logging.DEBUG:


### PR DESCRIPTION
Try to retrieve `SECRET_KEY` from an environment variable before falling back to the default key.

I'm not sure if there's anything performing encryption right now (since calibre-web doesn't appear to use Flask's `session` object) but in case that changes in the future, I think the option should exist to use a non-default key (especially since the current one comes straight from Flask's online documentation).