### PR TITLE
Added tags metadata handler for epubs

### DIFF
--- a/cps/epub.py
+++ b/cps/epub.py
@@ -43,12 +43,15 @@ def get_epub_info(tmp_file_path, original_file_name, original_file_extension):
 
     epub_metadata = {}
 
-    for s in ['title', 'description', 'creator', 'language']:
+    for s in ['title', 'description', 'creator', 'language', 'subject']:
         tmp = p.xpath('dc:%s/text()' % s, namespaces=ns)
         if len(tmp) > 0:
             epub_metadata[s] = p.xpath('dc:%s/text()' % s, namespaces=ns)[0]
         else:
             epub_metadata[s] = "Unknown"
+
+    if epub_metadata['subject'] == "Unknown":
+        epub_metadata['subject'] = ''
 
     if epub_metadata['description'] == "Unknown":
         description = tree.xpath("//*[local-name() = 'description']/text()")
@@ -101,7 +104,7 @@ def get_epub_info(tmp_file_path, original_file_name, original_file_extension):
         author=epub_metadata['creator'].encode('utf-8').decode('utf-8'),
         cover=coverfile,
         description=epub_metadata['description'],
-        tags="",
+        tags=epub_metadata['subject'].encode('utf-8').decode('utf-8'),
         series="",
         series_id="",
         languages=epub_metadata['language'])

--- a/cps/web.py
+++ b/cps/web.py
@@ -2928,7 +2928,7 @@ def upload():
 
         title = meta.title
         author = meta.author
-
+        tags = meta.tags
         title_dir = helper.get_valid_filename(title, False)
         author_dir = helper.get_valid_filename(author, False)
         data_name = title_dir
@@ -2995,6 +2995,11 @@ def upload():
         if upload_comment != "":
             db.session.add(db.Comments(upload_comment, db_book.id))
         db.session.commit()
+
+        input_tags = tags.split(',')
+        input_tags = map(lambda it: it.strip(), input_tags)
+        modify_database_object(input_tags, db_book.tags, db.Tags, db.session, 'tags')
+
         if db_language is not None:  # display Full name instead of iso639.part3
             db_book.languages[0].language_name = _(meta.languages)
         author_names = []


### PR DESCRIPTION
Automatically reads the dc:subject tag on epubs to autofill the Tags field when uploading a new book to the library