### PR TITLE
295   send azw to kindle

### DIFF
--- a/cps/helper.py
+++ b/cps/helper.py
@@ -185,6 +185,10 @@ def send_mail(book_id, kindle_mail, calibrepath, user_id):
             formats["epub"] = entry.name + ".epub"
         if entry.format == "PDF":
             formats["pdf"] = entry.name + ".pdf"
+        if entry.format == "AZW":
+            formats["azw"] = entry.name + ".azw"
+        if entry.format == "AZW3":
+            formats["azw3"] = entry.name + ".azw3"
 
     if len(formats) == 0:
         return _(u"Could not find any formats suitable for sending by e-mail")
@@ -194,6 +198,12 @@ def send_mail(book_id, kindle_mail, calibrepath, user_id):
     elif 'epub' in formats:
         # returns None if sucess, otherwise errormessage
         return convert_book_format(book_id, calibrepath, u'epub', u'mobi', user_id, kindle_mail)
+    elif 'azw3' in formats:
+        # returns None if sucess, otherwise errormessage
+        return convert_book_format(book_id, calibrepath, u'azw3', u'mobi', user_id, kindle_mail)
+    elif 'azw' in formats:
+        # returns None if sucess, otherwise errormessage
+        return convert_book_format(book_id, calibrepath, u'azw', u'mobi', user_id, kindle_mail)
     elif 'pdf' in formats:
         result = formats['pdf'] # worker.get_attachment()
     else:

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -142,16 +142,16 @@ def chk_send_to_kindle(book_id):
                 formatcount = 0
                 for bookformat in bookformats:
                     if bookformat.lower() in web.EXTENSIONS_CONVERT:
-                        formatcount += 1 
+                        formatcount += 1
                 
-                if formatcount > 0: 
+                if formatcount > 0:
                     return True
                 else:
                     return False
             else:
                 return False
 
-        return False    
+        return False
     else:
         app.logger.error(u'Cannot find book entry %d', book_id)
         return False

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -40,7 +40,7 @@
             </div>
             {% endif %}
           {% endif %}
-            {% if g.user.kindle_mail and g.user.is_authenticated %}
+            {% if g.user.kindle_mail and g.user.is_authenticated and flg_kindle%}
             <a href="{{url_for('send_to_kindle', book_id=entry.id)}}" id="sendbtn" class="btn btn-primary" role="button"><span class="glyphicon glyphicon-send"></span> {{_('Send to Kindle')}}</a>
             {% endif %}
               {% if entry.data|length  %}

--- a/cps/web.py
+++ b/cps/web.py
@@ -1586,9 +1586,11 @@ def show_book(book_id):
 
         entries.tags = sort(entries.tags, key = lambda tag: tag.name)
 
+        flg_send_to_kindle = helper.chk_send_to_kindle(book_id)
+
         return render_title_template('detail.html', entry=entries, cc=cc, is_xhr=request.is_xhr,
                                      title=entries.title, books_shelfs=book_in_shelfs,
-                                     have_read=have_read, page="book")
+                                     have_read=have_read, flg_kindle=flg_send_to_kindle, page="book")
     else:
         flash(_(u"Error opening eBook. File does not exist or file is not accessible:"), category="error")
         return redirect(url_for("index"))
@@ -3846,8 +3848,9 @@ def upload():
                     return render_title_template('book_edit.html', book=book, authors=author_names,
                                                  cc=cc, title=_(u"edit metadata"), page="upload")
                 book_in_shelfs = []
+                flg_send_to_kindle = helper.chk_send_to_kindle(book_id)
                 return render_title_template('detail.html', entry=book, cc=cc,
-                                             title=book.title, books_shelfs=book_in_shelfs, page="upload")
+                                             title=book.title, books_shelfs=book_in_shelfs, flg_kindle=flg_send_to_kindle, page="upload")
     return redirect(url_for("index"))
 
 

--- a/cps/worker.py
+++ b/cps/worker.py
@@ -320,7 +320,7 @@ class WorkerThread(threading.Thread):
             cur_book = web.db.session.query(web.db.Books).filter(web.db.Books.id == bookid).first()
             if os.path.isfile(file_path + format_new_ext):
                 new_format = web.db.Data(name=cur_book.data[0].name,
-                                         book_format=self.queue[self.current]['settings']['new_book_format'],
+                                         book_format=self.queue[self.current]['settings']['new_book_format'].upper(),
                                          book=bookid, uncompressed_size=os.path.getsize(file_path + format_new_ext))
                 cur_book.data.append(new_format)
                 web.db.session.commit()


### PR DESCRIPTION
Here is my interpretation of a fix for #295.

Added a pre-render check to ensure if we should expose the Send to Kindle button.  The check is based on what converter is configured (if any) and what available formats are currently in the system for that book.

Small bug fix to ensure that any new book added to the calibre database has a format field that is all capital letters.  

If a book now has any of the following formats, the system will send a mobi to the kindle:  ePub, azw, azw3.

I don't have any azw files - but I did test this with a book that only has azw3 version and it works.  The assumption I'm making here is that ebook-convert can convert an azw file to mobi.  I couldn't find if it could in the ebook-convert documentation.