### PR TITLE
Deal gracefully with invalid Accept-Languages header

### DIFF
--- a/cps/web.py
+++ b/cps/web.py
@@ -194,7 +194,11 @@ def get_locale():
         if user.nickname != 'Guest':   # if the account is the guest account bypass the config lang settings
             return user.locale
     translations = [str(item) for item in babel.list_translations()] + ['en']
-    preferred = [str(LC.parse(x.replace('-','_').replace('*','en'))) for x in request.accept_languages.values()]
+    try:
+        preferred = [str(LC.parse(x.replace('-','_').replace('*','en'))) for x in request.accept_languages.values()]
+    except (UnknownLocaleError, ValueError) as e:
+        app.logger.debug("Could not parse locale:", e)
+        preferred = ['en']
     return negotiate_locale(preferred, translations)
 
 


### PR DESCRIPTION
At the moment, calibre-web will raise an internal 500 error if an invalid locale identifier is passed in through the `Accept-Language` HTTP header (for a non-logged-in user).

This breaks some crappily-built OPDS feed readers, and there's no reason to error out so severely. This commit just gracefully falls back to `en` if it can't parse the locale identifier.

Fixes #743 among others.