### PR TITLE
Add option to hide mature content from some users

### DIFF
--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -73,6 +73,13 @@
       <input type="text" class="form-control" name="config_title_regex" id="config_title_regex" value="{% if content.config_title_regex != None %}{{ content.config_title_regex }}{% endif %}" autocomplete="off">
     </div>
     <div class="form-group">
+      <label for="config_mature_content_tags">{{_('Tags for Mature Content')}}</label>
+      <input type="text" class="form-control" name="config_mature_content_tags" id="config_mature_content_tags"
+             value="{% if content.config_mature_content_tags != None%}{{ content.config_mature_content_tags }}{% endif %}"
+             autocomplete="off"
+      >
+    </div>
+    <div class="form-group">
     <label for="config_log_level">{{_('Log Level')}}</label>
         <select name="config_log_level" id="config_log_level" class="form-control">
                 <option value="10" {% if content.config_log_level == 10 %}selected{% endif %}>DEBUG</option>

--- a/cps/templates/user_edit.html
+++ b/cps/templates/user_edit.html
@@ -40,45 +40,48 @@
             {% endfor %}
         </select>
     </div>
-      <div class="col-sm-6">
-
-    <div class="form-group">
-        <input type="checkbox" name="show_random" id="show_random" {% if content.show_random_books() %}checked{% endif %}>
-        <label for="show_random">{{_('Show random books')}}</label>
+    <div class="col-sm-6">
+      <div class="form-group">
+        <input type="checkbox" name="show_mature_content" id="show_mature_content" {% if content.mature_content %}checked{% endif %}>
+        <label for="show_mature_content">{{_('Show mature content')}}</label>
+      </div>
+      <div class="form-group">
+          <input type="checkbox" name="show_random" id="show_random" {% if content.show_random_books() %}checked{% endif %}>
+          <label for="show_random">{{_('Show random books')}}</label>
+      </div>
+      <div class="form-group">
+          <input type="checkbox" name="show_hot" id="show_hot" {% if content.show_hot_books() %}checked{% endif %}>
+          <label for="show_hot">{{_('Show hot books')}}</label>
+      </div>
+      <div class="form-group">
+          <input type="checkbox" name="show_best_rated" id="show_best_rated" {% if content.show_best_rated_books() %}checked{% endif %}>
+          <label for="show_best_rated">{{_('Show best rated books')}}</label>
+      </div>
+      <div class="form-group">
+          <input type="checkbox" name="show_language" id="show_language" {% if content.show_language() %}checked{% endif %}>
+          <label for="show_language">{{_('Show language selection')}}</label>
+      </div>
+      <div class="form-group">
+          <input type="checkbox" name="show_series" id="show_series" {% if content.show_series() %}checked{% endif %}>
+          <label for="show_series">{{_('Show series selection')}}</label>
+      </div>
+      <div class="form-group">
+          <input type="checkbox" name="show_category" id="show_category" {% if content.show_category() %}checked{% endif %}>
+          <label for="show_category">{{_('Show category selection')}}</label>
+      </div>
+      <div class="form-group">
+          <input type="checkbox" name="show_author" id="show_author" {% if content.show_author() %}checked{% endif %}>
+          <label for="show_author">{{_('Show author selection')}}</label>
+      </div>
+      <div class="form-group">
+          <input type="checkbox" name="show_read_and_unread" id="show_read_and_unread" {% if content.show_read_and_unread() %}checked{% endif %}>
+          <label for="show_read_and_unread">{{_('Show read and unread')}}</label>
+      </div>
+      <div class="form-group">
+          <input type="checkbox" name="show_detail_random" id="show_detail_random" {% if content.show_detail_random() %}checked{% endif %}>
+          <label for="show_detail_random">{{_('Show random books in detail view')}}</label>
+      </div>
     </div>
-    <div class="form-group">
-        <input type="checkbox" name="show_hot" id="show_hot" {% if content.show_hot_books() %}checked{% endif %}>
-        <label for="show_hot">{{_('Show hot books')}}</label>
-    </div>
-    <div class="form-group">
-        <input type="checkbox" name="show_best_rated" id="show_best_rated" {% if content.show_best_rated_books() %}checked{% endif %}>
-        <label for="show_best_rated">{{_('Show best rated books')}}</label>
-    </div>
-    <div class="form-group">
-        <input type="checkbox" name="show_language" id="show_language" {% if content.show_language() %}checked{% endif %}>
-        <label for="show_language">{{_('Show language selection')}}</label>
-    </div>
-    <div class="form-group">
-        <input type="checkbox" name="show_series" id="show_series" {% if content.show_series() %}checked{% endif %}>
-        <label for="show_series">{{_('Show series selection')}}</label>
-    </div>
-    <div class="form-group">
-        <input type="checkbox" name="show_category" id="show_category" {% if content.show_category() %}checked{% endif %}>
-        <label for="show_category">{{_('Show category selection')}}</label>
-    </div>
-    <div class="form-group">
-        <input type="checkbox" name="show_author" id="show_author" {% if content.show_author() %}checked{% endif %}>
-        <label for="show_author">{{_('Show author selection')}}</label>
-    </div>
-    <div class="form-group">
-        <input type="checkbox" name="show_read_and_unread" id="show_read_and_unread" {% if content.show_read_and_unread() %}checked{% endif %}>
-        <label for="show_read_and_unread">{{_('Show read and unread')}}</label>
-    </div>
-    <div class="form-group">
-        <input type="checkbox" name="show_detail_random" id="show_detail_random" {% if content.show_detail_random() %}checked{% endif %}>
-        <label for="show_detail_random">{{_('Show random books in detail view')}}</label>
-    </div>
-</div>
       <div class="col-sm-6">
     {% if g.user and g.user.role_admin() and not profile %}
     {% if not content.role_anonymous() %}

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -157,6 +157,7 @@ class User(UserBase, Base):
     locale = Column(String(2), default="en")
     sidebar_view = Column(Integer, default=1)
     default_language = Column(String(3), default="all")
+    mature_content = Column(Boolean, default=True)
 
 
 # Class for anonymous user is derived from User base and complets overrides methods and properties for the
@@ -266,6 +267,7 @@ class Settings(Base):
     config_use_goodreads = Column(Boolean)
     config_goodreads_api_key = Column(String)
     config_goodreads_api_secret = Column(String)
+    config_mature_content_tags = Column(String)  # type: str
 
     def __repr__(self):
         pass
@@ -297,7 +299,7 @@ class Config:
         self.loadSettings()
 
     def loadSettings(self):
-        data = session.query(Settings).first()
+        data = session.query(Settings).first()  # type: Settings
         self.config_calibre_dir = data.config_calibre_dir
         self.config_port = data.config_port
         self.config_calibre_web_title = data.config_calibre_web_title
@@ -326,6 +328,7 @@ class Config:
         self.config_use_goodreads = data.config_use_goodreads
         self.config_goodreads_api_key = data.config_goodreads_api_key
         self.config_goodreads_api_secret = data.config_goodreads_api_secret
+        self.config_mature_content_tags = data.config_mature_content_tags
 
     @property
     def get_main_dir(self):
@@ -371,6 +374,8 @@ class Config:
         return bool((self.config_default_role is not None) and
                     (self.config_default_role & ROLE_DELETE_BOOKS == ROLE_DELETE_BOOKS))
 
+    def mature_content_tags(self):
+        return self.config_mature_content_tags.split(",")
 
     def get_Log_Level(self):
         ret_value=""
@@ -470,6 +475,11 @@ def migrate_Database():
             'side_lang': SIDEBAR_LANGUAGE, 'side_series': SIDEBAR_SERIES, 'side_category': SIDEBAR_CATEGORY,
             'side_hot': SIDEBAR_HOT, 'side_autor': SIDEBAR_AUTHOR, 'detail_random': DETAIL_RANDOM})
         session.commit()
+    try:
+        session.query(exists().where(User.mature_content)).scalar()
+    except exc.OperationalError:
+        conn = engine.connect()
+        conn.execute("ALTER TABLE user ADD column `mature_content` INTEGER DEFAULT 1")
     if session.query(User).filter(User.role.op('&')(ROLE_ANONYMOUS) == ROLE_ANONYMOUS).first() is None:
         create_anonymous_user()
     try:
@@ -484,6 +494,11 @@ def migrate_Database():
         conn.execute("ALTER TABLE Settings ADD column `config_use_goodreads` INTEGER DEFAULT 0")
         conn.execute("ALTER TABLE Settings ADD column `config_goodreads_api_key` String DEFAULT ''")
         conn.execute("ALTER TABLE Settings ADD column `config_goodreads_api_secret` String DEFAULT ''")
+    try:
+        session.query(exists().where(Settings.config_mature_content_tags)).scalar()
+    except exc.OperationalError:
+        conn = engine.connect()
+        conn.execute("ALTER TABLE Settings ADD column `config_mature_content_tags` String DEFAULT ''")
 
 def clean_database():
     # Remove expired remote login tokens


### PR DESCRIPTION
Uses a configurable list of tags to denote what is mature and hides those books from the user.

![screen shot 2017-08-08 at 10 41 08](https://user-images.githubusercontent.com/999845/29086070-2945b870-7c26-11e7-971c-5312bfb6249c.png)

![screen shot 2017-08-08 at 10 40 54](https://user-images.githubusercontent.com/999845/29086062-252c4966-7c26-11e7-959a-8915b12accca.png)

All current users will have "Show mature content" checked and will have to manually be changed after updating to this. New users will have it unchecked by default. I figure that it is better to be conservative with new users while maintaining the same functionality current users have been experiencing.

Resolves #262.