### PR TITLE
Customize the Logo Text

### DIFF
--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -32,7 +32,7 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand" href="{{url_for('index')}}">Calibre Web</a>
+          <a class="navbar-brand" href="{{url_for('index')}}">{{instance}}</a>
         </div>
         {% if g.user.is_authenticated or g.user.is_anonymous() %}
           <form class="navbar-form navbar-left" role="search" action="{{url_for('search')}}" method="GET">

--- a/cps/templates/stats.html
+++ b/cps/templates/stats.html
@@ -1,5 +1,9 @@
 {% extends "layout.html" %}
 {% block body %}
+  <h3>{{_('About')}}</h3>
+<p>{{instance}} powered by 
+<a href="https://github.com/janeczku/calibre-web" title="Calibre-Web">Calibre Web</a>.
+</p>  
   <h3>{{_('Calibre library statistics')}}</h3>
 <table id="stats" class="table">
   <tbody>


### PR DESCRIPTION
With many browsertabs open the user hardly can see my library's name of choice.
I think it would be nice if the library title can be reflected in the logo text, to feel more like 'home' so to speak. In exchange I added a small "powered by" line in the stats page that links to the github repository.


