### PR TITLE
Force namespace resolution of imports

### DIFF
--- a/cps/web.py
+++ b/cps/web.py
@@ -40,7 +40,7 @@ import json
 import datetime
 from iso639 import languages as isoLanguages
 import re
-import db
+from cps import db
 import gdriveutils
 from redirect import redirect_back
 from cps import lm, babel, ub, config, get_locale, language_table, app


### PR DESCRIPTION
The current import for some local modules causes errors when those already exist in site-packages on the target system.
Namely "import db" is ambiguous and may cause errors due to loading of the 'db' PyPI package instead of the module.