### PR TITLE
file order fixed for some comic books

### DIFF
--- a/cps/web.py
+++ b/cps/web.py
@@ -30,6 +30,12 @@ try:
 except ImportError:
     rar_support=False
 
+try:
+    from natsort import natsorted as sorted
+except ImportError:
+    pass  # Just use regular sort then
+          #   may cause issues with badly named pages in cbz/cbr files
+
 import mimetypes
 import logging
 from logging.handlers import RotatingFileHandler
@@ -931,7 +937,7 @@ def get_comic_book(book_id, book_format, page):
                         rarfile.UNRAR_TOOL = config.config_rarfile_location
                         try:
                             rf = rarfile.RarFile(cbr_file)
-                            rarNames = rf.namelist()
+                            rarNames = sorted(rf.namelist())
                             b64 = codecs.encode(rf.read(rarNames[page]), 'base64').decode()
                             extractedfile="data:image/png;base64," + b64
                             fileData={"name": rarNames[page],"page":page, "last":rarNames.__len__()-1, "content": extractedfile}
@@ -945,7 +951,7 @@ def get_comic_book(book_id, book_format, page):
                         return "", 204
                 if book_format == "cbz":
                     zf = zipfile.ZipFile(cbr_file)
-                    zipNames=zf.namelist()
+                    zipNames=sorted(zf.namelist())
                     if sys.version_info.major >= 3:
                         b64 = codecs.encode(zf.read(zipNames[page]), 'base64').decode()
                     else:
@@ -955,7 +961,7 @@ def get_comic_book(book_id, book_format, page):
 
                 if book_format == "cbt":
                     tf = tarfile.TarFile(u'D:\\zip\\test.cbt')
-                    tarNames=tf.getnames()
+                    tarNames=sorted(tf.getnames())
                     if sys.version_info.major >= 3:
                         b64 = codecs.encode(tf.extractfile(tarNames[page]).read(), 'base64').decode()
                     else:

--- a/cps/web.py
+++ b/cps/web.py
@@ -31,10 +31,10 @@ except ImportError:
     rar_support=False
 
 try:
-    from natsort import natsorted as sorted
+    from natsort import natsorted as sort
 except ImportError:
-    pass  # Just use regular sort then
-          #   may cause issues with badly named pages in cbz/cbr files
+    sort=sorted # Just use regular sort then
+                #   may cause issues with badly named pages in cbz/cbr files
 
 import mimetypes
 import logging
@@ -937,7 +937,7 @@ def get_comic_book(book_id, book_format, page):
                         rarfile.UNRAR_TOOL = config.config_rarfile_location
                         try:
                             rf = rarfile.RarFile(cbr_file)
-                            rarNames = sorted(rf.namelist())
+                            rarNames = sort(rf.namelist())
                             b64 = codecs.encode(rf.read(rarNames[page]), 'base64').decode()
                             extractedfile="data:image/png;base64," + b64
                             fileData={"name": rarNames[page],"page":page, "last":rarNames.__len__()-1, "content": extractedfile}
@@ -951,7 +951,7 @@ def get_comic_book(book_id, book_format, page):
                         return "", 204
                 if book_format in ("cbz", "zip"):
                     zf = zipfile.ZipFile(cbr_file)
-                    zipNames=sorted(zf.namelist())
+                    zipNames=sort(zf.namelist())
                     if sys.version_info.major >= 3:
                         b64 = codecs.encode(zf.read(zipNames[page]), 'base64').decode()
                     else:
@@ -961,7 +961,7 @@ def get_comic_book(book_id, book_format, page):
 
                 if book_format in ("cbt", "tar"):
                     tf = tarfile.TarFile(cbr_file)
-                    tarNames=sorted(tf.getnames())
+                    tarNames=sort(tf.getnames())
                     if sys.version_info.major >= 3:
                         b64 = codecs.encode(tf.extractfile(tarNames[page]).read(), 'base64').decode()
                     else:

--- a/cps/web.py
+++ b/cps/web.py
@@ -932,7 +932,7 @@ def get_comic_book(book_id, book_format, page):
         for bookformat in book.data:
             if bookformat.format.lower() == book_format.lower():
                 cbr_file = os.path.join(config.config_calibre_dir, book.path, bookformat.name) + "." + book_format
-                if book_format == "cbr":
+                if book_format in ("cbr", "rar"):
                     if rar_support == True:
                         rarfile.UNRAR_TOOL = config.config_rarfile_location
                         try:
@@ -949,7 +949,7 @@ def get_comic_book(book_id, book_format, page):
                         app.logger.info('Unrar is not supported please install python rarfile extension')
                         # no support means return nothing
                         return "", 204
-                if book_format == "cbz":
+                if book_format in ("cbz", "zip"):
                     zf = zipfile.ZipFile(cbr_file)
                     zipNames=sorted(zf.namelist())
                     if sys.version_info.major >= 3:
@@ -959,8 +959,8 @@ def get_comic_book(book_id, book_format, page):
                     extractedfile="data:image/png;base64," + b64
                     fileData={"name": zipNames[page],"page":page, "last":zipNames.__len__()-1, "content": extractedfile}
 
-                if book_format == "cbt":
-                    tf = tarfile.TarFile(u'D:\\zip\\test.cbt')
+                if book_format in ("cbt", "tar"):
+                    tf = tarfile.TarFile(cbr_file)
                     tarNames=sorted(tf.getnames())
                     if sys.version_info.major >= 3:
                         b64 = codecs.encode(tf.extractfile(tarNames[page]).read(), 'base64').decode()

--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -14,3 +14,4 @@ uritemplate==3.0.0
 goodreads>=0.3.2
 python-Levenshtein>=0.12.0
 rarfile>=2.7
+natsort>=2.2.0


### PR DESCRIPTION
I noticed that some of my cbz files were being displayed in a reversed order(page 1 was '020.png', page 2 was '019.png', etc...)

Fix: sort file names in `web.py` before sending back a requested page.

Also, I added a optional requirement for the `natsort` package (supports both python 2 and 3). Since the filenames are strings, the built in `sorted` function may have issues with proper page order.

```
>>> sorted(['1', '2', '10', '5', '12', '21', '18', '4'])
['1', '10', '12', '18', '2', '21', '4', '5']
>>> from natsort import natsorted as sorted
>>> sorted(['1', '2', '10', '5', '12', '21', '18', '4'])
['1', '2', '4', '5', '10', '12', '18', '21'] 
```