### PR TITLE
Render 'url:' ID type as a link

### DIFF
--- a/cps/db.py
+++ b/cps/db.py
@@ -112,6 +112,8 @@ class Identifiers(Base):
             return u"https://books.google.com/books?id={0}".format(self.val)
         elif self.type == "kobo":
             return u"https://www.kobo.com/ebook/{0}".format(self.val)
+        elif self.type == "url":
+            return u"{0}".format(self.val)
         else:
             return u""
 


### PR DESCRIPTION
Calibre allows `url:` as a kind of book identifier and shows it in the UI as a link; this change makes calibre-web do the same.