### PR TITLE
Shelf - simple only-downloads view

### DIFF
--- a/cps/templates/shelf.html
+++ b/cps/templates/shelf.html
@@ -7,8 +7,7 @@
       {% endif %}
   {% if g.user.is_authenticated %}
     {% if (g.user.role_edit_shelfs() and shelf.is_public ) or not shelf.is_public  %}
-  
- <div id="delete_shelf" data-toggle="modal" data-target="#DeleteShelfDialog" class="btn btn-danger">{{ _('Delete this Shelf') }} </div>
+      <div id="delete_shelf" data-toggle="modal" data-target="#DeleteShelfDialog" class="btn btn-danger">{{ _('Delete this Shelf') }} </div>
       <a id="edit_shelf" href="{{ url_for('edit_shelf', shelf_id=shelf.id) }}" class="btn btn-primary">{{ _('Edit Shelf') }} </a>
       <a id="order_shelf" href="{{ url_for('order_shelf', shelf_id=shelf.id) }}" class="btn btn-primary">{{ _('Change order') }} </a>
     {% endif %}

--- a/cps/templates/shelf.html
+++ b/cps/templates/shelf.html
@@ -2,9 +2,13 @@
 {% block body %}
 <div class="discover">
   <h2>{{title}}</h2>
+  {% if g.user.role_download() %}
+ <a id="shelf_down" href="{{ url_for('show_shelf_down', shelf_id=shelf.id) }}" class="btn btn-primary">{{ _('Download') }} </a>
+      {% endif %}
   {% if g.user.is_authenticated %}
     {% if (g.user.role_edit_shelfs() and shelf.is_public ) or not shelf.is_public  %}
-      <div id="delete_shelf" data-toggle="modal" data-target="#DeleteShelfDialog" class="btn btn-danger">{{ _('Delete this Shelf') }} </div>
+  
+ <div id="delete_shelf" data-toggle="modal" data-target="#DeleteShelfDialog" class="btn btn-danger">{{ _('Delete this Shelf') }} </div>
       <a id="edit_shelf" href="{{ url_for('edit_shelf', shelf_id=shelf.id) }}" class="btn btn-primary">{{ _('Edit Shelf') }} </a>
       <a id="order_shelf" href="{{ url_for('order_shelf', shelf_id=shelf.id) }}" class="btn btn-primary">{{ _('Change order') }} </a>
     {% endif %}

--- a/cps/templates/shelfdown.html
+++ b/cps/templates/shelfdown.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="{{ g.user.locale }}">
+  <head>
+    <title>{{instance}} | {{title}}</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+
+    <!-- Bootstrap -->
+    <link rel="apple-touch-icon" sizes="140x140" href="{{ url_for('static', filename='favicon.ico') }}">
+    <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
+    <link href="{{ url_for('static', filename='css/libs/bootstrap.min.css') }}" rel="stylesheet" media="screen">
+    <link href="{{ url_for('static', filename='css/style.css') }}" rel="stylesheet" media="screen">
+    {% if g.user.get_theme == 1 %}
+       <link href="{{ url_for('static', filename='css/caliBlur-style.css') }}" rel="stylesheet" media="screen">
+    {% endif %}
+    <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
+    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+    <!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+      <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+    <![endif]-->
+
+    {% block header %}{% endblock %}
+  </head>
+  <body class="{{ page }}">
+{% block body %}
+<div class="discover">
+  <h2>{{title}}</h2>
+  <div class="row">
+
+    {% for entry in entries %}
+    <div class="col-sm-3 col-lg-2 col-xs-6 book">
+      
+      <div class="meta">
+        <p class="title">{{entry.title|shortentitle}}</p>
+        <p class="author">
+          {% for author in entry.authors %}
+            <a href="{{url_for('author', book_id=author.id) }}">{{author.name.replace('|',',')}}</a>
+            {% if not loop.last %}
+              &amp;
+            {% endif %}
+          {% endfor %}
+        </p>
+        
+      </div>
+	  
+	  <div class="btn-group" role="group" aria-label="Download, send to Kindle, reading">
+          {% if g.user.role_download() %}
+            {% if entry.data|length %}
+            <div class="btn-group" role="group">
+                {% if entry.data|length < 2 %}
+                  
+                  {% for format in entry.data %}
+                  <a href="{{ url_for('get_download_link_ext', book_id=entry.id, book_format=format.format|lower, anyname=entry.id|string+'.'+format.format|lower) }}" id="btnGroupDrop1{{format.format|lower}}" class="btn btn-primary" role="button">
+                    <span class="glyphicon glyphicon-download"></span>{{format.format}} ({{ format.uncompressed_size|filesizeformat }})
+                  </a>
+                  {% endfor %}
+                {% else %}
+                  <button id="btnGroupDrop1" type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    <span class="glyphicon glyphicon-download"></span> {{_('Download')}}
+                    <span class="caret"></span>
+                  </button>
+                  <ul class="dropdown-menu" aria-labelledby="btnGroupDrop1">
+                  {% for format in entry.data %}
+                    <li><a href="{{ url_for('get_download_link_ext', book_id=entry.id, book_format=format.format|lower, anyname=entry.id|string+'.'+format.format|lower) }}">{{format.format}} ({{ format.uncompressed_size|filesizeformat }})</a></li>
+                  {% endfor %}
+                  </ul>
+                {% endif %}
+            </div>
+            {% endif %}
+          {% endif %}
+       </div>
+    </div>
+    {% endfor %}
+  </div>
+</div>
+
+{% endblock %}
+  </body>
+</html>

--- a/cps/web.py
+++ b/cps/web.py
@@ -2677,7 +2677,6 @@ def show_shelf(shelf_id):
 
 
 @app.route("/shelfdown/<int:shelf_id>")
-@login_required_if_no_ano
 def show_shelf_down(shelf_id):
     if current_user.is_anonymous:
         shelf = ub.session.query(ub.Shelf).filter(ub.Shelf.is_public == 1, ub.Shelf.id == shelf_id).first()


### PR DESCRIPTION
This PR adds a new layout page for a shelf: a very basic simple layout with direct buttons for downloads. This is useful to download selected books of shelves to e-book reader devices (like Kobo) where the standard Calibre menu and scrolling pages with pictures is quite broken.
![shelf-kobo](https://user-images.githubusercontent.com/31888571/46819929-419db880-cd85-11e8-8970-3a40f2d2746c.png)

The new page can be reached via button link 'Download' from the specific shelf's page:
<img width="360" alt="download-shelf" src="https://user-images.githubusercontent.com/31888571/46819917-39457d80-cd85-11e8-960f-8761c22b59b0.png">
