### PR TITLE
python3 compatibility

### DIFF
--- a/cps/cache_buster.py
+++ b/cps/cache_buster.py
@@ -24,7 +24,7 @@ def init_cache_busting(app):
         for filename in filenames:
             # compute version component
             rooted_filename = os.path.join(dirpath, filename)
-            with open(rooted_filename, 'r') as f:
+            with open(rooted_filename, 'rb') as f:
                 file_hash = hashlib.md5(f.read()).hexdigest()[:7]
 
             # save version to tables


### PR DESCRIPTION
I attempted to run `cps.py` using python3 and got this error:

```
Traceback (most recent call last):
  File "cps.py", line 13, in <module>
    from cps import web
  File "/home/calibre/Git/calibre-web/cps/web.py", line 38, in <module>
    import helper
  File "/home/calibre/Git/calibre-web/cps/helper.py", line 40, in <module>
    import gdriveutils as gd
  File "/home/calibre/Git/calibre-web/cps/gdriveutils.py", line 16, in <module>
    import web
  File "/home/calibre/Git/calibre-web/cps/web.py", line 216, in <module>
    cache_buster.init_cache_busting(app)
  File "/home/calibre/Git/calibre-web/cps/cache_buster.py", line 28, in init_cache_busting
    file_hash = hashlib.md5(f.read()).hexdigest()[:7]
  File "/usr/lib/python3.6/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 0: invalid start byte
```

I noticed that `f` was opened in text mode(instead of binary mode) and added a small fix. `cps.py` now runs with python3.6 on my machine (arch).