### PR TITLE
Changed the args to subprocess.Popen to pass args to the command

### DIFF
--- a/cps/converter.py
+++ b/cps/converter.py
@@ -34,7 +34,7 @@ def versionCalibre():
     versions = _(u'not installed')
     if os.path.exists(ub.config.config_converterpath):
         try:
-            p = subprocess.Popen(ub.config.config_converterpath + ' --version', stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            p = subprocess.Popen([ub.config.config_converterpath, '--version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             p.wait()
             for lines in p.stdout.readlines():
                 if isinstance(lines, bytes):


### PR DESCRIPTION
Before the command was not working correctly to check the calibre version since it seemed to be treating the entire string as the command.  So when ' --version' was added it was breaking.  I changed the format to pass the command and args as a list and it seems to work correctly.