### PR TITLE
Use ajax to add/remove books from shelves

### DIFF
--- a/cps/static/css/style.css
+++ b/cps/static/css/style.css
@@ -53,3 +53,8 @@ span.glyphicon.glyphicon-tags {padding-right: 5px;color: #999;vertical-align: te
 .spinner2 {margin:0 41%;}
 
 .block-label {display: block;}
+
+#remove-from-shelves .btn,
+#shelf-action-errors {
+    margin-left: 5px;
+}

--- a/cps/static/js/details.js
+++ b/cps/static/js/details.js
@@ -6,7 +6,7 @@ $("#have_read_cb").on("change", function() {
     $(this).closest("form").submit();
 });
 
-$(document).on("click", "[data-shelf-action]", function (e) {
+$("#shelf-actions").on("click", "[data-shelf-action]", function (e) {
     e.preventDefault();
 
     $.get(this.href)

--- a/cps/static/js/details.js
+++ b/cps/static/js/details.js
@@ -1,0 +1,39 @@
+$( document ).ready(function() {
+    $("#have_read_form").ajaxForm();
+});
+
+$("#have_read_cb").on("change", function() {
+    $(this).closest("form").submit();
+});
+
+$(document).on("click", "[data-shelf-action]", function (e) {
+    e.preventDefault();
+
+    $.get(this.href)
+        .done(() => {
+            const $this = $(this);
+            switch ($this.data("shelf-action")) {
+                case "add":
+                    $("#remove-from-shelves").append(`<a href="${$this.data("remove-href")}"
+                       data-add-href="${this.href}"
+                       class="btn btn-sm btn-default" data-shelf-action="remove"
+                    ><span class="glyphicon glyphicon-remove"></span> ${this.textContent}</a>`);
+                    break;
+                case "remove":
+                    $("#add-to-shelves").append(`<li><a href="${$this.data("add-href")}"
+                      data-remove-href="${this.href}"
+                      data-shelf-action="add"
+                    >${this.textContent}</a></li>`);
+                    break;
+            }
+            this.parentNode.removeChild(this);
+        })
+        .fail(xhr => {
+            const $msg = $("<span/>", { "class": "text-danger"}).text(xhr.responseText);
+            $("#shelf-action-status").html($msg);
+
+            setTimeout(() => {
+                $msg.remove();
+            }, 10000);
+        });
+});

--- a/cps/static/js/details.js
+++ b/cps/static/js/details.js
@@ -28,7 +28,7 @@ $(document).on("click", "[data-shelf-action]", function (e) {
             }
             this.parentNode.removeChild(this);
         })
-        .fail(xhr => {
+        .fail((xhr) => {
             const $msg = $("<span/>", { "class": "text-danger"}).text(xhr.responseText);
             $("#shelf-action-status").html($msg);
 

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -185,41 +185,62 @@
       {% if g.user.shelf.all() or g.public_shelfes %}
       <div class="btn-toolbar" role="toolbar">
         <div class="btn-group" role="group" aria-label="Add to shelves">
-              <button id="btnGroupDrop2" type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                <span class="glyphicon glyphicon-list"></span> {{_('Add to shelf')}}
-                <span class="caret"></span>
-              </button>
-              <ul class="dropdown-menu" aria-labelledby="btnGroupDrop2">
-                {% for shelf in g.user.shelf %}
-                  {% if not shelf.id in books_shelfs and shelf.is_public != 1 %}
-                    <li><a href="{{ url_for('add_to_shelf', book_id=entry.id, shelf_id=shelf.id) }}">{{shelf.name}}</a></li>
-                  {% endif %}
-                {%endfor%}
-                {% for shelf in g.public_shelfes %}
-                  {% if not shelf.id in books_shelfs %}
-                    <li><a href="{{ url_for('add_to_shelf', book_id=entry.id, shelf_id=shelf.id) }}">{{shelf.name}}</a></li>
-                  {% endif %}
-                {%endfor%}
-              </ul>
-        </div>
-        {% if books_shelfs %}
-        <div class="btn-group" role="group" aria-label="Remove from shelves">
-              {% for shelf in g.user.shelf %}
-                {% if shelf.id in books_shelfs and shelf.is_public != 1 %}
-                  <a href="{{ url_for('remove_from_shelf', book_id=entry.id, shelf_id=shelf.id) }}" class="btn btn-sm btn-default" role="button">
-                    <span class="glyphicon glyphicon-remove"></span> {{shelf.name}}
+          <button id="btnGroupDrop2" type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <span class="glyphicon glyphicon-list"></span> {{_('Add to shelf')}}
+            <span class="caret"></span>
+          </button>
+          <ul id="add-to-shelves" class="dropdown-menu" aria-labelledby="btnGroupDrop2">
+            {% for shelf in g.user.shelf %}
+              {% if not shelf.id in books_shelfs and shelf.is_public != 1 %}
+                <li>
+                  <a href="{{ url_for('add_to_shelf', book_id=entry.id, shelf_id=shelf.id) }}"
+                     data-remove-href="{{ url_for('remove_from_shelf', book_id=entry.id, shelf_id=shelf.id) }}"
+                     data-shelf-action="add"
+                  >
+                    {{shelf.name}}
                   </a>
-                {% endif %}
-              {%endfor%}
-              {% for shelf in g.public_shelfes %}
-                {% if shelf.id in books_shelfs %}
-                  <a href="{{ url_for('remove_from_shelf', book_id=entry.id, shelf_id=shelf.id) }}" class="btn btn-sm btn-default" role="button">
-                    <span class="glyphicon glyphicon-remove"></span> {{shelf.name}}
+                </li>
+              {% endif %}
+            {%endfor%}
+            {% for shelf in g.public_shelfes %}
+              {% if not shelf.id in books_shelfs %}
+                <li>
+                  <a href="{{ url_for('add_to_shelf', book_id=entry.id, shelf_id=shelf.id) }}"
+                     data-remove-href="{{ url_for('remove_from_shelf', book_id=entry.id, shelf_id=shelf.id) }}"
+                     data-shelf-action="add"
+                  >
+                    {{shelf.name}}
                   </a>
-                {% endif %}
-              {%endfor%}
-            {% endif %}
+                </li>
+              {% endif %}
+            {%endfor%}
+          </ul>
         </div>
+        <div id="remove-from-shelves" class="btn-group" role="group" aria-label="Remove from shelves">
+          {% if books_shelfs %}
+            {% for shelf in g.user.shelf %}
+              {% if shelf.id in books_shelfs and shelf.is_public != 1 %}
+                <a href="{{ url_for('remove_from_shelf', book_id=entry.id, shelf_id=shelf.id) }}"
+                   data-add-href="{{ url_for('add_to_shelf', book_id=entry.id, shelf_id=shelf.id) }}"
+                   class="btn btn-sm btn-default" role="button" data-shelf-action="remove"
+                >
+                  <span class="glyphicon glyphicon-remove"></span> {{shelf.name}}
+                </a>
+              {% endif %}
+            {%endfor%}
+            {% for shelf in g.public_shelfes %}
+              {% if shelf.id in books_shelfs %}
+                <a href="{{ url_for('remove_from_shelf', book_id=entry.id, shelf_id=shelf.id) }}"
+                   data-add-href="{{ url_for('add_to_shelf', book_id=entry.id, shelf_id=shelf.id) }}"
+                   class="btn btn-sm btn-default" role="button" data-shelf-action="remove"
+                >
+                  <span class="glyphicon glyphicon-remove"></span> {{shelf.name}}
+                </a>
+              {% endif %}
+            {%endfor%}
+          {% endif %}
+        </div>
+        <div id="shelf-action-errors" class="pull-left" role="alert"></div>
       </div>
       {% endif %}
 
@@ -233,19 +254,12 @@
       {% endif %}
       </div>
 
-
     </div>
   </div>
+</div>
 {% endblock %}
 
 {% block js %}
 <script src="{{ url_for('static', filename='js/libs/jquery.form.js') }}"></script>
-<script>
-  $( document ).ready(function() {
-    $('#have_read_form').ajaxForm();
-  });
-  $("#have_read_cb").on('change', function() {
-    $(this).closest('form').submit();
-  });
-</script>
+<script src="{{ url_for('static', filename='js/details.js') }}"></script>
 {% endblock %}

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -183,7 +183,7 @@
 
       {% if g.user.is_authenticated %}
       {% if g.user.shelf.all() or g.public_shelfes %}
-      <div class="btn-toolbar" role="toolbar">
+      <div id="shelf-actions" class="btn-toolbar" role="toolbar">
         <div class="btn-group" role="group" aria-label="Add to shelves">
           <button id="btnGroupDrop2" type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <span class="glyphicon glyphicon-list"></span> {{_('Add to shelf')}}

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -99,17 +99,17 @@
     </div>
     {% for message in get_flashed_messages(with_categories=True) %}
       {%if message[0] == "error" %}
-      <div class="row-fluid" style="margin-top: -20px; text-align: center;">
+      <div class="row-fluid text-center" style="margin-top: -20px;">
         <div id="flash_alert" class="alert alert-danger">{{ message[1] }}</div>
       </div>
       {%endif%}
       {%if message[0] == "info" %}
-      <div class="row-fluid" style="margin-top: -20px; text-align: center;">
+      <div class="row-fluid text-center" style="margin-top: -20px;">
         <div id="flash_info" class="alert alert-info">{{ message[1] }}</div>
       </div>
       {%endif%}
       {%if message[0] == "success" %}
-      <div class="row-fluid" style="margin-top: -20px; text-align: center;">
+      <div class="row-fluid text-center" style="margin-top: -20px;">
         <div id="flash_success" class="alert alert-success">{{ message[1] }}</div>
       </div>
       {%endif%}


### PR DESCRIPTION
Instead of redirecting the user away from the page or causing a full refresh, the user is able to add books to multiple shelves in quick succession.

If JavaScript is disabled, it gracefully falls back to a standard request (the current behavior).

![shelf-actions](https://user-images.githubusercontent.com/999845/28493787-79ca61fe-6ed1-11e7-93da-78c06f75f6fe.gif)