### PR TITLE
Comic server

### DIFF
--- a/cps/db.py
+++ b/cps/db.py
@@ -272,7 +272,7 @@ class Books(Base):
         self.has_cover = has_cover
 
     def __repr__(self):
-        return u"<Books('{0},{1}{2}{3}{4}{5}{6}{7}{8}')>".format(self.title, self.sort, self.author_sort,
+        return u"<Issues('{0},{1}{2}{3}{4}{5}{6}{7}{8}')>".format(self.title, self.sort, self.author_sort,
                                                                  self.timestamp, self.pubdate, self.series_index,
                                                                  self.last_modified, self.path, self.has_cover)
 

--- a/cps/templates/admin.html
+++ b/cps/templates/admin.html
@@ -60,7 +60,7 @@
         <th>{{_('Calibre DB dir')}}</th>
         <th>{{_('Log Level')}}</th>
         <th>{{_('Port')}}</th>
-        <th>{{_('Books per page')}}</th>
+        <th>{{_('Issues per page')}}</th>
         <th>{{_('Uploading')}}</th>
         <th>{{_('Public registration')}}</th>
         <th>{{_('Anonymous browsing')}}</th>

--- a/cps/templates/book_edit.html
+++ b/cps/templates/book_edit.html
@@ -36,11 +36,11 @@
     </div>
 
     <div class="form-group">
-      <label for="series">{{_('Series')}}</label>
+      <label for="series">{{_('Comics')}}</label>
       <input type="text" class="form-control typeahead" name="series" id="series" value="{% if book.series %}{{book.series[0].name}}{% endif %}">
     </div>
     <div class="form-group">
-      <label for="series_index">{{_('Series id')}}</label>
+      <label for="series_index">{{_('Comics id')}}</label>
       <input type="text" class="form-control" name="series_index" id="series_index" value="{{book.series_index}}">
     </div>
     <div class="form-group">

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -57,7 +57,7 @@
       <input type="text" class="form-control" name="config_calibre_web_title" id="config_calibre_web_title" value="{% if content.config_calibre_web_title != None %}{{ content.config_calibre_web_title }}{% endif %}" autocomplete="off" required>
     </div>    
     <div class="form-group">
-      <label for="config_books_per_page">{{_('Books per page')}}</label>
+      <label for="config_books_per_page">{{_('Issues per page')}}</label>
       <input type="number" min="1" max="200" class="form-control" name="config_books_per_page" id="config_books_per_page" value="{% if content.config_books_per_page != None %}{{ content.config_books_per_page }}{% endif %}" autocomplete="off">
     </div>
     <div class="form-group">
@@ -146,7 +146,7 @@
     </div>
     <div class="form-group">
       <input type="checkbox" name="delete_role" id="delete_role" {% if content.role_delete_books() %}checked{% endif %}>
-      <label for="delete_role">{{_('Allow Delete books')}}</label>
+      <label for="delete_role">{{_('Allow Delete issues')}}</label>
     </div>
     <div class="form-group">
       <input type="checkbox" name="passwd_role" id="passwd_role" {% if content.role_passwd() %}checked{% endif %}>

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -44,14 +44,7 @@
           {% endif %}
           {% if (g.user.role_download() and g.user.is_anonymous) or g.user.is_authenticated %}
             {% with formats = entry.data|select('canread')|list %}
-              {% if formats|length == 1 %}
                 {% set format = formats|first %}
-                <div class="btn-group" role="group">
-                  <a target="_blank" class="btn btn-primary" href="{{ url_for('read_book', book_id=entry.id, book_format=format.format|lower) }}">{{format.format}}
-                    <span class="glyphicon glyphicon-eye-open"></span> {{_('Read in browser')}}
-                  </a>
-                </div>
-              {% elif formats|length > 1 %}
                 <div class="btn-group" role="group">
                   <button id="read-in-browser" type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     <span class="glyphicon glyphicon-eye-open"></span> {{_('Read in browser')}}
@@ -65,13 +58,11 @@
                     {%endfor%}
                   </ul>
                 </div>
-              {%endif%}
             {%endwith%}
           {%endif%}
         </div>
       </div>
       <h2>{{entry.title}}</h2>
-
       {% if entry.ratings.__len__() > 0 %}
         <div class="rating">
         <p>

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -71,14 +71,7 @@
         </div>
       </div>
       <h2>{{entry.title}}</h2>
-      <p class="author">
-          {% for author in entry.authors %}
-            <a href="{{url_for('author', book_id=author.id ) }}">{{author.name.replace('|',',')}}</a>
-            {% if not loop.last %}
-              &amp;
-            {% endif %}
-          {% endfor %}
-        </p>
+
       {% if entry.ratings.__len__() > 0 %}
         <div class="rating">
         <p>

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -95,7 +95,7 @@
       {% endif %}
 
       {% if entry.series|length > 0 %}
-        <p>{{_('Book')}} {{entry.series_index}} {{_('of')}} <a href="{{url_for('series', book_id=entry.series[0].id)}}">{{entry.series[0].name}}</a></p>
+        <p>{{_('Issue')}} {{entry.series_index}} {{_('of')}} <a href="{{url_for('series', book_id=entry.series[0].id)}}">{{entry.series[0].name}}</a></p>
       {% endif %}
 
       {% if entry.languages.__len__() > 0 %}

--- a/cps/templates/discover.html
+++ b/cps/templates/discover.html
@@ -3,23 +3,32 @@
 <div class="discover load-more">
     <h2>{{title}}</h2>
     <div class="row">
-
         {% for entry in entries %}
-        <div class="col-sm-3 col-lg-2 col-xs-6 book">
+        {% if entry.series_index == 1.0 %}
+        <div id="books" class="col-sm-3 col-lg-2 col-xs-6 book">
             <div class="cover">
-                {% if entry.has_cover is defined %}
-                <a href="{{url_for('series', book_id=entry.id)}}">
-                    <img src="{{ url_for('get_cover', cover_path=entry.book[0].path.replace('\\','/')) }}"
-                         alt="{{ entry.title }}"/>
+                <a href="{{url_for('series', book_id=entry.series[0].id)}}">
+                    <img src="{{ url_for('get_cover', cover_path=entry.path.replace('\\','/')) }}" alt="{{ entry.title }}" />
                 </a>
-                {% endif %}
             </div>
             <div class="meta">
-                <p class="title"><a href="{{url_for('series', book_id=entry.id)}}">{{entry.name}}</a></p>
+                <p class="title"><a href="{{url_for('series', book_id=entry.series[0].id)}}">{{entry.series[0].name}}</a></p>
+                {% if entry.ratings.__len__() > 0 %}
+                <div class="rating">
+                    {% for number in range((entry.ratings[0].rating/2)|int(2)) %}
+                    <span class="glyphicon glyphicon-star good"></span>
+                    {% if loop.last and loop.index < 5 %}
+                    {% for numer in range(5 - loop.index) %}
+                    <span class="glyphicon glyphicon-star"></span>
+                    {% endfor %}
+                    {% endif %}
+                    {% endfor %}
+                </div>
+                {% endif %}
             </div>
         </div>
+        {% endif %}
         {% endfor %}
-
     </div>
 </div>
 {% endblock %}

--- a/cps/templates/discover.html
+++ b/cps/templates/discover.html
@@ -1,36 +1,25 @@
 {% extends "layout.html" %}
 {% block body %}
 <div class="discover load-more">
-  <h2>{{title}}</h2>
-  <div class="row">
+    <h2>{{title}}</h2>
+    <div class="row">
 
-    {% for entry in entries %}
-    <div class="col-sm-3 col-lg-2 col-xs-6 book">
-      <div class="cover">
-        {% if entry.has_cover is defined %}
-          <a href="{{ url_for('show_book', book_id=entry.id) }}" data-toggle="modal" data-target="#bookDetailsModal" data-remote="false">
-            <img src="{{ url_for('get_cover', cover_path=entry.path.replace('\\','/')) }}" alt="{{ entry.title }}" />
-          </a>
-        {% endif %}
-      </div>
-      <div class="meta">
-        <p class="title">{{entry.title|shortentitle}}</p>
-        <p class="author"><a href="{{url_for('author', book_id=entry.authors[0].id) }}">{{entry.authors[0].name}}</a></p>
-        {% if entry.ratings.__len__() > 0 %}
-        <div class="rating">
-          {% for number in range((entry.ratings[0].rating/2)|int(2)) %}
-            <span class="glyphicon glyphicon-star good"></span>
-            {% if loop.last and loop.index < 5 %}
-              {% for numer in range(5 - loop.index) %}
-                <span class="glyphicon glyphicon-star"></span>
-              {% endfor %}
-            {% endif %}
-          {% endfor %}
+        {% for entry in entries %}
+        <div class="col-sm-3 col-lg-2 col-xs-6 book">
+            <div class="cover">
+                {% if entry.has_cover is defined %}
+                <a href="{{url_for('series', book_id=entry.id)}}">
+                    <img src="{{ url_for('get_cover', cover_path=entry.book[0].path.replace('\\','/')) }}"
+                         alt="{{ entry.title }}"/>
+                </a>
+                {% endif %}
+            </div>
+            <div class="meta">
+                <p class="title"><a href="{{url_for('series', book_id=entry.id)}}">{{entry.name}}</a></p>
+            </div>
         </div>
-        {% endif %}
-      </div>
+        {% endfor %}
+
     </div>
-    {% endfor %}
-  </div>
 </div>
 {% endblock %}

--- a/cps/templates/index.html
+++ b/cps/templates/index.html
@@ -2,7 +2,7 @@
 {% block body %}
 {% if g.user.show_detail_random() %}
 <div class="discover">
-  <h2>{{_('Discover (Random Books)')}}</h2>
+  <h2>{{_('Discover (Random Issues)')}}</h2>
   <div class="row">
 
     {% for entry in random %}
@@ -17,8 +17,10 @@
           </a>
       </div>
       <div class="meta">
-        <p class="title">{{entry.title|shortentitle}}</p>
-        <p class="author"><a href="{{url_for('author', book_id=entry.authors[0].id) }}">{{entry.authors[0].name}}</a></p>
+        <p class="title"><a href="{{url_for('series', book_id=entry.series[0].id)}}">{{entry.series[0].name}}</a> {{_('#')}}{{entry.series_index}}</p>
+          {% if entry.series|length > 0 %}
+        <p class="author">{{entry.title|shortentitle}}</p>
+          {% endif %}
         {% if entry.ratings.__len__() > 0 %}
         <div class="rating">
           {% for number in range((entry.ratings[0].rating/2)|int(2)) %}
@@ -52,29 +54,24 @@
             {% endif %}
           </a>
       </div>
-      <div class="meta">
-        <p class="title">{{entry.title|shortentitle}}</p>
-        <p class="author">
-          {% for author in entry.authors %}
-            <a href="{{url_for('author', book_id=author.id) }}">{{author.name.replace('|',',')}}</a>
-            {% if not loop.last %}
-              &amp;
+        <div class="meta">
+            <p class="title"><a href="{{url_for('series', book_id=entry.series[0].id)}}">{{entry.series[0].name}}</a> {{_('#')}}{{entry.series_index}}</p>
+            {% if entry.series|length > 0 %}
+            <p class="author">{{entry.title|shortentitle}}</p>
             {% endif %}
-          {% endfor %}
-        </p>
-        {% if entry.ratings.__len__() > 0 %}
-        <div class="rating">
-          {% for number in range((entry.ratings[0].rating/2)|int(2)) %}
-            <span class="glyphicon glyphicon-star good"></span>
-            {% if loop.last and loop.index < 5 %}
-              {% for numer in range(5 - loop.index) %}
+            {% if entry.ratings.__len__() > 0 %}
+            <div class="rating">
+                {% for number in range((entry.ratings[0].rating/2)|int(2)) %}
+                <span class="glyphicon glyphicon-star good"></span>
+                {% if loop.last and loop.index < 5 %}
+                {% for numer in range(5 - loop.index) %}
                 <span class="glyphicon glyphicon-star"></span>
-              {% endfor %}
+                {% endfor %}
+                {% endif %}
+                {% endfor %}
+            </div>
             {% endif %}
-          {% endfor %}
         </div>
-        {% endif %}
-      </div>
     </div>
     {% endfor %}
   {% endif %}

--- a/cps/templates/index.html
+++ b/cps/templates/index.html
@@ -17,10 +17,10 @@
           </a>
       </div>
       <div class="meta">
-        <p class="title"><a href="{{url_for('series', book_id=entry.series[0].id)}}">{{entry.series[0].name}}</a> {{_('#')}}{{entry.series_index}}</p>
           {% if entry.series|length > 0 %}
-        <p class="author">{{entry.title|shortentitle}}</p>
+          <p class="title">{{entry.title|shortentitle}}</p>
           {% endif %}
+        <p class="author"><a href="{{url_for('series', book_id=entry.series[0].id)}}">{{entry.series[0].name}}</a> {{_('#')}}{{entry.series_index}}</p>
         {% if entry.ratings.__len__() > 0 %}
         <div class="rating">
           {% for number in range((entry.ratings[0].rating/2)|int(2)) %}
@@ -55,10 +55,10 @@
           </a>
       </div>
         <div class="meta">
-            <p class="title"><a href="{{url_for('series', book_id=entry.series[0].id)}}">{{entry.series[0].name}}</a> {{_('#')}}{{entry.series_index}}</p>
             {% if entry.series|length > 0 %}
-            <p class="author">{{entry.title|shortentitle}}</p>
+            <p class="title">{{entry.title|shortentitle}}</p>
             {% endif %}
+            <p class="author"><a href="{{url_for('series', book_id=entry.series[0].id)}}">{{entry.series[0].name}}</a> {{_('#')}}{{entry.series_index}}</p>
             {% if entry.ratings.__len__() > 0 %}
             <div class="rating">
                 {% for number in range((entry.ratings[0].rating/2)|int(2)) %}

--- a/cps/templates/index.xml
+++ b/cps/templates/index.xml
@@ -11,59 +11,59 @@
     <uri>https://github.com/janeczku/calibre-web</uri>
   </author>
   <entry>
-    <title>{{_('Hot Books')}}</title>
+    <title>{{_('Hot Issues')}}</title>
     <link rel="http://opds-spec.org/sort/popular" href="{{url_for('feed_hot')}}" type="application/atom+xml;profile=opds-catalog"/>
     <id>{{url_for('feed_hot')}}</id>
     <content type="text">{{_('Popular publications from this catalog based on Downloads.')}}</content>
   </entry>
   <entry>
-    <title>{{_('Best rated Books')}}</title>
+    <title>{{_('Best rated Issues')}}</title>
     <link rel="http://opds-spec.org/recommended" href="{{url_for('feed_best_rated')}}" type="application/atom+xml;profile=opds-catalog"/>
     <id>{{url_for('feed_best_rated')}}</id>
     <content type="text">{{_('Popular publications from this catalog based on Rating.')}}</content>
   </entry>
   <entry>
-    <title>{{_('New Books')}}</title>
+    <title>{{_('New Issues')}}</title>
     <link rel="http://opds-spec.org/sort/new" href="{{url_for('feed_new')}}" type="application/atom+xml;profile=opds-catalog"/>
     <id>{{url_for('feed_new')}}</id>
-    <content type="text">{{_('The latest Books')}}</content>
+    <content type="text">{{_('The latest Issues')}}</content>
   </entry>
   <entry>
-    <title>{{_('Random Books')}}</title>
+    <title>{{_('Random Issues')}}</title>
     <link rel="http://opds-spec.org/featured" href="{{url_for('feed_discover')}}" type="application/atom+xml;profile=opds-catalog"/>
     <id>{{url_for('feed_discover')}}</id>
-    <content type="text">{{_('Show Random Books')}}</content>
+    <content type="text">{{_('Show Random Issues')}}</content>
   </entry>
 {% if not current_user.is_anonymous %}
   <entry>
-    <title>{{_('Read Books')}}</title>
+    <title>{{_('Read Issues')}}</title>
     <link rel="subsection" href="{{url_for('feed_read_books')}}" type="application/atom+xml;profile=opds-catalog"/>
     <id>{{url_for('feed_read_books')}}</id>
-    <content type="text">{{_('Read Books')}}</content>
+    <content type="text">{{_('Read Issues')}}</content>
   </entry>
 {% endif %}
   <entry>
-    <title>{{_('Unread Books')}}</title>
+    <title>{{_('Unread Issues')}}</title>
     <link rel="subsection" href="{{url_for('feed_unread_books')}}" type="application/atom+xml;profile=opds-catalog"/>
     <id>{{url_for('feed_unread_books')}}</id>
-    <content type="text">{{_('Unread Books')}}</content>
+    <content type="text">{{_('Unread Issues')}}</content>
   </entry>
   <entry>
     <title>{{_('Authors')}}</title>
     <link rel="subsection" href="{{url_for('feed_authorindex')}}" type="application/atom+xml;profile=opds-catalog"/>
     <id>{{url_for('feed_authorindex')}}</id>
-    <content type="text">{{_('Books ordered by Author')}}</content>
+    <content type="text">{{_('Issues ordered by Author')}}</content>
    </entry>
    <entry>
     <title>{{_('Category list')}}</title>
     <link rel="subsection" href="{{url_for('feed_categoryindex')}}" type="application/atom+xml;profile=opds-catalog"/>
     <id>{{url_for('feed_categoryindex')}}</id>
-    <content type="text">{{_('Books ordered by category')}}</content>
+    <content type="text">{{_('Issues ordered by category')}}</content>
    </entry>
    <entry>
-    <title>{{_('Series list')}}</title>
+    <title>{{_('Comics list')}}</title>
     <link rel="subsection" href="{{url_for('feed_seriesindex')}}" type="application/atom+xml;profile=opds-catalog"/>
     <id>{{url_for('feed_seriesindex')}}</id>
-    <content type="text">{{_('Books ordered by series')}}</content>
+    <content type="text">{{_('Issues ordered by series')}}</content>
    </entry>
 </feed>

--- a/cps/templates/index.xml
+++ b/cps/templates/index.xml
@@ -52,7 +52,7 @@
     <title>{{_('Authors')}}</title>
     <link rel="subsection" href="{{url_for('feed_authorindex')}}" type="application/atom+xml;profile=opds-catalog"/>
     <id>{{url_for('feed_authorindex')}}</id>
-    <content type="text">{{_('Issues ordered by Author')}}</content>
+    <content type="text">{{_('Issues ordered by publisher')}}</content>
    </entry>
    <entry>
     <title>{{_('Category list')}}</title>
@@ -64,6 +64,6 @@
     <title>{{_('Comics list')}}</title>
     <link rel="subsection" href="{{url_for('feed_seriesindex')}}" type="application/atom+xml;profile=opds-catalog"/>
     <id>{{url_for('feed_seriesindex')}}</id>
-    <content type="text">{{_('Issues ordered by series')}}</content>
+    <content type="text">{{_('Issues ordered by comics')}}</content>
    </entry>
 </feed>

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -110,7 +110,7 @@
               {% if g.user.show_sorted() %}
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                  <span class="glyphicon glyphicon-sort-by-attributes"></span> {{_('Sorted Books')}}
+                  <span class="glyphicon glyphicon-sort-by-attributes"></span> {{_('Sorted Issues')}}
                   <span class="caret"></span>
                 </a>
                 <ul class="dropdown-menu">
@@ -122,16 +122,16 @@
               </li>
               {%endif%}
               {% if g.user.show_hot_books() %}
-              <li id="nav_hot"><a href="{{url_for('hot_books')}}"><span class="glyphicon glyphicon-fire"></span> {{_('Hot Books')}}</a></li>
+              <li id="nav_hot"><a href="{{url_for('hot_books')}}"><span class="glyphicon glyphicon-fire"></span> {{_('Hot Issues')}}</a></li>
               {%endif%}
               {% if g.user.show_best_rated_books() %}
-              <li><a href="{{url_for('best_rated_books')}}"><span class="glyphicon glyphicon-star"></span> {{_('Best rated Books')}}</a></li>
+              <li><a href="{{url_for('best_rated_books')}}"><span class="glyphicon glyphicon-star"></span> {{_('Best rated Issues')}}</a></li>
               {%endif%}
               {% if g.user.show_read_and_unread() %}
                 {% if not g.user.is_anonymous %}
-                  <li><a href="{{url_for('read_books')}}"><span class="glyphicon glyphicon-eye-open"></span> {{_('Read Books')}}</a></li>
+                  <li><a href="{{url_for('read_books')}}"><span class="glyphicon glyphicon-eye-open"></span> {{_('Read Issues')}}</a></li>
                 {%endif%}
-                <li><a href="{{url_for('unread_books')}}"><span class="glyphicon glyphicon-eye-close"></span> {{_('Unread Books')}}</a></li>
+                <li><a href="{{url_for('unread_books')}}"><span class="glyphicon glyphicon-eye-close"></span> {{_('Unread Issues')}}</a></li>
               {%endif%}
               {% if g.user.show_random_books() %}
               <li id="nav_rand"><a href="{{url_for('discover')}}"><span class="glyphicon glyphicon-random"></span> {{_('Discover')}}</a></li>
@@ -140,10 +140,10 @@
               <li id="nav_cat"><a href="{{url_for('category_list')}}"><span class="glyphicon glyphicon-inbox"></span> {{_('Categories')}}</a></li>
               {%endif%}
               {% if g.user.show_series() %}
-              <li id="nav_serie"><a href="{{url_for('series_list')}}"><span class="glyphicon glyphicon-bookmark"></span> {{_('Series')}}</a></li>
+              <li id="nav_serie"><a href="{{url_for('series_list')}}"><span class="glyphicon glyphicon-bookmark"></span> {{_('Comics')}}</a></li>
               {%endif%}
               {% if g.user.show_author() %}
-              <li id="nav_author"><a href="{{url_for('author_list')}}"><span class="glyphicon glyphicon-user"></span> {{_('Authors')}}</a></li>
+              <li id="nav_author"><a href="{{url_for('author_list')}}"><span class="glyphicon glyphicon-user"></span> {{_('Publishers')}}</a></li>
               {%endif%}
               {% if g.user.filter_language() == 'all' and g.user.show_language() %}
                 <li id="nav_lang"><a href="{{url_for('language_overview')}}"><span class="glyphicon glyphicon-flag"></span> {{_('Languages')}} </a></li>

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -142,8 +142,8 @@
               {% if g.user.show_series() %}
               <li id="nav_serie"><a href="{{url_for('series_list')}}"><span class="glyphicon glyphicon-bookmark"></span> {{_('Comics')}}</a></li>
               {%endif%}
-              {% if g.user.show_author() %}
-              <li id="nav_author"><a href="{{url_for('author_list')}}"><span class="glyphicon glyphicon-user"></span> {{_('Publishers')}}</a></li>
+              {% if g.user.show_publisher() %}
+              <li id="nav_author"><a href="{{url_for('publisher_list')}}"><span class="glyphicon glyphicon-user"></span> {{_('Publishers')}}</a></li>
               {%endif%}
               {% if g.user.filter_language() == 'all' and g.user.show_language() %}
                 <li id="nav_lang"><a href="{{url_for('language_overview')}}"><span class="glyphicon glyphicon-flag"></span> {{_('Languages')}} </a></li>
@@ -200,7 +200,7 @@
         <div class="modal-content">
           <div class="modal-header">
             <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-            <h4 class="modal-title" id="bookDetailsModalLabel">{{_('Book Details')}}</h4>
+            <h4 class="modal-title" id="bookDetailsModalLabel">{{_('Issue Details')}}</h4>
           </div>
           <div class="modal-body">...</div>
           <div class="modal-footer">

--- a/cps/templates/publisher.html
+++ b/cps/templates/publisher.html
@@ -25,7 +25,7 @@
   <div class="row">
     {% if entries[0] %}
     {% for entry in entries %}
-      {% if entry.series_index.first %}
+      {% if loop.first %}
     <div id="books" class="col-sm-3 col-lg-2 col-xs-6 book">
       <div class="cover">
           <a href="{{url_for('series', book_id=entry.series[0].id)}}">

--- a/cps/templates/publisher.html
+++ b/cps/templates/publisher.html
@@ -25,7 +25,7 @@
   <div class="row">
     {% if entries[0] %}
     {% for entry in entries %}
-      {% for series_index in entry[:1] %}
+      {% if entry.series_index[:1] %}
     <div id="books" class="col-sm-3 col-lg-2 col-xs-6 book">
       <div class="cover">
           <a href="{{url_for('series', book_id=entry.series[0].id)}}">
@@ -48,7 +48,7 @@
         {% endif %}
       </div>
     </div>
-      {% endfor %}
+      {% endif %}
     {% endfor %}
     {% endif %}
   </div>

--- a/cps/templates/publisher.html
+++ b/cps/templates/publisher.html
@@ -25,7 +25,7 @@
   <div class="row">
     {% if entries[0] %}
     {% for entry in entries %}
-      {% if entry.series_index.first %}
+      {% for series_index in entry[:1] %}
     <div id="books" class="col-sm-3 col-lg-2 col-xs-6 book">
       <div class="cover">
           <a href="{{url_for('series', book_id=entry.series[0].id)}}">
@@ -48,7 +48,7 @@
         {% endif %}
       </div>
     </div>
-      {% endif %}
+      {% endfor %}
     {% endfor %}
     {% endif %}
   </div>

--- a/cps/templates/publisher.html
+++ b/cps/templates/publisher.html
@@ -25,7 +25,8 @@
   <div class="row">
     {% if entries[0] %}
     {% for entry in entries %}
-      {% if entry.series_index[:1] %}
+      {% for first in entry.series_index[:1] %}
+      {% if first %}
     <div id="books" class="col-sm-3 col-lg-2 col-xs-6 book">
       <div class="cover">
           <a href="{{url_for('series', book_id=entry.series[0].id)}}">
@@ -49,6 +50,7 @@
       </div>
     </div>
       {% endif %}
+      {% endfor %}
     {% endfor %}
     {% endif %}
   </div>

--- a/cps/templates/publisher.html
+++ b/cps/templates/publisher.html
@@ -24,9 +24,8 @@
   {% endif %}
   <div class="row">
     {% if entries[0] %}
-    {% for entry in entries %}
-      {% for first in entry.series_index[:1] %}
-      {% if first %}
+    {% for entrylist in entries %}
+      {% for entry in entrylist[:1] %}
     <div id="books" class="col-sm-3 col-lg-2 col-xs-6 book">
       <div class="cover">
           <a href="{{url_for('series', book_id=entry.series[0].id)}}">
@@ -49,7 +48,6 @@
         {% endif %}
       </div>
     </div>
-      {% endif %}
       {% endfor %}
     {% endfor %}
     {% endif %}

--- a/cps/templates/publisher.html
+++ b/cps/templates/publisher.html
@@ -25,7 +25,7 @@
   <div class="row">
     {% if entries[0] %}
     {% for entry in entries %}
-      {% if entry.first %}
+      {% if entry.series_index.first %}
     <div id="books" class="col-sm-3 col-lg-2 col-xs-6 book">
       <div class="cover">
           <a href="{{url_for('series', book_id=entry.series[0].id)}}">

--- a/cps/templates/publisher.html
+++ b/cps/templates/publisher.html
@@ -24,8 +24,8 @@
   {% endif %}
   <div class="row">
     {% if entries[0] %}
-    {% for entrylist in entries %}
-      {% for entry in entrylist[:1] %}
+    {% for entry in entries %}
+      {% if entry.first %}
     <div id="books" class="col-sm-3 col-lg-2 col-xs-6 book">
       <div class="cover">
           <a href="{{url_for('series', book_id=entry.series[0].id)}}">
@@ -48,7 +48,7 @@
         {% endif %}
       </div>
     </div>
-      {% endfor %}
+      {% endif %}
     {% endfor %}
     {% endif %}
   </div>

--- a/cps/templates/publisher.html
+++ b/cps/templates/publisher.html
@@ -25,7 +25,7 @@
   <div class="row">
     {% if entries[0] %}
     {% for entry in entries %}
-      {% if entry.series_index == 1.0 %}
+      {% if entry.series_index.first %}
     <div id="books" class="col-sm-3 col-lg-2 col-xs-6 book">
       <div class="cover">
           <a href="{{url_for('series', book_id=entry.series[0].id)}}">

--- a/cps/templates/publisher.html
+++ b/cps/templates/publisher.html
@@ -1,0 +1,106 @@
+{% extends "layout.html" %}
+{% block body %}
+<h2>{{title}}</h2>
+
+{% if publisher is not none %}
+<section class="publisher-bio">
+  {%if publisher.image_url is not none %}
+  <img src="{{publisher.image_url}}" alt="{{publisher.name|safe}}" class="publisher-photo pull-left">
+  {% endif %}
+
+  {%if publisher.about is not none %}
+  <p>{{publisher.about|safe}}</p>
+  {% endif %}
+
+  - {{_("via")}} <a href="{{publisher.link}}" class="publisher-link" target="_blank" rel="noopener">Goodreads</a>
+</section>
+
+<div class="clearfix"></div>
+{% endif %}
+
+<div class="discover load-more">
+  {% if publisher is not none %}
+    <h3>{{_("In Library")}}</h3>
+  {% endif %}
+  <div class="row">
+    {% if entries[0] %}
+    {% for entry in entries %}
+    <div id="books" class="col-sm-3 col-lg-2 col-xs-6 book">
+      <div class="cover">
+          <a href="{{ url_for('show_book', book_id=entry.id) }}" data-toggle="modal" data-target="#bookDetailsModal" data-remote="false">
+              <img src="{{ url_for('get_cover', cover_path=entry.path.replace('\\','/')) }}" alt="{{ entry.title }}" />
+          </a>
+      </div>
+      <div class="meta">
+        <p class="title">{{entry.title|shortentitle}}</p>
+        <p class="publisher">
+          {% for publisher in entry.publishers %}
+          <a href="{{url_for('publisher', book_id=publisher.id) }}">{{publisher.name.replace('|',',')}}</a>
+          {% if not loop.last %}
+          &amp;
+          {% endif %}
+          {% endfor %}
+        </p>
+        {% if entry.ratings.__len__() > 0 %}
+        <div class="rating">
+          {% for number in range((entry.ratings[0].rating/2)|int(2)) %}
+          <span class="glyphicon glyphicon-star good"></span>
+          {% if loop.last and loop.index < 5 %}
+          {% for numer in range(5 - loop.index) %}
+          <span class="glyphicon glyphicon-star"></span>
+          {% endfor %}
+          {% endif %}
+          {% endfor %}
+        </div>
+        {% endif %}
+      </div>
+    </div>
+    {% endfor %}
+    {% endif %}
+  </div>
+</div>
+
+{% if other_books %}
+<div class="discover">
+  <h3>{{_("More by")}} {{ publisher.name.replace('|',',')|safe }}</h3>
+  <div class="row">
+    {% for entry in other_books %}
+    <div class="col-sm-3 col-lg-2 col-xs-6 book">
+      <div class="cover">
+        <a href="https://www.goodreads.com/book/show/{{ entry.gid['#text'] }}" target="_blank" rel="noopener">
+          <img src="{{ entry.image_url }}" />
+        </a>
+      </div>
+      <div class="meta">
+        <p class="title">{{entry.title|shortentitle}}</p>
+        <p class="publisher">
+          {% for publisher in entry.publishers %}
+          <a href="https://www.goodreads.com/publisher/show/{{ publisher.gid }}" target="_blank" rel="noopener">
+            {{publisher.name.replace('|',',')}}
+          </a>
+          {% if not loop.last %}
+          &amp;
+          {% endif %}
+          {% endfor %}
+        </p>
+        <div class="rating">
+          {% for number in range((entry.average_rating)|float|round|int(2)) %}
+          <span class="glyphicon glyphicon-star good"></span>
+          {% if loop.last and loop.index < 5 %}
+          {% for numer in range(5 - loop.index) %}
+          <span class="glyphicon glyphicon-star"></span>
+          {% endfor %}
+          {% endif %}
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+
+  <a href="{{publisher.link}}" class="publisher-link" target="_blank" rel="noopener">
+    <img src="{{ url_for('static', filename='img/goodreads.svg') }}" alt="Goodreads">
+  </a>
+</div>
+{% endif %}
+{% endblock %}

--- a/cps/templates/publisher.html
+++ b/cps/templates/publisher.html
@@ -25,7 +25,6 @@
   <div class="row">
     {% if entries[0] %}
     {% for entry in entries %}
-      {% if loop.first %}
     <div id="books" class="col-sm-3 col-lg-2 col-xs-6 book">
       <div class="cover">
           <a href="{{url_for('series', book_id=entry.series[0].id)}}">
@@ -48,7 +47,6 @@
         {% endif %}
       </div>
     </div>
-      {% endif %}
     {% endfor %}
     {% endif %}
   </div>

--- a/cps/templates/publisher.html
+++ b/cps/templates/publisher.html
@@ -25,22 +25,15 @@
   <div class="row">
     {% if entries[0] %}
     {% for entry in entries %}
+      {% if entry.series_index == 1.0 %}
     <div id="books" class="col-sm-3 col-lg-2 col-xs-6 book">
       <div class="cover">
-          <a href="{{ url_for('show_book', book_id=entry.id) }}" data-toggle="modal" data-target="#bookDetailsModal" data-remote="false">
+          <a href="{{url_for('series', book_id=entry.series[0].id)}}">
               <img src="{{ url_for('get_cover', cover_path=entry.path.replace('\\','/')) }}" alt="{{ entry.title }}" />
           </a>
       </div>
       <div class="meta">
-        <p class="title">{{entry.title|shortentitle}}</p>
-        <p class="publisher">
-          {% for publisher in entry.publishers %}
-          <a href="{{url_for('publisher', book_id=publisher.id) }}">{{publisher.name.replace('|',',')}}</a>
-          {% if not loop.last %}
-          &amp;
-          {% endif %}
-          {% endfor %}
-        </p>
+          <p class="title"><a href="{{url_for('series', book_id=entry.series[0].id)}}">{{entry.series[0].name}}</a></p>
         {% if entry.ratings.__len__() > 0 %}
         <div class="rating">
           {% for number in range((entry.ratings[0].rating/2)|int(2)) %}
@@ -55,6 +48,7 @@
         {% endif %}
       </div>
     </div>
+      {% endif %}
     {% endfor %}
     {% endif %}
   </div>

--- a/cps/templates/search_form.html
+++ b/cps/templates/search_form.html
@@ -34,7 +34,7 @@
         {% endfor %}
       </div>
     </div>
-    <label for="include_serie">{{_('Series')}}</label>
+    <label for="include_serie">{{_('Comics')}}</label>
     <div class="form-group">
       <div class="btn-toolbar btn-toolbar-lg" data-toggle="buttons">
         {% for serie in series %}
@@ -44,7 +44,7 @@
         {% endfor %}
       </div>
     </div>
-    <label for="exclude_serie">{{_('Exclude Series')}}</label>
+    <label for="exclude_serie">{{_('Exclude Comics')}}</label>
     <div class="form-group">
       <div class="btn-toolbar btn-toolbar-lg" data-toggle="buttons">
         {% for serie in series %}

--- a/cps/templates/stats.html
+++ b/cps/templates/stats.html
@@ -13,7 +13,7 @@
     </tr>
     <tr>
       <th>{{authorcounter}}</th>
-      <td>{{_('Authors in this Library')}}</td>
+      <td>{{_('Publishers in this Library')}}</td>
     </tr>
     <tr>
       <th>{{categorycounter}}</th>

--- a/cps/templates/stats.html
+++ b/cps/templates/stats.html
@@ -9,7 +9,7 @@
   <tbody>
     <tr>
       <th>{{bookcounter}}</th>
-      <td>{{_('Books in this Library')}}</td>
+      <td>{{_('Issues in this Library')}}</td>
     </tr>
     <tr>
       <th>{{authorcounter}}</th>
@@ -21,7 +21,7 @@
     </tr>
     <tr>
       <th>{{seriecounter}}</th>
-      <td>{{_('Series in this Library')}}</td>
+      <td>{{_('Comics in this Library')}}</td>
     </tr>
   </tbody>
 </table>

--- a/cps/templates/user_edit.html
+++ b/cps/templates/user_edit.html
@@ -67,7 +67,7 @@
       </div>
       <div class="form-group">
           <input type="checkbox" name="show_series" id="show_series" {% if content.show_series() %}checked{% endif %}>
-          <label for="show_series">{{_('Show series selection')}}</label>
+          <label for="show_series">{{_('Show comics selection')}}</label>
       </div>
       <div class="form-group">
           <input type="checkbox" name="show_category" id="show_category" {% if content.show_category() %}checked{% endif %}>
@@ -75,7 +75,7 @@
       </div>
       <div class="form-group">
           <input type="checkbox" name="show_author" id="show_author" {% if content.show_author() %}checked{% endif %}>
-          <label for="show_author">{{_('Show author selection')}}</label>
+          <label for="show_author">{{_('Show publisher selection')}}</label>
       </div>
       <div class="form-group">
           <input type="checkbox" name="show_read_and_unread" id="show_read_and_unread" {% if content.show_read_and_unread() %}checked{% endif %}>
@@ -83,7 +83,7 @@
       </div>
       <div class="form-group">
           <input type="checkbox" name="show_detail_random" id="show_detail_random" {% if content.show_detail_random() %}checked{% endif %}>
-          <label for="show_detail_random">{{_('Show random books in detail view')}}</label>
+          <label for="show_detail_random">{{_('Show random issues in detail view')}}</label>
       </div>
     </div>
       <div class="col-sm-6">

--- a/cps/templates/user_edit.html
+++ b/cps/templates/user_edit.html
@@ -74,8 +74,8 @@
           <label for="show_category">{{_('Show category selection')}}</label>
       </div>
       <div class="form-group">
-          <input type="checkbox" name="show_author" id="show_author" {% if content.show_author() %}checked{% endif %}>
-          <label for="show_author">{{_('Show publisher selection')}}</label>
+          <input type="checkbox" name="show_publisher" id="show_publisher" {% if content.show_publisher() %}checked{% endif %}>
+          <label for="show_publisher">{{_('Show publisher selection')}}</label>
       </div>
       <div class="form-group">
           <input type="checkbox" name="show_read_and_unread" id="show_read_and_unread" {% if content.show_read_and_unread() %}checked{% endif %}>

--- a/cps/templates/user_edit.html
+++ b/cps/templates/user_edit.html
@@ -43,23 +43,23 @@
     <div class="col-sm-6">
       <div class="form-group">
           <input type="checkbox" name="show_random" id="show_random" {% if content.show_random_books() %}checked{% endif %}>
-          <label for="show_random">{{_('Show random books')}}</label>
+          <label for="show_random">{{_('Show random issues')}}</label>
       </div>
       <div class="form-group">
           <input type="checkbox" name="show_recent" id="show_recent" {% if content.show_recent() %}checked{% endif %}>
-          <label for="show_recent">{{_('Show recent books')}}</label>
+          <label for="show_recent">{{_('Show recent issues')}}</label>
       </div>
       <div class="form-group">
           <input type="checkbox" name="show_sorted" id="show_sorted" {% if content.show_sorted() %}checked{% endif %}>
-          <label for="show_sorted">{{_('Show sorted books')}}</label>
+          <label for="show_sorted">{{_('Show sorted issues')}}</label>
       </div>
       <div class="form-group">
           <input type="checkbox" name="show_hot" id="show_hot" {% if content.show_hot_books() %}checked{% endif %}>
-          <label for="show_hot">{{_('Show hot books')}}</label>
+          <label for="show_hot">{{_('Show hot issues')}}</label>
       </div>
       <div class="form-group">
           <input type="checkbox" name="show_best_rated" id="show_best_rated" {% if content.show_best_rated_books() %}checked{% endif %}>
-          <label for="show_best_rated">{{_('Show best rated books')}}</label>
+          <label for="show_best_rated">{{_('Show best rated issues')}}</label>
       </div>
       <div class="form-group">
           <input type="checkbox" name="show_language" id="show_language" {% if content.show_language() %}checked{% endif %}>
@@ -112,7 +112,7 @@
     </div>
     <div class="form-group">
       <input type="checkbox" name="delete_role" id="delete_role" {% if content.role_delete_books() %}checked{% endif %}>
-      <label for="delete_role">{{_('Allow Delete books')}}</label>
+      <label for="delete_role">{{_('Allow Delete issues')}}</label>
     </div>
       {% if not content.role_anonymous() %}
         <div class="form-group">

--- a/cps/translations/de/LC_MESSAGES/messages.po
+++ b/cps/translations/de/LC_MESSAGES/messages.po
@@ -111,15 +111,15 @@ msgid "Update finished, please press okay and reload page"
 msgstr "Update abgeschlossen, bitte okay drücken und Seite neu laden"
 
 #: cps/web.py:1044
-msgid "Recently Added Books"
+msgid "Recently Added Issues"
 msgstr "Kürzlich hinzugefügte Bücher"
 
 #: cps/web.py:1054
-msgid "Newest Books"
+msgid "Newest Issues"
 msgstr "Neueste Bücher"
 
 #: cps/web.py:1065
-msgid "Oldest Books"
+msgid "Oldest Issues"
 msgstr "Älteste Bücher"
 
 #: cps/web.py:1077
@@ -131,19 +131,19 @@ msgid "Books (Z-A)"
 msgstr "Bücher (Z-A)"
 
 #: cps/web.py:1116
-msgid "Hot Books (most downloaded)"
+msgid "Hot Issues (most downloaded)"
 msgstr "Beliebte Bücher (die meisten Downloads)"
 
 #: cps/web.py:1129
-msgid "Best rated books"
+msgid "Best Rated Issues"
 msgstr "Best bewertete Bücher"
 
 #: cps/templates/index.xml:32 cps/web.py:1140
-msgid "Random Books"
+msgid "Random Issues"
 msgstr "Zufällige Bücher"
 
 #: cps/web.py:1154
-msgid "Author list"
+msgid "Publisher list"
 msgstr "Autorenliste"
 
 #: cps/web.py:1166 cps/web.py:1225 cps/web.py:1355 cps/web.py:1827
@@ -153,7 +153,7 @@ msgstr ""
 "zugänglich."
 
 #: cps/templates/index.xml:64 cps/web.py:1209
-msgid "Series list"
+msgid "Comics list"
 msgstr "Liste Serien"
 
 #: cps/web.py:1223
@@ -205,12 +205,12 @@ msgstr "Suche"
 
 #: cps/templates/index.xml:39 cps/templates/index.xml:42
 #: cps/templates/layout.html:131 cps/web.py:1782
-msgid "Read Books"
+msgid "Read Issues"
 msgstr "Gelesene Bücher"
 
 #: cps/templates/index.xml:45 cps/templates/index.xml:48
 #: cps/templates/layout.html:132 cps/web.py:1785
-msgid "Unread Books"
+msgid "Unread Issues"
 msgstr "Ungelesene Bücher"
 
 #: cps/web.py:1860 cps/web.py:1862 cps/web.py:1864 cps/web.py:1873
@@ -966,7 +966,7 @@ msgid "Search"
 msgstr "Suche"
 
 #: cps/templates/index.html:5
-msgid "Discover (Random Books)"
+msgid "Discover (Random Issues)"
 msgstr "Entdecke (Zufälliges Buch)"
 
 #: cps/templates/index.xml:5
@@ -974,7 +974,7 @@ msgid "Start"
 msgstr "Start"
 
 #: cps/templates/index.xml:14 cps/templates/layout.html:125
-msgid "Hot Books"
+msgid "Hot Issues"
 msgstr "Beliebte Bücher"
 
 #: cps/templates/index.xml:17
@@ -998,7 +998,7 @@ msgid "The latest Books"
 msgstr "Die neuesten Bücher"
 
 #: cps/templates/index.xml:35
-msgid "Show Random Books"
+msgid "Show Random Issues"
 msgstr "Zeige zufällige Bücher"
 
 #: cps/templates/index.xml:52 cps/templates/layout.html:144

--- a/cps/translations/es/LC_MESSAGES/messages.po
+++ b/cps/translations/es/LC_MESSAGES/messages.po
@@ -102,15 +102,15 @@ msgid "Update finished, please press okay and reload page"
 msgstr "Actualización finalizada. Por favor, pulse OK y recargue la página"
 
 #: cps/web.py:1044
-msgid "Recently Added Books"
+msgid "Recently Added Issues"
 msgstr ""
 
 #: cps/web.py:1054
-msgid "Newest Books"
+msgid "Newest Issues"
 msgstr ""
 
 #: cps/web.py:1065
-msgid "Oldest Books"
+msgid "Oldest Issues"
 msgstr ""
 
 #: cps/web.py:1077
@@ -122,19 +122,19 @@ msgid "Books (Z-A)"
 msgstr ""
 
 #: cps/web.py:1116
-msgid "Hot Books (most downloaded)"
+msgid "Hot Issues (most downloaded)"
 msgstr "Libros populares (los mas descargados)"
 
 #: cps/web.py:1129
-msgid "Best rated books"
+msgid "Best Rated Issues"
 msgstr "Libros mejor valorados"
 
 #: cps/templates/index.xml:32 cps/web.py:1140
-msgid "Random Books"
+msgid "Random Issues"
 msgstr "Libros al azar"
 
 #: cps/web.py:1154
-msgid "Author list"
+msgid "Publisher list"
 msgstr "Lista de autores"
 
 #: cps/web.py:1166 cps/web.py:1225 cps/web.py:1355 cps/web.py:1827
@@ -142,7 +142,7 @@ msgid "Error opening eBook. File does not exist or file is not accessible:"
 msgstr "Error en la apertura del eBook. El archivo no existe o no es accesible:"
 
 #: cps/templates/index.xml:64 cps/web.py:1209
-msgid "Series list"
+msgid "Comics list"
 msgstr "Lista de series"
 
 #: cps/web.py:1223
@@ -194,12 +194,12 @@ msgstr "búsqueda"
 
 #: cps/templates/index.xml:39 cps/templates/index.xml:42
 #: cps/templates/layout.html:131 cps/web.py:1782
-msgid "Read Books"
+msgid "Read Issues"
 msgstr "Libros leídos"
 
 #: cps/templates/index.xml:45 cps/templates/index.xml:48
 #: cps/templates/layout.html:132 cps/web.py:1785
-msgid "Unread Books"
+msgid "Unread Issues"
 msgstr "Libros no leídos"
 
 #: cps/web.py:1860 cps/web.py:1862 cps/web.py:1864 cps/web.py:1873
@@ -953,7 +953,7 @@ msgid "Search"
 msgstr "Buscar"
 
 #: cps/templates/index.html:5
-msgid "Discover (Random Books)"
+msgid "Discover (Random Issues)"
 msgstr "Descubrir (Libros al azar)"
 
 #: cps/templates/index.xml:5
@@ -961,7 +961,7 @@ msgid "Start"
 msgstr "Iniciar"
 
 #: cps/templates/index.xml:14 cps/templates/layout.html:125
-msgid "Hot Books"
+msgid "Hot Issues"
 msgstr "Libros Populares"
 
 #: cps/templates/index.xml:17
@@ -985,7 +985,7 @@ msgid "The latest Books"
 msgstr "Libros recientes"
 
 #: cps/templates/index.xml:35
-msgid "Show Random Books"
+msgid "Show Random Issues"
 msgstr "Mostrar libros al azar"
 
 #: cps/templates/index.xml:52 cps/templates/layout.html:144

--- a/cps/translations/fr/LC_MESSAGES/messages.po
+++ b/cps/translations/fr/LC_MESSAGES/messages.po
@@ -108,15 +108,15 @@ msgid "Update finished, please press okay and reload page"
 msgstr "Mise à jour terminée, merci d’appuyer sur okay et de rafraîchir la page"
 
 #: cps/web.py:1044
-msgid "Recently Added Books"
+msgid "Recently Added Issues"
 msgstr "Ajouts récents"
 
 #: cps/web.py:1054
-msgid "Newest Books"
+msgid "Newest Issues"
 msgstr "Livres récents"
 
 #: cps/web.py:1065
-msgid "Oldest Books"
+msgid "Oldest Issues"
 msgstr "Anciens livres"
 
 #: cps/web.py:1077
@@ -128,19 +128,19 @@ msgid "Books (Z-A)"
 msgstr "Livres (Z-A)"
 
 #: cps/web.py:1116
-msgid "Hot Books (most downloaded)"
+msgid "Hot Issues (most downloaded)"
 msgstr "Livres populaires (les plus téléchargés)"
 
 #: cps/web.py:1129
-msgid "Best rated books"
+msgid "Best Rated Issues"
 msgstr "Livres les mieux notés"
 
 #: cps/templates/index.xml:32 cps/web.py:1140
-msgid "Random Books"
+msgid "Random Issues"
 msgstr "Livres au hasard"
 
 #: cps/web.py:1154
-msgid "Author list"
+msgid "Publisher list"
 msgstr "Liste des auteurs"
 
 #: cps/web.py:1166 cps/web.py:1225 cps/web.py:1355 cps/web.py:1827
@@ -150,7 +150,7 @@ msgstr ""
 "pas accessible :"
 
 #: cps/templates/index.xml:64 cps/web.py:1209
-msgid "Series list"
+msgid "Comics list"
 msgstr "Liste des séries"
 
 #: cps/web.py:1223
@@ -202,12 +202,12 @@ msgstr "recherche"
 
 #: cps/templates/index.xml:39 cps/templates/index.xml:42
 #: cps/templates/layout.html:131 cps/web.py:1782
-msgid "Read Books"
+msgid "Read Issues"
 msgstr "Livres lus"
 
 #: cps/templates/index.xml:45 cps/templates/index.xml:48
 #: cps/templates/layout.html:132 cps/web.py:1785
-msgid "Unread Books"
+msgid "Unread Issues"
 msgstr "Livres non-lus"
 
 #: cps/web.py:1860 cps/web.py:1862 cps/web.py:1864 cps/web.py:1873
@@ -961,7 +961,7 @@ msgid "Search"
 msgstr "Chercher"
 
 #: cps/templates/index.html:5
-msgid "Discover (Random Books)"
+msgid "Discover (Random Issues)"
 msgstr "Découverte (livres au hasard)"
 
 #: cps/templates/index.xml:5
@@ -969,7 +969,7 @@ msgid "Start"
 msgstr "Démarrer"
 
 #: cps/templates/index.xml:14 cps/templates/layout.html:125
-msgid "Hot Books"
+msgid "Hot Issues"
 msgstr "Livres populaires"
 
 #: cps/templates/index.xml:17
@@ -995,7 +995,7 @@ msgid "The latest Books"
 msgstr "Les derniers livres"
 
 #: cps/templates/index.xml:35
-msgid "Show Random Books"
+msgid "Show Random Issues"
 msgstr "Montrer des livres au hasard"
 
 #: cps/templates/index.xml:52 cps/templates/layout.html:144

--- a/cps/translations/it/LC_MESSAGES/messages.po
+++ b/cps/translations/it/LC_MESSAGES/messages.po
@@ -102,15 +102,15 @@ msgid "Update finished, please press okay and reload page"
 msgstr "Aggiornamento completato, prego premere bene e ricaricare pagina"
 
 #: cps/web.py:1044
-msgid "Recently Added Books"
+msgid "Recently Added Issues"
 msgstr "Libri aggiunti di recente"
 
 #: cps/web.py:1054
-msgid "Newest Books"
+msgid "Newest Issues"
 msgstr "I più nuovi libri"
 
 #: cps/web.py:1065
-msgid "Oldest Books"
+msgid "Oldest Issues"
 msgstr "Libri più vecchi"
 
 #: cps/web.py:1077
@@ -122,19 +122,19 @@ msgid "Books (Z-A)"
 msgstr "Ebook (Z-A)"
 
 #: cps/web.py:1116
-msgid "Hot Books (most downloaded)"
-msgstr "Hot Books (più scaricati)"
+msgid "Hot Issues (most downloaded)"
+msgstr "Hot Issues (più scaricati)"
 
 #: cps/web.py:1129
-msgid "Best rated books"
+msgid "Best Rated Issues"
 msgstr "I migliori libri valutati"
 
 #: cps/templates/index.xml:32 cps/web.py:1140
-msgid "Random Books"
+msgid "Random Issues"
 msgstr "Libri casuali"
 
 #: cps/web.py:1154
-msgid "Author list"
+msgid "Publisher list"
 msgstr "Elenco degli autori"
 
 #: cps/web.py:1166 cps/web.py:1225 cps/web.py:1355 cps/web.py:1827
@@ -144,7 +144,7 @@ msgstr ""
 "accessibile:"
 
 #: cps/templates/index.xml:64 cps/web.py:1209
-msgid "Series list"
+msgid "Comics list"
 msgstr "Lista delle serie"
 
 #: cps/web.py:1223
@@ -196,12 +196,12 @@ msgstr "ricerca"
 
 #: cps/templates/index.xml:39 cps/templates/index.xml:42
 #: cps/templates/layout.html:131 cps/web.py:1782
-msgid "Read Books"
+msgid "Read Issues"
 msgstr "Leggere libri"
 
 #: cps/templates/index.xml:45 cps/templates/index.xml:48
 #: cps/templates/layout.html:132 cps/web.py:1785
-msgid "Unread Books"
+msgid "Unread Issues"
 msgstr "Libri non letti"
 
 #: cps/web.py:1860 cps/web.py:1862 cps/web.py:1864 cps/web.py:1873
@@ -959,7 +959,7 @@ msgid "Search"
 msgstr "Cerca"
 
 #: cps/templates/index.html:5
-msgid "Discover (Random Books)"
+msgid "Discover (Random Issues)"
 msgstr "Scoprire (Libri casuali)"
 
 #: cps/templates/index.xml:5
@@ -967,7 +967,7 @@ msgid "Start"
 msgstr "Inizio"
 
 #: cps/templates/index.xml:14 cps/templates/layout.html:125
-msgid "Hot Books"
+msgid "Hot Issues"
 msgstr "Hot Ebook"
 
 #: cps/templates/index.xml:17
@@ -991,7 +991,7 @@ msgid "The latest Books"
 msgstr "Gli ultimi Libri"
 
 #: cps/templates/index.xml:35
-msgid "Show Random Books"
+msgid "Show Random Issues"
 msgstr "Mostra libri casuali"
 
 #: cps/templates/index.xml:52 cps/templates/layout.html:144

--- a/cps/translations/nl/LC_MESSAGES/messages.po
+++ b/cps/translations/nl/LC_MESSAGES/messages.po
@@ -110,15 +110,15 @@ msgid "Update finished, please press okay and reload page"
 msgstr "Update voltooid, klik op ok en herlaad de pagina"
 
 #: cps/web.py:1044
-msgid "Recently Added Books"
+msgid "Recently Added Issues"
 msgstr "Recent toegevoegde boeken"
 
 #: cps/web.py:1054
-msgid "Newest Books"
+msgid "Newest Issues"
 msgstr "Nieuwste boeken"
 
 #: cps/web.py:1065
-msgid "Oldest Books"
+msgid "Oldest Issues"
 msgstr "Oudste boeken"
 
 #: cps/web.py:1077
@@ -130,19 +130,19 @@ msgid "Books (Z-A)"
 msgstr "Boeken (A-Z)"
 
 #: cps/web.py:1116
-msgid "Hot Books (most downloaded)"
+msgid "Hot Issues (most downloaded)"
 msgstr "Populaire boeken (meeste downloads)"
 
 #: cps/web.py:1129
-msgid "Best rated books"
+msgid "Best Rated Issues"
 msgstr "Best beoordeelde boeken"
 
 #: cps/templates/index.xml:32 cps/web.py:1140
-msgid "Random Books"
+msgid "Random Issues"
 msgstr "Willekeurige boeken"
 
 #: cps/web.py:1154
-msgid "Author list"
+msgid "Publisher list"
 msgstr "Auteur lijst"
 
 #: cps/web.py:1166 cps/web.py:1225 cps/web.py:1355 cps/web.py:1827
@@ -152,7 +152,7 @@ msgstr ""
 "toegankelijk:"
 
 #: cps/templates/index.xml:64 cps/web.py:1209
-msgid "Series list"
+msgid "Comics list"
 msgstr "Serie lijst"
 
 #: cps/web.py:1223
@@ -204,12 +204,12 @@ msgstr "zoek"
 
 #: cps/templates/index.xml:39 cps/templates/index.xml:42
 #: cps/templates/layout.html:131 cps/web.py:1782
-msgid "Read Books"
+msgid "Read Issues"
 msgstr "Gelezen Boeken"
 
 #: cps/templates/index.xml:45 cps/templates/index.xml:48
 #: cps/templates/layout.html:132 cps/web.py:1785
-msgid "Unread Books"
+msgid "Unread Issues"
 msgstr "Ongelezen Boeken"
 
 #: cps/web.py:1860 cps/web.py:1862 cps/web.py:1864 cps/web.py:1873
@@ -963,7 +963,7 @@ msgid "Search"
 msgstr "Zoek"
 
 #: cps/templates/index.html:5
-msgid "Discover (Random Books)"
+msgid "Discover (Random Issues)"
 msgstr "Ontdek (Willekeurige Boeken)"
 
 #: cps/templates/index.xml:5
@@ -971,7 +971,7 @@ msgid "Start"
 msgstr "Start"
 
 #: cps/templates/index.xml:14 cps/templates/layout.html:125
-msgid "Hot Books"
+msgid "Hot Issues"
 msgstr "Populaire Boeken"
 
 #: cps/templates/index.xml:17
@@ -995,7 +995,7 @@ msgid "The latest Books"
 msgstr "Recentste boeken"
 
 #: cps/templates/index.xml:35
-msgid "Show Random Books"
+msgid "Show Random Issues"
 msgstr "Toon Willekeurige Boeken"
 
 #: cps/templates/index.xml:52 cps/templates/layout.html:144

--- a/cps/translations/pl/LC_MESSAGES/messages.po
+++ b/cps/translations/pl/LC_MESSAGES/messages.po
@@ -103,15 +103,15 @@ msgid "Update finished, please press okay and reload page"
 msgstr "Aktualizacja zakończona, proszę nacisnąć OK i odświeżyć stronę"
 
 #: cps/web.py:1044
-msgid "Recently Added Books"
+msgid "Recently Added Issues"
 msgstr ""
 
 #: cps/web.py:1054
-msgid "Newest Books"
+msgid "Newest Issues"
 msgstr ""
 
 #: cps/web.py:1065
-msgid "Oldest Books"
+msgid "Oldest Issues"
 msgstr ""
 
 #: cps/web.py:1077
@@ -123,19 +123,19 @@ msgid "Books (Z-A)"
 msgstr ""
 
 #: cps/web.py:1116
-msgid "Hot Books (most downloaded)"
+msgid "Hot Issues (most downloaded)"
 msgstr "Najpopularniejsze książki (najczęściej pobierane)"
 
 #: cps/web.py:1129
-msgid "Best rated books"
+msgid "Best Rated Issues"
 msgstr "Najlepiej oceniane książki"
 
 #: cps/templates/index.xml:32 cps/web.py:1140
-msgid "Random Books"
+msgid "Random Issues"
 msgstr "Losowe książki"
 
 #: cps/web.py:1154
-msgid "Author list"
+msgid "Publisher list"
 msgstr "Lista autorów"
 
 #: cps/web.py:1166 cps/web.py:1225 cps/web.py:1355 cps/web.py:1827
@@ -143,7 +143,7 @@ msgid "Error opening eBook. File does not exist or file is not accessible:"
 msgstr "Błąd otwierania e-booka. Plik nie istnieje lub plik nie jest dostępny:"
 
 #: cps/templates/index.xml:64 cps/web.py:1209
-msgid "Series list"
+msgid "Comics list"
 msgstr "Lista serii"
 
 #: cps/web.py:1223
@@ -195,12 +195,12 @@ msgstr "szukaj"
 
 #: cps/templates/index.xml:39 cps/templates/index.xml:42
 #: cps/templates/layout.html:131 cps/web.py:1782
-msgid "Read Books"
+msgid "Read Issues"
 msgstr "Przeczytane książki"
 
 #: cps/templates/index.xml:45 cps/templates/index.xml:48
 #: cps/templates/layout.html:132 cps/web.py:1785
-msgid "Unread Books"
+msgid "Unread Issues"
 msgstr "Nieprzeczytane książki"
 
 #: cps/web.py:1860 cps/web.py:1862 cps/web.py:1864 cps/web.py:1873
@@ -953,7 +953,7 @@ msgid "Search"
 msgstr "Szukaj"
 
 #: cps/templates/index.html:5
-msgid "Discover (Random Books)"
+msgid "Discover (Random Issues)"
 msgstr "Odkrywaj (losowe książki)"
 
 #: cps/templates/index.xml:5
@@ -961,7 +961,7 @@ msgid "Start"
 msgstr "Rozpocznij"
 
 #: cps/templates/index.xml:14 cps/templates/layout.html:125
-msgid "Hot Books"
+msgid "Hot Issues"
 msgstr "Najpopularniejsze książki"
 
 #: cps/templates/index.xml:17
@@ -985,7 +985,7 @@ msgid "The latest Books"
 msgstr "Ostatnie książki"
 
 #: cps/templates/index.xml:35
-msgid "Show Random Books"
+msgid "Show Random Issues"
 msgstr "Pokazuj losowe książki"
 
 #: cps/templates/index.xml:52 cps/templates/layout.html:144

--- a/cps/translations/ru/LC_MESSAGES/messages.po
+++ b/cps/translations/ru/LC_MESSAGES/messages.po
@@ -103,15 +103,15 @@ msgid "Update finished, please press okay and reload page"
 msgstr "Обновления установлены, нажмите okay и перезагрузите страницу"
 
 #: cps/web.py:1044
-msgid "Recently Added Books"
+msgid "Recently Added Issues"
 msgstr ""
 
 #: cps/web.py:1054
-msgid "Newest Books"
+msgid "Newest Issues"
 msgstr ""
 
 #: cps/web.py:1065
-msgid "Oldest Books"
+msgid "Oldest Issues"
 msgstr ""
 
 #: cps/web.py:1077
@@ -123,19 +123,19 @@ msgid "Books (Z-A)"
 msgstr ""
 
 #: cps/web.py:1116
-msgid "Hot Books (most downloaded)"
+msgid "Hot Issues (most downloaded)"
 msgstr "Популярные книги (часто загружаемые)"
 
 #: cps/web.py:1129
-msgid "Best rated books"
+msgid "Best Rated Issues"
 msgstr "Книги с наивысшим рейтингом"
 
 #: cps/templates/index.xml:32 cps/web.py:1140
-msgid "Random Books"
+msgid "Random Issues"
 msgstr "Случайный выбор"
 
 #: cps/web.py:1154
-msgid "Author list"
+msgid "Publisher list"
 msgstr "Авторы"
 
 #: cps/web.py:1166 cps/web.py:1225 cps/web.py:1355 cps/web.py:1827
@@ -143,7 +143,7 @@ msgid "Error opening eBook. File does not exist or file is not accessible:"
 msgstr "Невозможно открыть книгу. Файл не существует или недоступен."
 
 #: cps/templates/index.xml:64 cps/web.py:1209
-msgid "Series list"
+msgid "Comics list"
 msgstr "Серии"
 
 #: cps/web.py:1223
@@ -195,12 +195,12 @@ msgstr "поиск"
 
 #: cps/templates/index.xml:39 cps/templates/index.xml:42
 #: cps/templates/layout.html:131 cps/web.py:1782
-msgid "Read Books"
+msgid "Read Issues"
 msgstr "Прочитанные"
 
 #: cps/templates/index.xml:45 cps/templates/index.xml:48
 #: cps/templates/layout.html:132 cps/web.py:1785
-msgid "Unread Books"
+msgid "Unread Issues"
 msgstr "Непрочитанные"
 
 #: cps/web.py:1860 cps/web.py:1862 cps/web.py:1864 cps/web.py:1873
@@ -950,7 +950,7 @@ msgid "Search"
 msgstr "Поиск"
 
 #: cps/templates/index.html:5
-msgid "Discover (Random Books)"
+msgid "Discover (Random Issues)"
 msgstr "Обзор (случайные книги)"
 
 #: cps/templates/index.xml:5
@@ -958,7 +958,7 @@ msgid "Start"
 msgstr "Старт"
 
 #: cps/templates/index.xml:14 cps/templates/layout.html:125
-msgid "Hot Books"
+msgid "Hot Issues"
 msgstr "Популярные книги"
 
 #: cps/templates/index.xml:17
@@ -982,7 +982,7 @@ msgid "The latest Books"
 msgstr "Последние поступления"
 
 #: cps/templates/index.xml:35
-msgid "Show Random Books"
+msgid "Show Random Issues"
 msgstr "Показывать случайные книги"
 
 #: cps/templates/index.xml:52 cps/templates/layout.html:144

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -135,7 +135,7 @@ class UserBase:
     def show_category(self):
         return bool((self.sidebar_view is not None)and(self.sidebar_view & SIDEBAR_CATEGORY == SIDEBAR_CATEGORY))
 
-    def show_author(self):
+    def show_publisher(self):
         return bool((self.sidebar_view is not None)and(self.sidebar_view & SIDEBAR_AUTHOR == SIDEBAR_AUTHOR))
 
     def show_best_rated_books(self):

--- a/cps/web.py
+++ b/cps/web.py
@@ -1191,7 +1191,7 @@ def get_matching_tags():
 def index(page):
     entries, random, pagination = fill_indexpage(page, db.Books, True, db.Books.timestamp.desc())
     return render_title_template('index.html', random=random, entries=entries, pagination=pagination,
-                                 title=_(u"Recently Added Books"))
+                                 title=_(u"Recently Added Issues"))
 
 
 @app.route('/books/newest', defaults={'page': 1})
@@ -1201,7 +1201,7 @@ def newest_books(page):
     if current_user.show_sorted():
         entries, random, pagination = fill_indexpage(page, db.Books, True, db.Books.pubdate.desc())
         return render_title_template('index.html', random=random, entries=entries, pagination=pagination,
-                                     title=_(u"Newest Books"))
+                                     title=_(u"Newest Issues"))
     else:
         abort(404)
 
@@ -1212,7 +1212,7 @@ def oldest_books(page):
     if current_user.show_sorted():
         entries, random, pagination = fill_indexpage(page, db.Books, True, db.Books.pubdate)
         return render_title_template('index.html', random=random, entries=entries, pagination=pagination,
-                                     title=_(u"Oldest Books"))
+                                     title=_(u"Oldest Issues"))
     else:
         abort(404)
 
@@ -1224,7 +1224,7 @@ def titles_ascending(page):
     if current_user.show_sorted():
         entries, random, pagination = fill_indexpage(page, db.Books, True, db.Books.sort)
         return render_title_template('index.html', random=random, entries=entries, pagination=pagination,
-                                     title=_(u"Books (A-Z)"))
+                                     title=_(u"Issues (A-Z)"))
     else:
         abort(404)
 
@@ -1235,7 +1235,7 @@ def titles_ascending(page):
 def titles_descending(page):
     entries, random, pagination = fill_indexpage(page, db.Books, True, db.Books.sort.desc())
     return render_title_template('index.html', random=random, entries=entries, pagination=pagination,
-                                 title=_(u"Books (Z-A)"))
+                                 title=_(u"Issues (Z-A)"))
 
 
 @app.route("/hot", defaults={'page': 1})
@@ -1263,7 +1263,7 @@ def hot_books(page):
         numBooks = entries.__len__()
         pagination = Pagination(page, config.config_books_per_page, numBooks)
         return render_title_template('index.html', random=random, entries=entries, pagination=pagination,
-                                     title=_(u"Hot Books (most downloaded)"))
+                                     title=_(u"Hot Issues (most downloaded)"))
     else:
        abort(404)
 
@@ -1276,7 +1276,7 @@ def best_rated_books(page):
         entries, random, pagination = fill_indexpage(page, db.Books, db.Books.ratings.any(db.Ratings.rating > 9),
                                                      db.Books.timestamp.desc())
         return render_title_template('index.html', random=random, entries=entries, pagination=pagination,
-                                     title=_(u"Best rated books"))
+                                     title=_(u"Best Rated Issues"))
     abort(404)
 
 
@@ -1287,7 +1287,7 @@ def discover(page):
     if current_user.show_random_books():
         entries, __, pagination = fill_indexpage(page, db.Books, True, func.randomblob(2))
         pagination = Pagination(1, config.config_books_per_page,config.config_books_per_page)
-        return render_title_template('discover.html', entries=entries, pagination=pagination, title=_(u"Random Books"))
+        return render_title_template('discover.html', entries=entries, pagination=pagination, title=_(u"Random Issues"))
     else:
         abort(404)
 
@@ -1301,7 +1301,7 @@ def author_list():
             .group_by('books_authors_link.author').order_by(db.Authors.sort).all()
         for entry in entries:
             entry.Authors.name=entry.Authors.name.replace('|',',')
-        return render_title_template('list.html', entries=entries, folder='author', title=_(u"Author list"))
+        return render_title_template('list.html', entries=entries, folder='author', title=_(u"Publisher list"))
     else:
         abort(404)
 
@@ -1356,7 +1356,7 @@ def series_list():
         entries = db.session.query(db.Series, func.count('books_series_link.book').label('count'))\
             .join(db.books_series_link).join(db.Books).filter(common_filters())\
             .group_by('books_series_link.series').order_by(db.Series.sort).all()
-        return render_title_template('list.html', entries=entries, folder='series', title=_(u"Series list"))
+        return render_title_template('list.html', entries=entries, folder='series', title=_(u"Comics list"))
     else:
         abort(404)
 
@@ -1370,9 +1370,9 @@ def series(book_id, page):
     name = db.session.query(db.Series).filter(db.Series.id == book_id).first().name
     if entries:
         return render_title_template('index.html', random=random, pagination=pagination, entries=entries,
-                                     title=_(u"Series: %(serie)s", serie=name))
+                                     title=_(u"Comics: %(serie)s", serie=name))
     else:
-        flash(_(u"Error opening eBook. File does not exist or file is not accessible:"), category="error")
+        flash(_(u"Error opening Issue. File does not exist or file is not accessible:"), category="error")
         return redirect(url_for("index"))
 
 
@@ -1975,11 +1975,11 @@ def read_book(book_id, book_format):
                     fd.write(zfile.read(name))
                     fd.close()
             zfile.close()
-        return render_title_template('read.html', bookid=book_id, title=_(u"Read a Book"), bookmark=bookmark)
+        return render_title_template('read.html', bookid=book_id, title=_(u"Read an Issue"), bookmark=bookmark)
     elif book_format.lower() == "pdf":
-        return render_title_template('readpdf.html', pdffile=book_id, title=_(u"Read a Book"))
+        return render_title_template('readpdf.html', pdffile=book_id, title=_(u"Read an Issue"))
     elif book_format.lower() == "txt":
-        return render_title_template('readtxt.html', txtfile=book_id, title=_(u"Read a Book"))
+        return render_title_template('readtxt.html', txtfile=book_id, title=_(u"Read an Issue"))
     else:
         if rar_support == True:
             extensionList = ["cbr","cbt","cbz"]
@@ -1987,7 +1987,7 @@ def read_book(book_id, book_format):
             extensionList = ["cbt","cbz"]
         for fileext in extensionList:
             if book_format.lower() == fileext:
-                return render_title_template('readcbr.html', comicfile=book_id, extension=fileext, title=_(u"Read a Book"), book=book)
+                return render_title_template('readcbr.html', comicfile=book_id, extension=fileext, title=_(u"Read an Issue"), book=book)
         flash(_(u"Error opening eBook. File does not exist or file is not accessible."), category="error")
         return redirect(url_for("index"))
 

--- a/cps/web.py
+++ b/cps/web.py
@@ -1285,7 +1285,7 @@ def best_rated_books(page):
 @login_required_if_no_ano
 def discover(page):
     if current_user.show_random_books():
-        entries, __, pagination = fill_indexpage(page, db.Series, True, func.randomblob(2))
+        entries, __, pagination = fill_indexpage(page, db.Books, True, func.randomblob(2))
         pagination = Pagination(1, config.config_books_per_page,config.config_books_per_page)
         return render_title_template('discover.html', entries=entries, pagination=pagination, title=_(u"Random Comics"))
     else:
@@ -1313,7 +1313,7 @@ def publisher(book_id, page):
     entries, __, pagination = fill_indexpage(page, db.Books, db.Books.publishers.any(db.Publishers.id == book_id),
                                                  db.Books.timestamp.desc())
     if entries is None:
-        flash(_(u"Error opening eBook. File does not exist or file is not accessible:"), category="error")
+        flash(_(u"Error opening comic. File does not exist or file is not accessible:"), category="error")
         return redirect(url_for("index"))
 
     name = (db.session.query(db.Publishers).filter(db.Publishers.id == book_id).first().name).replace('|',',')
@@ -1370,7 +1370,7 @@ def series(book_id, page):
     name = db.session.query(db.Series).filter(db.Series.id == book_id).first().name
     if entries:
         return render_title_template('index.html', random=random, pagination=pagination, entries=entries,
-                                     title=_(u"Comics: %(serie)s", serie=name))
+                                     title=_(u"Issues for the comic: %(serie)s", serie=name))
     else:
         flash(_(u"Error opening Issue. File does not exist or file is not accessible:"), category="error")
         return redirect(url_for("index"))

--- a/cps/web.py
+++ b/cps/web.py
@@ -771,7 +771,7 @@ def feed_hot():
     return response
 
 
-@app.route("/opds/author")
+@app.route("/opds/publisher")
 @requires_basic_auth_if_no_ano
 def feed_authorindex():
     off = request.args.get("offset")
@@ -787,7 +787,7 @@ def feed_authorindex():
     return response
 
 
-@app.route("/opds/author/<int:book_id>")
+@app.route("/opds/publisher/<int:book_id>")
 @requires_basic_auth_if_no_ano
 def feed_author(book_id):
     off = request.args.get("offset")
@@ -831,7 +831,7 @@ def feed_category(book_id):
     return response
 
 
-@app.route("/opds/series")
+@app.route("/opds/comics")
 @requires_basic_auth_if_no_ano
 def feed_seriesindex():
     off = request.args.get("offset")
@@ -847,7 +847,7 @@ def feed_seriesindex():
     return response
 
 
-@app.route("/opds/series/<int:book_id>")
+@app.route("/opds/comics/<int:book_id>")
 @requires_basic_auth_if_no_ano
 def feed_series(book_id):
     off = request.args.get("offset")
@@ -918,7 +918,7 @@ def get_opds_download_link(book_id, book_format):
         return response
 
 
-@app.route("/ajax/book/<string:uuid>")
+@app.route("/ajax/issue/<string:uuid>")
 @requires_basic_auth_if_no_ano
 def get_metadata_calibre_companion(uuid):
     entry = db.session.query(db.Books).filter(db.Books.uuid.like("%" + uuid + "%")).first()
@@ -1058,7 +1058,7 @@ def bookmark(book_id, book_format):
     return "", 201
 
 
-@app.route("/get_authors_json", methods=['GET', 'POST'])
+@app.route("/get_publishers_json", methods=['GET', 'POST'])
 @login_required_if_no_ano
 def get_authors_json():
     if request.method == "GET":
@@ -1148,7 +1148,7 @@ def get_languages_json():
         return json_dumps
 
 
-@app.route("/get_series_json", methods=['GET', 'POST'])
+@app.route("/get_comics_json", methods=['GET', 'POST'])
 @login_required_if_no_ano
 def get_series_json():
     if request.method == "GET":
@@ -1194,8 +1194,8 @@ def index(page):
                                  title=_(u"Recently Added Issues"))
 
 
-@app.route('/books/newest', defaults={'page': 1})
-@app.route('/books/newest/page/<int:page>')
+@app.route('/issues/newest', defaults={'page': 1})
+@app.route('/issues/newest/page/<int:page>')
 @login_required_if_no_ano
 def newest_books(page):
     if current_user.show_sorted():
@@ -1205,8 +1205,8 @@ def newest_books(page):
     else:
         abort(404)
 
-@app.route('/books/oldest', defaults={'page': 1})
-@app.route('/books/oldest/page/<int:page>')
+@app.route('/issues/oldest', defaults={'page': 1})
+@app.route('/issues/oldest/page/<int:page>')
 @login_required_if_no_ano
 def oldest_books(page):
     if current_user.show_sorted():
@@ -1217,8 +1217,8 @@ def oldest_books(page):
         abort(404)
 
 
-@app.route('/books/a-z', defaults={'page': 1})
-@app.route('/books/a-z/page/<int:page>')
+@app.route('/issues/a-z', defaults={'page': 1})
+@app.route('/issues/a-z/page/<int:page>')
 @login_required_if_no_ano
 def titles_ascending(page):
     if current_user.show_sorted():
@@ -1229,8 +1229,8 @@ def titles_ascending(page):
         abort(404)
 
 
-@app.route('/books/z-a', defaults={'page': 1})
-@app.route('/books/z-a/page/<int:page>')
+@app.route('/issues/z-a', defaults={'page': 1})
+@app.route('/issues/z-a/page/<int:page>')
 @login_required_if_no_ano
 def titles_descending(page):
     entries, random, pagination = fill_indexpage(page, db.Books, True, db.Books.sort.desc())
@@ -1292,7 +1292,7 @@ def discover(page):
         abort(404)
 
 
-@app.route("/author")
+@app.route("/publisher")
 @login_required_if_no_ano
 def author_list():
     if current_user.show_author():
@@ -1306,8 +1306,8 @@ def author_list():
         abort(404)
 
 
-@app.route("/author/<int:book_id>", defaults={'page': 1})
-@app.route("/author/<int:book_id>/<int:page>'")
+@app.route("/publisher/<int:book_id>", defaults={'page': 1})
+@app.route("/publisher/<int:book_id>/<int:page>'")
 @login_required_if_no_ano
 def author(book_id, page):
     entries, __, pagination = fill_indexpage(page, db.Books, db.Books.authors.any(db.Authors.id == book_id),
@@ -1329,7 +1329,7 @@ def author(book_id, page):
                                  title=name, author=author_info, other_books=other_books)
 
 
-def get_unique_other_books(library_books, author_books):
+def get_unique_other_issues(library_books, author_books):
     # Get all identifiers (ISBN, Goodreads, etc) and filter author's books by that list so we show fewer duplicates
     # Note: Not all images will be shown, even though they're available on Goodreads.com.
     #       See https://www.goodreads.com/topic/show/18213769-goodreads-book-images
@@ -1349,7 +1349,7 @@ def get_unique_other_books(library_books, author_books):
 
 
 
-@app.route("/series")
+@app.route("/comics")
 @login_required_if_no_ano
 def series_list():
     if current_user.show_series():
@@ -1361,8 +1361,8 @@ def series_list():
         abort(404)
 
 
-@app.route("/series/<int:book_id>/", defaults={'page': 1})
-@app.route("/series/<int:book_id>/<int:page>'")
+@app.route("/comics/<int:book_id>/", defaults={'page': 1})
+@app.route("/comics/<int:book_id>/<int:page>'")
 @login_required_if_no_ano
 def series(book_id, page):
     entries, random, pagination = fill_indexpage(page, db.Books, db.Books.series.any(db.Series.id == book_id),
@@ -1449,7 +1449,7 @@ def category(book_id, page):
 
 
 
-@app.route("/book/<int:book_id>")
+@app.route("/issue/<int:book_id>")
 @login_required_if_no_ano
 def show_book(book_id):
     entries = db.session.query(db.Books).filter(db.Books.id == book_id).filter(common_filters()).first()
@@ -1897,15 +1897,15 @@ def render_read_books(page, are_read, as_xml=False):
         return response
     else:
         if are_read:
-            name = _(u'Read Books') + ' (' + str(len(readBookIds)) + ')'
+            name = _(u'Read Issues') + ' (' + str(len(readBookIds)) + ')'
         else:
             total_books = db.session.query(func.count(db.Books.id)).scalar()
-            name = _(u'Unread Books') + ' (' + str(total_books - len(readBookIds)) + ')'
+            name = _(u'Unread Issues') + ' (' + str(total_books - len(readBookIds)) + ')'
         return render_title_template('index.html', random=random, entries=entries, pagination=pagination,
                                 title=_(name, name=name))
 
 
-@app.route("/opds/readbooks/")
+@app.route("/opds/readissues/")
 @login_required_if_no_ano
 def feed_read_books():
     off = request.args.get("offset")
@@ -1914,14 +1914,14 @@ def feed_read_books():
     return render_read_books(int(off) / (int(config.config_books_per_page)) + 1, True, True)
 
 
-@app.route("/readbooks/", defaults={'page': 1})
-@app.route("/readbooks/<int:page>'")
+@app.route("/readissues/", defaults={'page': 1})
+@app.route("/readissues/<int:page>'")
 @login_required_if_no_ano
 def read_books(page):
     return render_read_books(page, True)
 
 
-@app.route("/opds/unreadbooks/")
+@app.route("/opds/unreadissues/")
 @login_required_if_no_ano
 def feed_unread_books():
     off = request.args.get("offset")
@@ -1930,8 +1930,8 @@ def feed_unread_books():
     return render_read_books(int(off) / (int(config.config_books_per_page)) + 1, False, True)
 
 
-@app.route("/unreadbooks/", defaults={'page': 1})
-@app.route("/unreadbooks/<int:page>'")
+@app.route("/unreadissues/", defaults={'page': 1})
+@app.route("/unreadissues/<int:page>'")
 @login_required_if_no_ano
 def unread_books(page):
     return render_read_books(page, False)
@@ -2664,7 +2664,7 @@ def new_user():
             content.sidebar_view += ub.SIDEBAR_RANDOM
         if "show_language" in to_save:
             content.sidebar_view += ub.SIDEBAR_LANGUAGE
-        if "show_series" in to_save:
+        if "show_comics" in to_save:
             content.sidebar_view += ub.SIDEBAR_SERIES
         if "show_category" in to_save:
             content.sidebar_view += ub.SIDEBAR_CATEGORY
@@ -2674,7 +2674,7 @@ def new_user():
             content.sidebar_view += ub.SIDEBAR_READ_AND_UNREAD
         if "show_best_rated" in to_save:
             content.sidebar_view += ub.SIDEBAR_BEST_RATED
-        if "show_author" in to_save:
+        if "show_publisher" in to_save:
             content.sidebar_view += ub.SIDEBAR_AUTHOR
         if "show_detail_random" in to_save:
             content.sidebar_view += ub.DETAIL_RANDOM
@@ -2883,7 +2883,7 @@ def edit_user(user_id):
                                  title=_(u"Edit User %(nick)s", nick=content.nickname))
 
 
-@app.route("/admin/book/<int:book_id>", methods=['GET', 'POST'])
+@app.route("/admin/issue/<int:book_id>", methods=['GET', 'POST'])
 @login_required_if_no_ano
 @edit_required
 def edit_book(book_id):

--- a/messages.pot
+++ b/messages.pot
@@ -126,7 +126,7 @@ msgid "Random Books"
 msgstr ""
 
 #: cps/web.py:1154
-msgid "Author list"
+msgid "Publisher list"
 msgstr ""
 
 #: cps/web.py:1166 cps/web.py:1225 cps/web.py:1355 cps/web.py:1827

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ Calibre Web is a web app providing a clean interface for browsing, reading and d
 - Admin interface
 - User Interface in dutch, english, french, german, italian, polish, russian, simplified chinese, spanish
 - OPDS feed for eBook reader apps 
-- Filter and search by titles, authors, tags, series and language
+- Filter and search by titles, publishers, tags, series and language
 - Create custom book collection (shelves)
 - Support for editing eBook metadata and deleting eBooks from Calibre library
 - Support for converting eBooks from EPUB to Kindle format (mobi/azw)


### PR DESCRIPTION
I've made comics a bit more usable for comics.

Changed Author into Publisher
Changed Series into Comics
Changed Books into Issues
Discover now shows Comics (Series) instead of Issues (Books)
When clicking on a Publisher (Author) it now shows Comics (Series) instead of Issues (Books)
Added issue number from metadata

This does require a couple mandatory metadata rules to be used optimally. But that's all possible through ComicTagger and Calibre (Best way to metadata comics anyway).

The way Calibre should be:
![image](https://user-images.githubusercontent.com/24505478/36758284-4ac5c402-1c14-11e8-9ef9-ed0353a91422.png)

Images of the end result:

Homepage:
![image](https://user-images.githubusercontent.com/24505478/36839107-5bb9c79e-1d41-11e8-9909-ccdeeaf842f0.png)

Publishers list: (Comics list is the same, but with comics instead of publishers)
![image](https://user-images.githubusercontent.com/24505478/36839117-605a5a16-1d41-11e8-905c-dfd723b0a29e.png)

When clicked on publisher view (DC Comics in this case):
![image](https://user-images.githubusercontent.com/24505478/36839119-63c6c662-1d41-11e8-9a16-d35e330d71de.png)

Discover:
![image](https://user-images.githubusercontent.com/24505478/36839123-66b177be-1d41-11e8-9ffc-f38d247c1c2c.png)

Issues sorted by A-Z:
![image](https://user-images.githubusercontent.com/24505478/36839133-6a8ec792-1d41-11e8-9a8a-fd90a361c4dd.png)

When clicked on issue
![image](https://user-images.githubusercontent.com/24505478/36839136-6e02ee08-1d41-11e8-8537-d2d86ab875e0.png)

It does so rating, so does the comics view. I just don't have any ratings set up myself.