### PR TITLE
Use HTTP_X_FORWARDED_HOST instead of HTTP_X_FORWARDED_SERVER

### DIFF
--- a/cps/reverseproxy.py
+++ b/cps/reverseproxy.py
@@ -49,7 +49,7 @@ class ReverseProxied(object):
         scheme = environ.get('HTTP_X_SCHEME', '')
         if scheme:
             environ['wsgi.url_scheme'] = scheme
-        servr = environ.get('HTTP_X_FORWARDED_SERVER', '')
+        servr = environ.get('HTTP_X_FORWARDED_HOST', '')
         if servr:
             environ['HTTP_HOST'] = servr
         return self.app(environ, start_response)


### PR DESCRIPTION
Use HTTP_X_FORWARDED_HOST since HTTP_X_FORWARDED_SERVER holds the hostname of the proxy server on HAProxy/Traefik.

This causes problems on redirects for users of these systems. See https://httpd.apache.org/docs/2.4/mod/mod_proxy.html for more details about this.