### PR TITLE
fix(template): download book with .AZW3 in kindle's browser

### DIFF
--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -22,7 +22,7 @@
                     {{_('Download')}} :
                   </button>
                   {% for format in entry.data %}
-                  <a href="{{ url_for('get_download_link_ext', book_id=entry.id, book_format=format.format|lower, anyname=entry.id|string+'.'+format.format) }}" id="btnGroupDrop1{{format.format|lower}}" class="btn btn-primary" role="button">
+                  <a href="{{ url_for('get_download_link_ext', book_id=entry.id, book_format=format.format|lower, anyname=entry.id|string+'.'+format.format|lower) }}" id="btnGroupDrop1{{format.format|lower}}" class="btn btn-primary" role="button">
                     <span class="glyphicon glyphicon-download"></span>{{format.format}} ({{ format.uncompressed_size|filesizeformat }})
                   </a>
                   {% endfor %}
@@ -33,7 +33,7 @@
                   </button>
                   <ul class="dropdown-menu" aria-labelledby="btnGroupDrop1">
                   {% for format in entry.data %}
-                    <li><a href="{{ url_for('get_download_link_ext', book_id=entry.id, book_format=format.format|lower, anyname=entry.id|string+'.'+format.format) }}">{{format.format}} ({{ format.uncompressed_size|filesizeformat }})</a></li>
+                    <li><a href="{{ url_for('get_download_link_ext', book_id=entry.id, book_format=format.format|lower, anyname=entry.id|string+'.'+format.format|lower) }}">{{format.format}} ({{ format.uncompressed_size|filesizeformat }})</a></li>
                   {% endfor %}
                   </ul>
                 {% endif %}


### PR DESCRIPTION
When the book's extension is .azw3 and downloaded by kindle's experimental browser, 'anyname' would be used as the name of the book in URL. In this case, the format of book will be in capital, which cannot be opened in Kindle Paperwhite.

Kindle Paperwhite firmware: 5.9.4