### PR TITLE
Beautify http errors

### DIFF
--- a/cps/static/css/style.css
+++ b/cps/static/css/style.css
@@ -5,6 +5,22 @@
   src: local('Grand Hotel'), local('GrandHotel-Regular'), url("fonts/GrandHotel-Regular.ttf") format('truetype');
 }
 
+html.http-error {
+  margin: 0;
+  height: 100%;
+}
+.http-error body {
+  margin: 0;
+  height: 100%;
+  display: table;
+  width: 100%;
+}
+.http-error body > div {
+  display: table-cell;
+  vertical-align: middle;
+  text-align: center;
+}
+
 body{background:#f2f2f2}body h2{font-weight:normal;color:#444}
 body { margin-bottom: 40px;}
 a{color: #45b29d}a:hover{color: #444;}

--- a/cps/templates/http_error.html
+++ b/cps/templates/http_error.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html class="http-error" lang="{{ g.user.locale }}">
+  <head>
+    <title>{{ instance }} | HTTP Error ({{ error_code }})</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+
+    <!-- Bootstrap -->
+    <link rel="apple-touch-icon" sizes="140x140" href="{{ url_for('static', filename='favicon.ico') }}">
+    <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
+    <link href="{{ url_for('static', filename='css/libs/bootstrap.min.css') }}" rel="stylesheet" media="screen">
+    <link href="{{ url_for('static', filename='css/style.css') }}" rel="stylesheet" media="screen">
+    {% if g.user.get_theme == 1 %}
+       <link href="{{ url_for('static', filename='css/caliBlur-style.css') }}" rel="stylesheet" media="screen">
+    {% endif %}
+  </head>
+  <body>
+    <div class="container text-center">
+        <h1>{{ error_code }}</h1>
+        <h3>{{ error_name }}</h3>
+        <a href="{{url_for('index')}}" title="{{ _('Back to home') }}">{{_('Back to home')}}</a>
+    </div>
+  </body>
+</html>

--- a/cps/web.py
+++ b/cps/web.py
@@ -42,6 +42,8 @@ from flask import (Flask, render_template, request, Response, redirect,
                    abort, Markup)
 from flask import __version__ as flaskVersion
 from werkzeug import __version__ as werkzeugVersion
+from werkzeug.exceptions import default_exceptions
+
 from jinja2 import __version__  as jinja2Version
 import cache_buster
 import ub
@@ -176,6 +178,20 @@ mimetypes.add_type('application/x-cbt', '.cbt')
 mimetypes.add_type('image/vnd.djvu', '.djvu')
 
 app = (Flask(__name__))
+
+
+def error_http(error):
+    return render_template('http_error.html',
+                           error_code=error.code,
+                           error_name=error.name,
+                           instance=config.config_calibre_web_title
+                           ), error.code
+
+
+# http error handling
+for ex in default_exceptions:
+    app.register_error_handler(ex, error_http)
+
 app.wsgi_app = ReverseProxied(app.wsgi_app)
 cache_buster.init_cache_busting(app)
 


### PR DESCRIPTION
Hello,

this PR beutifies the http errors.
Instead of the standard "not found" etc. page we get a nicer one.

@OzzieIsaacs should be localize the error messages too?
Right now the english message comes directly from werkzeug.HTTPException

![cw_404](https://user-images.githubusercontent.com/2580723/46278292-04a41b80-c566-11e8-8f5d-b5bad53e2953.png)
![cw_503](https://user-images.githubusercontent.com/2580723/46278290-04a41b80-c566-11e8-9090-9ae32ac69d9b.png)

