### PR TITLE
Escape special characters in file names

### DIFF
--- a/cps/helper.py
+++ b/cps/helper.py
@@ -266,6 +266,7 @@ def get_valid_filename(value, replace_whitespace=True):
     """
     if value[-1:] == u'.':
         value = value[:-1]+u'_'
+    value = value.replace("/", "_").replace(":", "_")
     if use_unidecode:
         value=(unidecode.unidecode(value)).strip()
     else:


### PR DESCRIPTION
Follows Calibre's convention of using underscores as replacements

Fixes #286