### PR TITLE
1-Line Fix for "Internal Server Error" on advanced search

### DIFF
--- a/cps/web.py
+++ b/cps/web.py
@@ -2025,7 +2025,6 @@ def advanced_search():
             custom_query = request.args.get('custom_column_' + str(c.id))
             if custom_query:
                 if c.datatype == 'bool':
-                    getattr(db.Books, 'custom_column_1')
                     q = q.filter(getattr(db.Books, 'custom_column_'+str(c.id)).any(
                         db.cc_classes[c.id].value == (custom_query== "True") ))
                 elif c.datatype == 'int':


### PR DESCRIPTION
While searching Custom boolean columns in advanced search an "Internal Server Error" is returned if calibre does not have a custom_column_1 in the DB.
The line causing the error appears to be side-effect free, so the bug is fixed by removing it.

Traceback of original Error:
```
[2019-05-05 18:03:03,597] ERROR in app: Exception on /advanced_search [GET]
Traceback (most recent call last):

  File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/pi/servers/calibre-web/cps/web.py", line 348, in decorated_view
    return func(*args, **kwargs)
  File "/home/pi/servers/calibre-web/cps/web.py", line 2028, in advanced_search
    getattr(db.Books, 'custom_column_1')
AttributeError: type object 'Books' has no attribute 'custom_column_1'
ERROR:tornado.access:500 GET /advanced_search?book_title=&author_name=&publisher=&Publishstart=&Publishend=&ratinghigh=&ratinglow=&comment=&custom_column_3=&custom_column_4=&custom_column_6=&custom_column_7=&custom_column_8=&custom_column_10=&custom_column_11=&custom_column_16=&custom_column_17=&custom_column_21=True&custom_column_23= (127.0.0.1) 44.38ms
```