### PR TITLE
Fix hmac creation in send_test_email function

### DIFF
--- a/cps/helper.py
+++ b/cps/helper.py
@@ -176,7 +176,7 @@ def send_raw_email(kindle_mail, msg):
             mailserver.starttls()
 
         if settings["mail_password"]:
-            mailserver.login(settings["mail_login"], settings["mail_password"])
+            mailserver.login(str(settings["mail_login"]), str(settings["mail_password"]))
         mailserver.sendmail(settings["mail_from"], kindle_mail, msg)
         mailserver.quit()
 


### PR DESCRIPTION
Now, on send test email try got an exception:

```
  File "/opt/calibre-web/cps/helper.py", line 179, in send_raw_email
    mailserver.login(settings["mail_login"], settings["mail_password"])
  File "/usr/lib/python2.7/smtplib.py", line 607, in login
    (code, resp) = self.docmd(encode_cram_md5(resp, user, password))
  File "/usr/lib/python2.7/smtplib.py", line 571, in encode_cram_md5
    response = user + " " + hmac.HMAC(password, challenge).hexdigest()
  File "/usr/lib/python2.7/hmac.py", line 75, in __init__
    self.outer.update(key.translate(trans_5C))
TypeError: character mapping must return integer, None or unicode
```