### PR TITLE
 Option to delete individual book formats 

### DIFF
--- a/cps/helper.py
+++ b/cps/helper.py
@@ -307,12 +307,12 @@ def get_sorted_author(value):
     return value2
 
 
-def delete_book(book, calibrepath, format=None):
+def delete_book(book, calibrepath, book_format=None):
     if "/" in book.path:
         path = os.path.join(calibrepath, book.path)
-        if format:
+        if book_format:
             for file in os.listdir(path):
-                if file.upper().endswith("."+format):
+                if file.upper().endswith("."+book_format):
                     os.remove(os.path.join(path, file))
         else:
             shutil.rmtree(path, ignore_errors=True)

--- a/cps/templates/book_edit.html
+++ b/cps/templates/book_edit.html
@@ -21,7 +21,7 @@
       {% for file in book.data %}
         <p>
           <label>{{file.format}} ({{ file.uncompressed_size|filesizeformat }})</label>
-          <a href="{{ url_for('delete_book_format', book_id=book.id, format=file.format) }}" class="btn-sm btn btn-danger" type="button">{{_('Delete')}}</a>
+          <a href="{{ url_for('delete_book_format', book_id=book.id, book_format=file.format) }}" class="btn-sm btn btn-danger" type="button">{{_('Delete')}}</a>
         </p>
       {% endfor %}
       </div>

--- a/cps/web.py
+++ b/cps/web.py
@@ -1476,14 +1476,14 @@ def stats():
                                  categorycounter=categorys, seriecounter=series, title=_(u"Statistics"))
 
 
-@app.route("/delete/<int:book_id>/<string:format>/")
+@app.route("/delete/<int:book_id>/<string:book_format>/")
 @login_required
-def delete_book_format(book_id, format):
+def delete_book_format(book_id, book_format):
     if current_user.role_delete_books():
         book = db.session.query(db.Books).filter(db.Books.id == book_id).first()
         if book:
-            helper.delete_book(book, config.config_calibre_dir, format=format)
-            db.session.query(db.Data).filter(db.Data.book == book.id).filter(db.Data.format == format).delete()
+            helper.delete_book(book, config.config_calibre_dir, book_format=book_format)
+            db.session.query(db.Data).filter(db.Data.book == book.id).filter(db.Data.format == book_format).delete()
             db.session.commit()
         else:
             # book not found


### PR DESCRIPTION
Displays an option on the book edit page to delete individual formats if the book has more than one. 
![screenshot](https://i.imgur.com/QQ4SBpR.png)

When a book only has one format (or once you've deleted all the others) the page displays how it originally did:
![screenshot](https://i.imgur.com/MEyDExk.png)

Implementation of this feature request: #485