### PR TITLE
Use comicapi to enable basic metadata reading for CBZ/CBT files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,3 @@ gdrive_credentials
 
 vendor
 client_secrets.json
-
-# External dependencies - need proper integrating
-libunrar

--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,4 @@ vendor
 client_secrets.json
 
 # External dependencies - need proper integrating
-comicapi
 libunrar

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ gdrive_credentials
 
 vendor
 client_secrets.json
+
+# External dependencies - need proper integrating
+comicapi
+libunrar

--- a/cps/comic.py
+++ b/cps/comic.py
@@ -19,8 +19,7 @@
 
 import os
 import uploader
-from comicapi.comicarchive import *
-from comicapi.issuestring import *
+from comicapi.comicarchive import ComicArchive, MetaDataStyle
 from iso639 import languages as isoLanguages
 
 def extractCover(tmp_file_name, original_file_extension):
@@ -31,7 +30,6 @@ def extractCover(tmp_file_name, original_file_extension):
         extension = ext[1].lower()
         if extension == '.jpg' or extension == '.jpeg':
             cover_data = archive.getPage(0)
-    print(archive.getPageName(0))
     prefix = os.path.dirname(tmp_file_name)
     if cover_data:
         tmp_cover_name = prefix + '/cover' + extension

--- a/cps/comic.py
+++ b/cps/comic.py
@@ -17,33 +17,21 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import zipfile
-import tarfile
 import os
 import uploader
-
+from comicapi.comicarchive import *
+from comicapi.issuestring import *
+from iso639 import languages as isoLanguages
 
 def extractCover(tmp_file_name, original_file_extension):
+    archive = ComicArchive(tmp_file_name)
     cover_data = None
-    if original_file_extension.upper() == '.CBZ':
-        cf = zipfile.ZipFile(tmp_file_name)
-        for name in cf.namelist():
-            ext = os.path.splitext(name)
-            if len(ext) > 1:
-                extension = ext[1].lower()
-                if extension == '.jpg':
-                    cover_data = cf.read(name)
-                    break
-    elif original_file_extension.upper() == '.CBT':
-        cf = tarfile.TarFile(tmp_file_name)
-        for name in cf.getnames():
-            ext = os.path.splitext(name)
-            if len(ext) > 1:
-                extension = ext[1].lower()
-                if extension == '.jpg':
-                    cover_data = cf.extractfile(name).read()
-                    break
-
+    ext = os.path.splitext(archive.getPageName(0))
+    if len(ext) > 1:
+        extension = ext[1].lower()
+        if extension == '.jpg' or extension == '.jpeg':
+            cover_data = archive.getPage(0)
+    print(archive.getPageName(0))
     prefix = os.path.dirname(tmp_file_name)
     if cover_data:
         tmp_cover_name = prefix + '/cover' + extension
@@ -56,17 +44,34 @@ def extractCover(tmp_file_name, original_file_extension):
 
 
 def get_comic_info(tmp_file_path, original_file_name, original_file_extension):
+    archive = ComicArchive(tmp_file_path)
+    if archive.seemsToBeAComicArchive():
+        if archive.hasMetadata(MetaDataStyle.CIX):
+            style = MetaDataStyle.CIX
+        elif archive.hasMetadata(MetaDataStyle.CBI):
+            style = MetaDataStyle.CBI
+        else:
+            style = None
 
-    coverfile = extractCover(tmp_file_path, original_file_extension)
+        if style is not None:
+            loadedMetadata = archive.readMetadata(style)
+
+    lang = loadedMetadata.language
+    if len(lang) == 2:
+         loadedMetadata.language = isoLanguages.get(part1=lang).name
+    elif len(lang) == 3:
+         loadedMetadata.language = isoLanguages.get(part3=lang).name
+    else:
+         loadedMetadata.language = ""
 
     return uploader.BookMeta(
             file_path=tmp_file_path,
             extension=original_file_extension,
-            title=original_file_name,
-            author=u"Unknown",
-            cover=coverfile,
-            description="",
+            title=loadedMetadata.title or original_file_name,
+            author=" & ".join([credit["person"] for credit in loadedMetadata.credits if credit["role"] == "Writer"]) or u"Unknown",
+            cover=extractCover(tmp_file_path, original_file_extension),
+            description=loadedMetadata.comments or "",
             tags="",
-            series="",
-            series_id="",
-            languages="")
+            series=loadedMetadata.series or "",
+            series_id=loadedMetadata.issue or "",
+            languages=loadedMetadata.language)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ SQLAlchemy>=1.1.0
 tornado>=4.1
 Wand>=0.4.4
 unidecode>=0.04.19
-git+https://github.com/wildthyme/comicapi.git@c57bda958e56cf1ae23bec1cde974b4c424b2eb4#egg=comicapi
+git+https://github.com/wildthyme/comicapi.git@0f36fdd81bd03d6a979bebf03f907a1405d992c4#egg=comicapi

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ SQLAlchemy>=1.1.0
 tornado>=4.1
 Wand>=0.4.4
 unidecode>=0.04.19
-git+https://github.com/wildthyme/comicapi.git@0f36fdd81bd03d6a979bebf03f907a1405d992c4#egg=comicapi
+git+https://github.com/wildthyme/comicapi.git@cb279168f9c5cec742b5a05ac8326b9c168a8a91#egg=comicapi

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ SQLAlchemy>=1.1.0
 tornado>=4.1
 Wand>=0.4.4
 unidecode>=0.04.19
+git+https://github.com/wildthyme/comicapi.git@c57bda958e56cf1ae23bec1cde974b4c424b2eb4#egg=comicapi


### PR DESCRIPTION
Basic metadata (title/author/cover-if-jpg/etc.) is now extracted from comics if it's in a format comictagger supports. CBR's are still disabled, mainly because libunrar is a hassle and a half.