### PR TITLE
Add automatic epub to kepub conversion using kepubify

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -303,6 +303,10 @@ def _configuration_update_helper():
     _config_string("config_calibre")
     _config_string("config_converterpath")
 
+    _config_checkbox_int("config_automatic_kepub")
+    _config_string("config_kepubify_path")
+    _config_string("config_kepub_cache_dir")
+
     if _config_int("config_login_type"):
         reboot_required |= config.config_login_type != constants.LOGIN_STANDARD
 

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -104,6 +104,10 @@ class _Settings(_Base):
     config_calibre = Column(String)
     config_rarfile_location = Column(String)
 
+    config_automatic_kepub = Column(Boolean, default=False)
+    config_kepubify_path = Column(String)
+    config_kepub_cache_dir = Column(String)
+
     config_updatechannel = Column(Integer, default=constants.UPDATE_STABLE)
 
     def __repr__(self):

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -309,6 +309,18 @@
                 <input type="text" class="form-control" name="config_rarfile_location" id="config_rarfile_location" value="{% if config.config_rarfile_location != None %}{{ config.config_rarfile_location }}{% endif %}" autocomplete="off">
             </div>
           {% endif %}
+            <div class="form-group">
+                <input type="checkbox" id="config_automatic_kepub" name="config_automatic_kepub" {% if config.config_automatic_kepub %}checked{% endif %}>
+                <label for="config_uploading">{{_('Enable automatic kobo epub conversion')}}</label>
+            </div>
+            <div class="form-group">
+                <label for="config_kepubify_path">{{_('Path to kepubify')}}</label>
+                <input type="text" class="form-control" id="config_kepubify_path" name="config_kepubify_path" value="{% if config.config_kepubify_path != None %}{{ config.config_kepubify_path }}{% endif %}" autocomplete="off">
+            </div>
+            <div class="form-group">
+                <label for="config_kepub_cache_dir">{{_('Path to kepubify')}}</label>
+                <input type="text" class="form-control" id="config_kepub_cache_dir" name="config_kepub_cache_dir" value="{% if config.config_kepub_cache_dir != None %}{{ config.config_kepub_cache_dir }}{% endif %}" autocomplete="off">
+            </div>
       </div>
     </div>
   </div>

--- a/cps/web.py
+++ b/cps/web.py
@@ -1010,7 +1010,11 @@ def serve_book(book_id, book_format):
 @login_required_if_no_ano
 @download_required
 def download_link(book_id, book_format, anyname):
-    return get_download_link(book_id, book_format)
+    if (config.config_automatic_kepub and
+        "Kobo" in request.headers.get('User-Agent')):
+        client = "kobo"
+
+    return get_download_link(book_id, book_format, client)
 
 
 @web.route('/send/<int:book_id>/<book_format>/<int:convert>')


### PR DESCRIPTION
**Intro**
Kobo e-readers use a specific epub variant that allows more advanced capabilities like pages left in this chapter, length of different chapters and faster page turns. 

When using Calibre I transfer files to my Kobo e-reader with the KoboTouchExtended plugin installed. This plugin automatically converts epub's to the so called "_kepubs_" that allow me to use the advanced Kobo features. In my kobo they are shown as being of the "kobo epub" type.

**Problem**
I would like to be able to use calibre-web on the experimental browser on the Kobo to directly download the books to my device without having to connect to a computer. I can do that with the current calibre-web but I lose the "kobo epub" functionality.

Calibre's convert utility that is already integrated in calibre-web is not able to convert from epub to _kepub_.

**Proposed solution**
There is an open source go utility called Kepubify which makes it very easy to convert epub's to _kepub's_: https://github.com/geek1011/kepubify. I propose to enable the user to integrate this into calibre-web in a similar way to the convert utility and then automatically using it when downloading a book on a device with a "Kobo" useragent. 

**Note**
The code in this pull request is not yet final, but it is working. I want to see if such change would be welcome in calibre web before putting the final touches on the change. If so, I will finish up this change and update this pull request. I chose to submit a pull request instead of a ticket to outline the change as I see it. 



