### PR TITLE
A better solution to #681

### DIFF
--- a/cps/web.py
+++ b/cps/web.py
@@ -197,12 +197,7 @@ def get_locale():
         if user.nickname != 'Guest':   # if the account is the guest account bypass the config lang settings
             return user.locale
     translations = [item.language for item in babel.list_translations()] + ['en']
-    preferred = [x.replace('-', '_') for x in request.accept_languages.values()]
-
-    # In the case of Simplified Chinese, Accept-Language is "zh-CN", while our translation of Simplified Chinese is "zh_Hans_CN".
-    # TODO: This is Not a good solution, should be improved.
-    if "zh_CN" in preferred:
-        return "zh_Hans_CN"
+    preferred = [str(LC.parse(x, '-')) for x in request.accept_languages.values()]
     return negotiate_locale(preferred, translations)
 
 


### PR DESCRIPTION
Babel supports likely subtags (see [here](http://babel.pocoo.org/en/latest/locale.html#likely-subtags)).
We just need to process Accept-Language values using Locale.parse().