### PR TITLE
Explain difference between Docker images

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -113,8 +113,8 @@ Additionally the public adress your server uses (e.g.https://example.com) has to
 Pre-built Docker images based on Alpine Linux are available in these Docker Hub repositories:
 
 **x64**
-+ **technosoft2000** at [technosoft2000/calibre-web](https://hub.docker.com/r/technosoft2000/calibre-web/)
-+ **linuxserver.io** at [linuxserver/calibre-web](https://hub.docker.com/r/linuxserver/calibre-web/)
++ **technosoft2000** at [technosoft2000/calibre-web](https://hub.docker.com/r/technosoft2000/calibre-web/). If you want the option to convert/download ebooks in multiple formats, use this image as it includes Calibre's ebook-convert binary. The "path to convertertool" should be set to /opt/calibre/ebook-convert.
++ **linuxserver.io** at [linuxserver/calibre-web](https://hub.docker.com/r/linuxserver/calibre-web/). Cannot convert between ebook formats.
 
 **armhf**
 + **linuxserver.io** at [lsioarmhf/calibre-web](https://hub.docker.com/r/lsioarmhf/calibre-web/)


### PR DESCRIPTION
Updated the readme to explain their differences. Namely that technosoft's can convert while lsio's can't.

linuxserver.io's image is much more popular so it's important to point out that people are losing functionality by using it. 