### PR TITLE
Add initial setuptools integration

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include cps/static/*
+include cps/templates/*
+include cps/translations/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,62 @@
+[bdist_wheel]
+universal = 1
+
+[metadata]
+name = calibre-web
+url = https://github.com/janeczku/calibre-web
+project_urls =
+  Bug Tracker = https://github.com/janeczku/calibre-web/issues
+  Release Management = https://github.com/janeczku/calibre-web/releases
+  Documentation = https://github.com/janeczku/calibre-web/wiki
+  Source Code = https://github.com/janeczku/calibre-web
+description = Web app for browsing, reading and downloading eBooks stored in a Calibre database.
+long_description = file: README.md
+author = @janeczku
+maintainer = @janeczku
+license = GPLv3+
+license_file = LICENSE
+classifiers =
+    Development Status :: 5 - Production/Stable
+    License :: OSI Approved :: GNU Affero General Public License v3
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+keywords =
+  calibre
+  calibre-web
+  library
+
+[options]
+python_requires = >=2.6
+packages = find:
+include_package_data = True
+zip_safe = False
+install_requires =
+  Babel >= 1.3
+  Flask-Babel >= 0.11.1
+  Flask-Login >= 0.3.2
+  Flask-Principal >= 0.3.2
+  singledispatch >= 3.4.0.0
+  backports_abc >= 0.4
+  Flask >= 0.11
+  iso-639 >= 0.4.5
+  PyPDF2 == 1.26.0
+  pytz >= 2016.10
+  requests >= 2.11.1
+  SQLAlchemy >= 1.1.0
+  tornado >= 4.1
+  Wand >= 0.4.4
+  unidecode >= 0.04.19
+  comicapi @ git+https://github.com/wildthyme/comicapi.git@cb279168f9c5cec742b5a05ac8326b9c168a8a91#egg=comicapi
+
+[options.extras_require]
+gdrive =
+  google-api-python-client == 1.6.1
+goodreads =
+  goodreads >= 0.3.2
+
+[options.packages.find]
+where = .

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,5 @@
+"""Calibre-web distribution package setuptools installer."""
+
+from setuptools import setup
+
+setup()


### PR DESCRIPTION
Closes https://github.com/janeczku/calibre-web/issues/456.

Given a recent version of setuptools (pip install -U pip setuptools), you can now do:

* `pip install -e .`
* `pip install -e .'[gdrive]'`
* `pip install -e .'[goodreads]'`

Questions:
  * Did I get the right dependencies in the extras (from optional requirements.txt)?
  * Would you also like to integrate https://github.com/pypa/setuptools_scm/ for versions?
    * Needed for https://github.com/janeczku/calibre-web/issues/677 or some workflow.