### PR TITLE
Fix for missing public shelves

### DIFF
--- a/cps/shelf.py
+++ b/cps/shelf.py
@@ -268,7 +268,6 @@ def delete_shelf(shelf_id):
 # @shelf.route("/shelfdown/<int:shelf_id>")
 @shelf.route("/shelf/<int:shelf_id>", defaults={'shelf_type': 1})
 @shelf.route("/shelf/<int:shelf_id>/<int:shelf_type>")
-@login_required
 def show_shelf(shelf_type, shelf_id):
     if current_user.is_anonymous:
         shelf = ub.session.query(ub.Shelf).filter(ub.Shelf.is_public == 1, ub.Shelf.id == shelf_id).first()

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -128,7 +128,7 @@
                 {% endif %}
               {% endfor %}
 
-              {% if g.user.is_authenticated or allow_anonymous %}
+              {% if g.user.is_authenticated or g.allow_anonymous %}
                 <li class="nav-head hidden-xs public-shelves">{{_('Public Shelves')}}</li>
                 {% for shelf in g.public_shelfes %}
                   <li><a href="{{url_for('shelf.show_shelf', shelf_id=shelf.id)}}"><span class="glyphicon glyphicon-list public_shelf"></span>{{shelf.name|shortentitle(40)}}</a></li>


### PR DESCRIPTION
Fix for a typo from 4708347c16fcabc4a620cd9489984106c5794890. Should resolve https://github.com/janeczku/calibre-web/issues/1002