### PR TITLE
(fix) Fix task page crash for long tasks

### DIFF
--- a/cps/worker.py
+++ b/cps/worker.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 import smtplib
 import threading
 from datetime import datetime
+import datetime as dt
 import logging
 import time
 import socket
@@ -482,15 +483,9 @@ class WorkerThread(threading.Thread):
             return None
 
     def _formatRuntime(self, runtime):
-        self.UIqueue[self.current]['rt'] = runtime.total_seconds()
-        val = re.split('\:|\.', str(runtime))[0:3]
-        erg = list()
-        for v in val:
-            if int(v) > 0:
-                erg.append(v)
-        retVal = (':'.join(erg)).lstrip('0') + ' s'
-        if retVal == ' s':
-            retVal = '0 s'
+        total_seconds = runtime.total_seconds()
+        self.UIqueue[self.current]['rt'] = total_seconds
+        retVal = str(dt.timedelta(seconds = int(total_seconds)))
         return retVal
 
     def _handleError(self, error_message):


### PR DESCRIPTION
Fixes #954 

Didn't see any unit tests here, so didn't add any!


 - When tasks run for over a day, they produce a string like
   "1 day, 1:23:45." which the current code doesn't properly parse.

 - Since the initial code appears to simply be intending to truncate
   fractional seconds, do that by rounding total seconds of the
   duration to an integer value, then use the built-in formatting