### PR TITLE
Remove leading space in span

### DIFF
--- a/cps/static/js/caliBlur.js
+++ b/cps/static/js/caliBlur.js
@@ -220,8 +220,8 @@ publisher = $( '.publishers p span' ).text().split( ':' );
   $.each(publisher, function(i, val) {
     $( '.publishers' ).append( '<span>' + publisher[i] + '</span>' );
   });
-$( '.publishers span:nth-child(2)' ).text(function() {
-return $(this).text().replace(/^\s+/g, "");
+$( '.publishers span:nth-child(3)' ).text(function() {
+return $(this).text().replace(/^\s+|^\t+|\t+|\s+$/g, "");
 });
 
   published = $( '.book-meta p:contains("Publishing date")' )


### PR DESCRIPTION
Previous code was not targeting right element, additionally was only removing a single leading space. New regex will remove any leading spaces from span