### PR TITLE
Shorten the display of authors if there are too many

### DIFF
--- a/cps/static/css/style.css
+++ b/cps/static/css/style.css
@@ -36,6 +36,11 @@ a{color: #45b29d}a:hover{color: #444;}
 .container-fluid .book .meta .title{font-weight:bold;font-size:15px;color:#444}
 .container-fluid .book .meta .author{font-size:12px;color:#999}
 .container-fluid .book .meta .rating{margin-top:5px}.rating .glyphicon-star{color:#999}.rating .glyphicon-star.good{color:#45b29d}
+
+.container-fluid .author .author-hidden, .container-fluid .author .author-hidden-divider {
+  display: none;
+}
+
 .navbar-brand{font-family: 'Grand Hotel', cursive; font-size: 35px; color: #45b29d !important;}
 .more-stuff{margin-top: 20px; padding-top: 20px; border-top: 1px solid #ccc}
 .more-stuff>li{margin-bottom: 10px;}
@@ -52,6 +57,7 @@ span.glyphicon.glyphicon-tags {padding-right: 5px;color: #999;vertical-align: te
     -moz-box-shadow: 0 5px 8px -6px #777;
     box-shadow: 0 5px 8px -6px #777;
 }
+
 .navbar-default .navbar-toggle .icon-bar {background-color: #000;}
 .navbar-default .navbar-toggle {border-color: #000;}
 .cover { margin-bottom: 10px;}

--- a/cps/static/js/main.js
+++ b/cps/static/js/main.js
@@ -205,11 +205,11 @@ $(function() {
         $(".discover .row").isotope("layout");
     });
 	
-	$(".author-expand").click(function() {
-		$(this).parent().find('a.author-name').slice($(this).data("authors-max")).toggle();
-		$(this).parent().find('span.author-hidden-divider').toggle();
-		$(this).html()==$(this).data("collapse-caption")? $(this).html('(...)'):$(this).html($(this).data("collapse-caption"));
-		$(".discover .row").isotope("layout");
-	});
+    $(".author-expand").click(function() {
+        $(this).parent().find("a.author-name").slice($(this).data("authors-max")).toggle();
+        $(this).parent().find("span.author-hidden-divider").toggle();
+        $(this).html()===$(this).data("collapse-caption") ? $(this).html("(...)") : $(this).html($(this).data("collapse-caption"));
+        $(".discover .row").isotope("layout");
+    });
 	
 });

--- a/cps/static/js/main.js
+++ b/cps/static/js/main.js
@@ -208,7 +208,7 @@ $(function() {
     $(".author-expand").click(function() {
         $(this).parent().find("a.author-name").slice($(this).data("authors-max")).toggle();
         $(this).parent().find("span.author-hidden-divider").toggle();
-        $(this).html()===$(this).data("collapse-caption") ? $(this).html("(...)") : $(this).html($(this).data("collapse-caption"));
+        $(this).html() === $(this).data("collapse-caption") ? $(this).html("(...)") : $(this).html($(this).data("collapse-caption"));
         $(".discover .row").isotope("layout");
     });
 	

--- a/cps/static/js/main.js
+++ b/cps/static/js/main.js
@@ -204,4 +204,12 @@ $(function() {
     $(window).resize(function() {
         $(".discover .row").isotope("layout");
     });
+	
+	$(".author-expand").click(function() {
+		$(this).parent().find('a.author-name').slice($(this).data("authors-max")).toggle();
+		$(this).parent().find('span.author-hidden-divider').toggle();
+		$(this).html()==$(this).data("collapse-caption")? $(this).html('(...)'):$(this).html($(this).data("collapse-caption"));
+		$(".discover .row").isotope("layout");
+	});
+	
 });

--- a/cps/templates/author.html
+++ b/cps/templates/author.html
@@ -41,10 +41,20 @@
         </a>
         <p class="author">
           {% for author in entry.authors %}
-          <a href="{{url_for('author', book_id=author.id) }}">{{author.name.replace('|',',')}}</a>
-          {% if not loop.last %}
-          &amp;
-          {% endif %}
+            {% if loop.index > config_authors_max and config_authors_max != 0 %}
+              {% if not loop.first %}
+                <span class="author-hidden-divider">&amp;</span>
+			  {% endif %}
+              <a class="author-name author-hidden" href="{{url_for('author', book_id=author.id) }}">{{author.name.replace('|',',')|shortentitle(30)}}</a>
+              {% if loop.last %}
+                <a href="#" class="author-expand" data-authors-max="{{config_authors_max}}" data-collapse-caption="({{_('reduce')}})">(...)</a>
+              {% endif %}
+            {% else %}
+              {% if not loop.first %}
+                <span>&amp;</span>
+              {% endif %}
+              <a class="author-name" href="{{url_for('author', book_id=author.id) }}">{{author.name.replace('|',',')|shortentitle(30)}}</a>
+            {% endif %}
           {% endfor %}
         </p>
         {% if entry.ratings.__len__() > 0 %}
@@ -80,13 +90,15 @@
       <div class="meta">
         <p class="title">{{entry.title|shortentitle}}</p>
         <p class="author">
-          {% for author in entry.authors %}
-          <a href="https://www.goodreads.com/author/show/{{ author.gid }}" target="_blank" rel="noopener">
-            {{author.name.replace('|',',')}}
-          </a>
-          {% if not loop.last %}
-          &amp;
-          {% endif %}
+		  {% for author in entry.authors %}
+			{% if loop.index > config_authors_max and config_authors_max != 0 %}
+				<a class="author-name author-hidden" href="https://www.goodreads.com/author/show/{{ author.gid }}" target="_blank" rel="noopener">{{author.name.replace('|',',')}}</a>
+				{% if loop.last %}
+					<a href="#" class="author-expand" data-authors-max="{{config_authors_max}}" data-collapse-caption="({{_('reduce')}})">(...)</a>
+				{% endif %}
+			{% else %}
+				<a class="author-name" href="https://www.goodreads.com/author/show/{{ author.gid }}" target="_blank" rel="noopener">{{author.name.replace('|',',')}}</a>
+		    {% endif %}
           {% endfor %}
         </p>
         <div class="rating">

--- a/cps/templates/config_view_edit.html
+++ b/cps/templates/config_view_edit.html
@@ -28,6 +28,10 @@
           <input type="number" min="1" max="30" class="form-control" name="config_random_books" id="config_random_books" value="{% if content.config_random_books != None %}{{ content.config_random_books }}{% endif %}" autocomplete="off">
         </div>
         <div class="form-group">
+          <label for="config_authors_max">{{_('No. of authors to show before hiding (0=disable hiding)')}}</label>
+          <input type="number" min="0" max="999" class="form-control" name="config_authors_max" id="config_authors_max" value="{% if content.config_authors_max != None %}{{ content.config_authors_max }}{% endif %}" autocomplete="off">
+        </div>
+        <div class="form-group">
         <label for="config_theme">{{_('Theme')}}</label>
             <select name="config_theme" id="config_theme" class="form-control">
                 <option value="0" {% if content.config_theme == 0 %}selected{% endif %}>{{ _("Standard Theme") }}</option>

--- a/cps/templates/discover.html
+++ b/cps/templates/discover.html
@@ -19,9 +19,19 @@
         </a>
         <p class="author">
           {% for author in entry.authors %}
-            <a href="{{url_for('author', book_id=author.id) }}">{{author.name.replace('|',',')|shortentitle(30)}}</a>
-            {% if not loop.last %}
-              &amp;
+            {% if loop.index > config_authors_max and config_authors_max != 0 %}
+              {% if not loop.first %}
+                <span class="author-hidden-divider">&amp;</span>
+			  {% endif %}
+              <a class="author-name author-hidden" href="{{url_for('author', book_id=author.id) }}">{{author.name.replace('|',',')|shortentitle(30)}}</a>
+              {% if loop.last %}
+                <a href="#" class="author-expand" data-authors-max="{{config_authors_max}}" data-collapse-caption="({{_('reduce')}})">(...)</a>
+              {% endif %}
+            {% else %}
+              {% if not loop.first %}
+                <span>&amp;</span>
+              {% endif %}
+              <a class="author-name" href="{{url_for('author', book_id=author.id) }}">{{author.name.replace('|',',')|shortentitle(30)}}</a>
             {% endif %}
           {% endfor %}
         </p>

--- a/cps/templates/index.html
+++ b/cps/templates/index.html
@@ -22,9 +22,19 @@
         </a>
         <p class="author">
           {% for author in entry.authors %}
-            <a href="{{url_for('author', book_id=author.id) }}">{{author.name.replace('|',',')|shortentitle(30)}}</a>
-            {% if not loop.last %}
-              &amp;
+            {% if loop.index > config_authors_max and config_authors_max != 0 %}
+              {% if not loop.first %}
+                <span class="author-hidden-divider">&amp;</span>
+			  {% endif %}
+              <a class="author-name author-hidden" href="{{url_for('author', book_id=author.id) }}">{{author.name.replace('|',',')|shortentitle(30)}}</a>
+              {% if loop.last %}
+                <a href="#" class="author-expand" data-authors-max="{{config_authors_max}}" data-collapse-caption="({{_('reduce')}})">(...)</a>
+              {% endif %}
+            {% else %}
+              {% if not loop.first %}
+                <span>&amp;</span>
+              {% endif %}
+              <a class="author-name" href="{{url_for('author', book_id=author.id) }}">{{author.name.replace('|',',')|shortentitle(30)}}</a>
             {% endif %}
           {% endfor %}
         </p>
@@ -67,9 +77,19 @@
         </a>
         <p class="author">
           {% for author in entry.authors %}
-            <a href="{{url_for('author', book_id=author.id) }}">{{author.name.replace('|',',')|shortentitle(30)}}</a>
-            {% if not loop.last %}
-              &amp;
+            {% if loop.index > config_authors_max and config_authors_max != 0 %}
+              {% if not loop.first %}
+                <span class="author-hidden-divider">&amp;</span>
+			  {% endif %}
+              <a class="author-name author-hidden" href="{{url_for('author', book_id=author.id) }}">{{author.name.replace('|',',')|shortentitle(30)}}</a>
+              {% if loop.last %}
+                <a href="#" class="author-expand" data-authors-max="{{config_authors_max}}" data-collapse-caption="({{_('reduce')}})">(...)</a>
+              {% endif %}
+            {% else %}
+              {% if not loop.first %}
+                <span>&amp;</span>
+              {% endif %}
+              <a class="author-name" href="{{url_for('author', book_id=author.id) }}">{{author.name.replace('|',',')|shortentitle(30)}}</a>
             {% endif %}
           {% endfor %}
         </p>

--- a/cps/templates/search.html
+++ b/cps/templates/search.html
@@ -46,9 +46,19 @@
         </a>
         <p class="author">
           {% for author in entry.authors %}
-            <a href="{{url_for('author', book_id=author.id ) }}">{{author.name.replace('|',',')}}</a>
-            {% if not loop.last %}
-              &amp;
+            {% if loop.index > config_authors_max and config_authors_max != 0 %}
+              {% if not loop.first %}
+                <span class="author-hidden-divider">&amp;</span>
+			  {% endif %}
+              <a class="author-name author-hidden" href="{{url_for('author', book_id=author.id) }}">{{author.name.replace('|',',')|shortentitle(30)}}</a>
+              {% if loop.last %}
+                <a href="#" class="author-expand" data-authors-max="{{config_authors_max}}" data-collapse-caption="({{_('reduce')}})">(...)</a>
+              {% endif %}
+            {% else %}
+              {% if not loop.first %}
+                <span>&amp;</span>
+              {% endif %}
+              <a class="author-name" href="{{url_for('author', book_id=author.id) }}">{{author.name.replace('|',',')|shortentitle(30)}}</a>
             {% endif %}
           {% endfor %}
         </p>

--- a/cps/templates/shelf.html
+++ b/cps/templates/shelf.html
@@ -28,9 +28,19 @@
         </a>
         <p class="author">
           {% for author in entry.authors %}
-            <a href="{{url_for('author', book_id=author.id) }}">{{author.name.replace('|',',')}}</a>
-            {% if not loop.last %}
-              &amp;
+            {% if loop.index > config_authors_max and config_authors_max != 0 %}
+              {% if not loop.first %}
+                <span class="author-hidden-divider">&amp;</span>
+			  {% endif %}
+              <a class="author-name author-hidden" href="{{url_for('author', book_id=author.id) }}">{{author.name.replace('|',',')|shortentitle(30)}}</a>
+              {% if loop.last %}
+                <a href="#" class="author-expand" data-authors-max="{{config_authors_max}}" data-collapse-caption="({{_('reduce')}})">(...)</a>
+              {% endif %}
+            {% else %}
+              {% if not loop.first %}
+                <span>&amp;</span>
+              {% endif %}
+              <a class="author-name" href="{{url_for('author', book_id=author.id) }}">{{author.name.replace('|',',')|shortentitle(30)}}</a>
             {% endif %}
           {% endfor %}
         </p>

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -315,6 +315,7 @@ class Settings(Base):
     config_calibre_web_title = Column(String, default=u'Calibre-Web')
     config_books_per_page = Column(Integer, default=60)
     config_random_books = Column(Integer, default=4)
+    config_authors_max = Column(Integer, default=5)
     config_read_column = Column(Integer, default=0)
     config_title_regex = Column(String, default=u'^(A|The|An|Der|Die|Das|Den|Ein|Eine|Einen|Dem|Des|Einem|Eines)\s+')
     config_log_level = Column(SmallInteger, default=logging.INFO)
@@ -380,6 +381,7 @@ class Config:
         self.config_calibre_web_title = data.config_calibre_web_title
         self.config_books_per_page = data.config_books_per_page
         self.config_random_books = data.config_random_books
+        self.config_authors_max = data.config_authors_max
         self.config_title_regex = data.config_title_regex
         self.config_read_column = data.config_read_column
         self.config_log_level = data.config_log_level
@@ -600,6 +602,12 @@ def migrate_Database():
     except exc.OperationalError:  # Database is not compatible, some rows are missing
         conn = engine.connect()
         conn.execute("ALTER TABLE Settings ADD column `config_default_role` SmallInteger DEFAULT 0")
+        session.commit()
+    try:
+        session.query(exists().where(Settings.config_authors_max)).scalar()
+    except exc.OperationalError:  # Database is not compatible, some rows are missing
+        conn = engine.connect()
+        conn.execute("ALTER TABLE Settings ADD column `config_authors_max` INTEGER DEFAULT 5")
         session.commit()
     try:
         session.query(exists().where(BookShelf.order)).scalar()

--- a/cps/web.py
+++ b/cps/web.py
@@ -1207,7 +1207,7 @@ def get_updater_status():
 def index(page):
     entries, random, pagination = fill_indexpage(page, db.Books, True, [db.Books.timestamp.desc()])
     return render_title_template('index.html', random=random, entries=entries, pagination=pagination,
-                                 title=_(u"Recently Added Books"), page="root")
+                                 title=_(u"Recently Added Books"), page="root", config_authors_max=config.config_authors_max)
 
 
 @app.route('/books/newest', defaults={'page': 1})
@@ -1351,7 +1351,8 @@ def author(book_id, page):
             app.logger.error('Goodreads website is down/inaccessible')
 
     return render_title_template('author.html', entries=entries, pagination=pagination,
-                                 title=name, author=author_info, other_books=other_books, page="author")
+                                 title=name, author=author_info, other_books=other_books, page="author",
+                                 config_authors_max=config.config_authors_max)
 
 
 @app.route("/publisher")
@@ -2817,6 +2818,9 @@ def view_configuration():
             content.config_random_books = int(to_save["config_random_books"])
         if "config_books_per_page" in to_save:
             content.config_books_per_page = int(to_save["config_books_per_page"])
+        # maximum authors to show before we display a 'show more' link
+        if "config_authors_max" in to_save:
+            content.config_authors_max = int(to_save["config_authors_max"])
         # Mature Content configuration
         if "config_mature_content_tags" in to_save:
             content.config_mature_content_tags = to_save["config_mature_content_tags"].strip()


### PR DESCRIPTION
Hi there,

I've added a book to calibre-web which has many authors.
While this works technically perfect, it will "break" the layout.

![Before PR](https://user-images.githubusercontent.com/2580723/53359756-1d0d3c00-3934-11e9-9540-f324cdc922b8.png)

This PR introduces a function to calibre-web which shortens the display of authors if there are too many.
The default is set to 5 authors.

![Reducing in action](https://user-images.githubusercontent.com/2580723/53359917-7c6b4c00-3934-11e9-9b86-f3874a9e54f6.png)

By clicking on the 3 dots the whole list with authors will expand. Clicking on "reduce" the list will be reduced again.

The behavior can be modified in "UI configuration":

![UI configuration](https://user-images.githubusercontent.com/2580723/53359955-99a01a80-3934-11e9-87d4-21b978003980.png)

Setting the value to 0 will deactivate the "reducing" which results in the same behavior like calibre-web is acting now.