### PR TITLE
Add 2 modules to reqirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Babel>=1.3
 Flask-Babel>=0.11.1
 Flask-Login>=0.3.2
 Flask-Principal>=0.3.2
+Flask-SimpleLDAP>=1.4.0
 singledispatch>=3.4.0.0
 backports_abc>=0.4
 Flask>=0.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ SQLAlchemy>=1.1.0
 tornado>=4.1
 Wand>=0.4.4
 unidecode>=0.04.19
+goodreads>=0.3.2


### PR DESCRIPTION
Launching Calibre-Web on Windows displayed messages about missing modules.