### PR TITLE
[fix] add a scroll bar to a long list of meta information

### DIFF
--- a/cps/static/css/style.css
+++ b/cps/static/css/style.css
@@ -103,6 +103,10 @@ input.pill:not(:checked) + label .glyphicon {
 
 .tags_click, .serie_click, .language_click {margin-right: 5px;}
 
+#meta-info {
+    height:600px;
+    overflow:scroll;
+}
 #meta-info img { max-height: 150px; max-width: 100px; cursor: pointer; }
 
 .padded-bottom { margin-bottom: 15px; }


### PR DESCRIPTION
When the meta-information list is long, it will exceed the screen. I fixed it
