### PR TITLE
Use lazy loading to show images

### DIFF
--- a/cps/static/css/style.css
+++ b/cps/static/css/style.css
@@ -15,7 +15,11 @@ a{color: #45b29d}a:hover{color: #444;}
 .container-fluid img{display:block;max-width:100%;height:auto}
 .container-fluid .discover{margin-bottom:50px}
 .container-fluid .new-books{border-top:1px solid #ccc}.container-fluid .new-books h2{margin:50px 0 0 0}
-.container-fluid .book{margin-top:20px}.container-fluid .book .cover{height:225px;position:relative}.container-fluid .book .cover img{border:1px solid #fff;/*border-radius:7px;*/box-sizeing:border-box;height:100%;bottom:0;position:absolute;-webkit-box-shadow: 0 5px 8px -6px #777;-moz-box-shadow: 0 5px 8px -6px #777;box-shadow: 0 5px 8px -6px #777;}
+.container-fluid .book {margin-top:20px}
+.container-fluid .book .cover {height:225px; position:relative;}
+.container-fluid .book .cover.has-loader .loader {display: inline-block;}
+.container-fluid .book .cover .loader {display: none; font-size: 1em; position: absolute; top: 50%; left: 50%; margin: -0.5em 0 0 -0.5em;}
+.container-fluid .book .cover img {border:1px solid #fff; box-shadow: 0 5px 8px -6px #777; box-sizing:border-box; display: inline-block; height:100%;}
 .container-fluid .book .meta{margin-top:10px}.container-fluid .book .meta p{margin:0}
 .container-fluid .book .meta .title{font-weight:bold;font-size:15px;color:#444}
 .container-fluid .book .meta .author{font-size:12px;color:#999}
@@ -38,7 +42,18 @@ span.glyphicon.glyphicon-tags {padding-right: 5px;color: #999;vertical-align: te
 }
 .navbar-default .navbar-toggle .icon-bar {background-color: #000;}
 .navbar-default .navbar-toggle {border-color: #000;}
-.cover { margin-bottom: 10px;}
+.cover {margin-bottom: 10px;}
+
+.glyphicon-refresh-animate {
+    animation: spin .7s infinite linear;
+}
+@keyframes spin {
+    from { transform: rotate(0); }
+    to { transform: rotate(360deg); }
+}
+
+img.lazy {transition: opacity 0.5s;}
+.lazy-not-loaded {opacity: 0;}
 
 .btn-file {position: relative; overflow: hidden;}
 .btn-file input[type=file] {position: absolute; top: 0; right: 0; min-width: 100%; min-height: 100%; font-size: 100px; text-align: right; filter: alpha(opacity=0); opacity: 0; outline: none; background: white; cursor: inherit; display: block;}

--- a/cps/static/js/libs/unveil.min.js
+++ b/cps/static/js/libs/unveil.min.js
@@ -1,0 +1,11 @@
+/**
+ * jQuery Unveil v1.3.0
+ * A very lightweight jQuery plugin to lazy load images
+ * http://luis-almeida.github.com/unveil
+ *
+ * Licensed under the MIT license.
+ * Copyright 2013 Luís Almeida
+ * https://github.com/luis-almeida
+ */
+
+!function(t){t.fn.unveil=function(i,e){function n(){var i=l.filter(function(){var i=t(this);if(!i.is(":hidden")){var e=o.scrollTop(),n=e+o.height(),r=i.offset().top;return r+i.height()>=e-u&&r<=n+u}});r=i.trigger("unveil"),l=l.not(r)}var r,o=t(window),u=i||0,s=window.devicePixelRatio>1?"data-src-retina":"data-src",l=this;return this.one("unveil",function(){var t=this.getAttribute(s);(t=t||this.getAttribute("data-src"))&&(this.setAttribute("src",t),"function"==typeof e&&e.call(this))}),o.on("scroll.unveil resize.unveil lookup.unveil",n),n(),this}}(window.jQuery||window.Zepto);

--- a/cps/static/js/main.js
+++ b/cps/static/js/main.js
@@ -60,6 +60,25 @@ $(function() {
         layoutMode : "fitRows"
     });
 
+    function initLazyLoad() {
+        $("img.lazy").each(function() {
+            var $this = $(this).one("unveil", function() {
+                this.$loader = $("<span/>", {
+                    class: "glyphicon glyphicon-refresh glyphicon-refresh-animate loader"
+                });
+                $this.closest(".has-loader").prepend(this.$loader);
+            });
+        }).unveil(200, function() {
+            var $this = $(this).on("load", function() {
+                this.$loader.remove();
+                $this.closest(".has-loader").removeClass("has-loader");
+                $this.removeClass("lazy-not-loaded");
+            });
+        });
+    }
+
+    initLazyLoad();
+
     $(".load-more .row").infinitescroll({
         debug: false,
         navSelector  : ".pagination",
@@ -72,6 +91,8 @@ $(function() {
                    // selector for all items you'll retrieve
     }, function(data) {
         $(".load-more .row").isotope( "appended", $(data), null );
+
+        initLazyLoad();
     });
 
     $("#sendbtn").click(function() {

--- a/cps/templates/discover.html
+++ b/cps/templates/discover.html
@@ -6,12 +6,14 @@
 
     {% for entry in entries %}
     <div class="col-sm-3 col-lg-2 col-xs-6 book">
-      <div class="cover">
-        {% if entry.has_cover is defined %}
-          <a href="{{ url_for('show_book', book_id=entry.id) }}" data-toggle="modal" data-target="#bookDetailsModal" data-remote="false">
-            <img src="{{ url_for('get_cover', cover_path=entry.path.replace('\\','/')) }}" alt="{{ entry.title }}" />
-          </a>
-        {% endif %}
+      <div class="cover has-loader">
+        <a href="{{ url_for('show_book', book_id=entry.id) }}" data-toggle="modal" data-target="#bookDetailsModal" data-remote="false">
+          {% if entry.has_cover %}
+            <img class="lazy lazy-not-loaded" data-src="{{ url_for('get_cover', cover_path=entry.path.replace('\\','/')) }}" alt="{{ entry.title }}" />
+          {% else %}
+            <img class="lazy lazy-not-loaded" data-src="{{ url_for('static', filename='generic_cover.jpg') }}" alt="{{ entry.title }}" />
+          {% endif %}
+        </a>
       </div>
       <div class="meta">
         <p class="title">{{entry.title|shortentitle}}</p>

--- a/cps/templates/discover.html
+++ b/cps/templates/discover.html
@@ -10,8 +10,14 @@
         <a href="{{ url_for('show_book', book_id=entry.id) }}" data-toggle="modal" data-target="#bookDetailsModal" data-remote="false">
           {% if entry.has_cover %}
             <img class="lazy lazy-not-loaded" data-src="{{ url_for('get_cover', cover_path=entry.path.replace('\\','/')) }}" alt="{{ entry.title }}" />
+            <noscript>
+              <img src="{{ url_for('get_cover', cover_path=entry.path.replace('\\','/')) }}" alt="{{ entry.title }}" />
+            </noscript>
           {% else %}
             <img class="lazy lazy-not-loaded" data-src="{{ url_for('static', filename='generic_cover.jpg') }}" alt="{{ entry.title }}" />
+            <noscript>
+              <img src="{{ url_for('static', filename='generic_cover.jpg') }}" alt="{{ entry.title }}" />
+            </noscript>
           {% endif %}
         </a>
       </div>

--- a/cps/templates/index.html
+++ b/cps/templates/index.html
@@ -7,14 +7,14 @@
 
     {% for entry in random %}
     <div class="col-sm-3 col-lg-2 col-xs-6 book">
-      <div class="cover">
-          <a href="{{ url_for('show_book', book_id=entry.id) }}" data-toggle="modal" data-target="#bookDetailsModal" data-remote="false">
-            {% if entry.has_cover %}
-              <img src="{{ url_for('get_cover', cover_path=entry.path.replace('\\','/')) }}" alt="{{ entry.title }}" />
-            {% else %}
-              <img src="{{ url_for('static', filename='generic_cover.jpg') }}" alt="{{ entry.title }}" />
-            {% endif %}
-          </a>
+      <div class="cover has-loader">
+        <a href="{{ url_for('show_book', book_id=entry.id) }}" data-toggle="modal" data-target="#bookDetailsModal" data-remote="false">
+          {% if entry.has_cover %}
+            <img class="lazy lazy-not-loaded" data-src="{{ url_for('get_cover', cover_path=entry.path.replace('\\','/')) }}" alt="{{ entry.title }}" />
+          {% else %}
+            <img class="lazy lazy-not-loaded" data-src="{{ url_for('static', filename='generic_cover.jpg') }}" alt="{{ entry.title }}" />
+          {% endif %}
+        </a>
       </div>
       <div class="meta">
         <p class="title">{{entry.title|shortentitle}}</p>
@@ -43,14 +43,14 @@
     {% if entries[0] %}
     {% for entry in entries %}
     <div class="col-sm-3 col-lg-2 col-xs-6 book">
-      <div class="cover">
-          <a href="{{ url_for('show_book', book_id=entry.id) }}" data-toggle="modal" data-target="#bookDetailsModal" data-remote="false">
-            {% if entry.has_cover %}
-              <img src="{{ url_for('get_cover', cover_path=entry.path.replace('\\','/')) }}" alt="{{ entry.title }}"/>
-            {% else %}
-              <img src="{{ url_for('static', filename='generic_cover.jpg') }}" alt="{{ entry.title }}" />
-            {% endif %}
-          </a>
+      <div class="cover has-loader">
+        <a href="{{ url_for('show_book', book_id=entry.id) }}" data-toggle="modal" data-target="#bookDetailsModal" data-remote="false">
+          {% if entry.has_cover %}
+            <img class="lazy lazy-not-loaded" data-src="{{ url_for('get_cover', cover_path=entry.path.replace('\\','/')) }}" alt="{{ entry.title }}"/>
+          {% else %}
+            <img class="lazy lazy-not-loaded" data-src="{{ url_for('static', filename='generic_cover.jpg') }}" alt="{{ entry.title }}" />
+          {% endif %}
+        </a>
       </div>
       <div class="meta">
         <p class="title">{{entry.title|shortentitle}}</p>

--- a/cps/templates/index.html
+++ b/cps/templates/index.html
@@ -11,8 +11,14 @@
         <a href="{{ url_for('show_book', book_id=entry.id) }}" data-toggle="modal" data-target="#bookDetailsModal" data-remote="false">
           {% if entry.has_cover %}
             <img class="lazy lazy-not-loaded" data-src="{{ url_for('get_cover', cover_path=entry.path.replace('\\','/')) }}" alt="{{ entry.title }}" />
+            <noscript>
+              <img src="{{ url_for('get_cover', cover_path=entry.path.replace('\\','/')) }}" alt="{{ entry.title }}" />
+            </noscript>
           {% else %}
             <img class="lazy lazy-not-loaded" data-src="{{ url_for('static', filename='generic_cover.jpg') }}" alt="{{ entry.title }}" />
+            <noscript>
+              <img src="{{ url_for('static', filename='generic_cover.jpg') }}" alt="{{ entry.title }}" />
+            </noscript>
           {% endif %}
         </a>
       </div>
@@ -47,8 +53,14 @@
         <a href="{{ url_for('show_book', book_id=entry.id) }}" data-toggle="modal" data-target="#bookDetailsModal" data-remote="false">
           {% if entry.has_cover %}
             <img class="lazy lazy-not-loaded" data-src="{{ url_for('get_cover', cover_path=entry.path.replace('\\','/')) }}" alt="{{ entry.title }}"/>
+            <noscript>
+              <img src="{{ url_for('get_cover', cover_path=entry.path.replace('\\','/')) }}" alt="{{ entry.title }}"/>
+            </noscript>
           {% else %}
             <img class="lazy lazy-not-loaded" data-src="{{ url_for('static', filename='generic_cover.jpg') }}" alt="{{ entry.title }}" />
+            <noscript>
+              <img src="{{ url_for('static', filename='generic_cover.jpg') }}" alt="{{ entry.title }}" />
+            </noscript>
           {% endif %}
         </a>
       </div>

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -213,6 +213,7 @@
     <script src="{{ url_for('static', filename='js/libs/context.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/libs/plugins.js') }}"></script>
     <script src="{{ url_for('static', filename='js/libs/jquery.form.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/libs/unveil.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>
     <script type="text/javascript">
         $(function() {


### PR DESCRIPTION
Loads images when they're within 200px of being in the viewport. Prevents loading images that might not be seen, and ought to improve "time to first render" performance.

![lazy-load](https://user-images.githubusercontent.com/999845/29376744-6a8e32e6-826e-11e7-8840-38b4e19edcb2.gif)

