### PR TITLE
Verify if certfile and keyfile are paths to actual files

### DIFF
--- a/cps/server.py
+++ b/cps/server.py
@@ -70,8 +70,8 @@ class server:
                 keyfile_path    = web.ub.config.get_config_keyfile()
                 if certfile_path and keyfile_path:
                     if os.path.isfile(certfile_path) and os.path.isfile(keyfile_path):
-                        ssl_args = {"certfile": certfile_path,
-                                    "keyfile": keyfile_path}
+                        ssl = {"certfile": certfile_path,
+                               "keyfile": keyfile_path}
                     else:
                         web.app.logger.info('The specified paths for the ssl certificate file and/or key file seem to be broken. Ignoring ssl. Cert path: %s | Key path: %s' % (certfile_path, keyfile_path))
                 else:

--- a/cps/server.py
+++ b/cps/server.py
@@ -32,9 +32,14 @@ class server:
     def start_gevent(self):
         try:
             ssl_args = dict()
-            if web.ub.config.get_config_certfile() and web.ub.config.get_config_keyfile():
-                ssl_args = {"certfile": web.ub.config.get_config_certfile(),
-                            "keyfile": web.ub.config.get_config_keyfile()}
+            certfile_path   = web.ub.config.get_config_certfile()
+            keyfile_path    = web.ub.config.get_config_keyfile()
+            if certfile_path and keyfile_path:
+                if os.path.isfile(certfile_path) and os.path.isfile(keyfile_path):
+                    ssl_args = {"certfile": certfile_path,
+                                "keyfile": keyfile_path}
+                else:
+                    web.app.logger.info('The specified paths for the ssl certificate file and/or key file seem to be broken. Ignoring ssl. Cert path: %s | Key path: %s' % (certfile_path, keyfile_path))
             if os.name == 'nt':
                 self.wsgiserver= WSGIServer(('0.0.0.0', web.ub.config.config_port), web.app, spawn=Pool(), **ssl_args)
             else:
@@ -61,9 +66,14 @@ class server:
         else:
             try:
                 web.app.logger.info('Starting Tornado server')
-                if web.ub.config.get_config_certfile() and web.ub.config.get_config_keyfile():
-                    ssl={"certfile": web.ub.config.get_config_certfile(),
-                         "keyfile": web.ub.config.get_config_keyfile()}
+                certfile_path   = web.ub.config.get_config_certfile()
+                keyfile_path    = web.ub.config.get_config_keyfile()
+                if certfile_path and keyfile_path:
+                    if os.path.isfile(certfile_path) and os.path.isfile(keyfile_path):
+                        ssl_args = {"certfile": certfile_path,
+                                    "keyfile": keyfile_path}
+                    else:
+                        web.app.logger.info('The specified paths for the ssl certificate file and/or key file seem to be broken. Ignoring ssl. Cert path: %s | Key path: %s' % (certfile_path, keyfile_path))
                 else:
                     ssl=None
                 # Max Buffersize set to 200MB


### PR DESCRIPTION
I was running calibre on a docker container, and i tried to set up SSL just as an experiment. I later decided to not use SSL on the container and having it on the web server. I removed the certificate and key files from the container, expecting the app would fallback to not use SSL. That didn't happen, it crashed, and since it crashed, i could not easily update the settings from the GUI.

I guess the solution was to enter the database and removed manually from there, but i think a user should not be expected to fix the problem that way. My solution was to simply delete the configuration database, which did work, but was far from ideal.

Falling back to not use SSL if the paths are broken seems a sensible approach to me. Maybe further verification of the files should be done, but i think this is a good start.

Commit message:

> This allow to try to not use ssl if the key file path or the certificate file are broken. The files might be missing because the user intentionally removed them but didn't update the settings first. In that situation, this change won't make the app crash, the warning is logged and that way the user has the chance to update the settings.