### PR TITLE
Update ID of button from sendbtn2 to sendbtn

### DIFF
--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -45,7 +45,7 @@
                 <a href="{{url_for('send_to_kindle', book_id=entry.id, book_format=kindle_list[0]['format'], convert=kindle_list[0]['convert'])}}" id="sendbtn" class="btn btn-primary" role="button"><span class="glyphicon glyphicon-send"></span> {{kindle_list[0]['text']}}</a>
               {% else %}
                 <div class="btn-group" role="group">
-                  <button id="sendbtn2" type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                  <button id="sendbtn" type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     <span class="glyphicon glyphicon-send"></span>{{_('Send to Kindle')}}
                     <span class="caret"></span>
                   </button>


### PR DESCRIPTION
The ID of this button is currently `sendbtn` if the condition is true, but `sendbtn2` when false. Propose renaming both to `sendbtn` as neither button will render on screen at the same time. This will assist in caliBlur more easily targeting both states, rather than individually targeting the same button twice