### PR TITLE
Added separation for input labels in advanced search view

### DIFF
--- a/cps/static/css/style.css
+++ b/cps/static/css/style.css
@@ -63,4 +63,4 @@ span.glyphicon.glyphicon-tags {padding-right: 5px;color: #999;vertical-align: te
     margin-left: 5px;
 }
 
-.tags_click, .serie_click, .language_click {margin-right: 0px;}
+.tags_click, .serie_click, .language_click {margin-right: 5px;}

--- a/cps/static/css/style.css
+++ b/cps/static/css/style.css
@@ -62,3 +62,5 @@ span.glyphicon.glyphicon-tags {padding-right: 5px;color: #999;vertical-align: te
 #shelf-action-errors {
     margin-left: 5px;
 }
+
+tags_click, .serie_click, .language_click {margin-right: 5px;}

--- a/cps/static/css/style.css
+++ b/cps/static/css/style.css
@@ -63,4 +63,4 @@ span.glyphicon.glyphicon-tags {padding-right: 5px;color: #999;vertical-align: te
     margin-left: 5px;
 }
 
-tags_click, .serie_click, .language_click {margin-right: 5px;}
+.tags_click, .serie_click, .language_click {margin-right: 0px;}


### PR DESCRIPTION
Improve readability of the labels by separating them 5 px.

Before:
![image](https://user-images.githubusercontent.com/5280026/28791070-7520b1ec-762b-11e7-9ea2-e4e0d0d207fc.png)

After:
![image](https://user-images.githubusercontent.com/5280026/28791033-5c0cf08a-762b-11e7-98f0-0a4e601efcbf.png)
