### PR TITLE
support pycountry if iso-639 is not available

### DIFF
--- a/cps/epub.py
+++ b/cps/epub.py
@@ -21,7 +21,7 @@ import zipfile
 from lxml import etree
 import os
 import uploader
-from iso639 import languages as isoLanguages
+import isoLanguages
 
 
 def extractCover(zipFile, coverFile, coverpath, tmp_file_name):

--- a/cps/isoLanguages.py
+++ b/cps/isoLanguages.py
@@ -11,7 +11,7 @@ except ImportError:
         import pkg_resources
         __version__ = pkg_resources.get_distribution('pycountry').version + ' (PyCountry)'
         del pkg_resources
-    except:
+    except (ImportError, Exception):
         __version__ = "? (PyCountry)"
 
     def _copy_fields(l):

--- a/cps/isoLanguages.py
+++ b/cps/isoLanguages.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+try:
+    from iso639 import languages, __version__
+    get = languages.get
+except ImportError:
+    from pycountry import languages as pyc_languages
+    try:
+        import pkg_resources
+        __version__ = pkg_resources.get_distribution('pycountry').version + ' (PyCountry)'
+        del pkg_resources
+    except:
+        __version__ = "? (PyCountry)"
+
+    def _copy_fields(l):
+        l.part1 = l.alpha_2
+        l.part3 = l.alpha_3
+        return l
+
+    def get(name=None, part1=None, part3=None):
+        if (part3 is not None):
+            return _copy_fields(pyc_languages.get(alpha_3=part3))
+        if (part1 is not None):
+            return _copy_fields(pyc_languages.get(alpha_2=part1))
+        if (name is not None):
+            return _copy_fields(pyc_languages.get(name=name))

--- a/cps/web.py
+++ b/cps/web.py
@@ -61,8 +61,7 @@ import base64
 from sqlalchemy.sql import *
 import json
 import datetime
-from iso639 import languages as isoLanguages
-from iso639 import __version__ as iso639Version
+import isoLanguages
 from pytz import __version__ as pytzVersion
 from uuid import uuid4
 import os.path
@@ -1657,7 +1656,7 @@ def stats():
     versions['Flask'] = 'v' + flaskVersion
     versions['Flask Login'] = 'v' + flask_loginVersion
     versions['Flask Principal'] = 'v' + flask_principalVersion
-    versions['Iso 639'] = 'v' + iso639Version
+    versions['Iso 639'] = 'v' + isoLanguages.__version__
     versions['pytz'] = 'v' + pytzVersion
 
     versions['Requests'] = 'v' + requests.__version__


### PR DESCRIPTION
Some Linux distributions do not provide iso-639 as a system package (Debian at least).
This patch uses pycountry as a fallback, is iso639 cannot be imported, making it easier to run calibre-web without the use of pip.