### PR TITLE
Hotfix for search title

### DIFF
--- a/cps/web.py
+++ b/cps/web.py
@@ -798,9 +798,9 @@ def search():
         for element in entries:
             ids.append(element.id)
         searched_ids[current_user.id] = ids
-        return render_title_template('search.html', searchterm=term, entries=entries, page="search")
+        return render_title_template('search.html', searchterm=term, entries=entries, title=_(u"Search"), page="search")
     else:
-        return render_title_template('search.html', searchterm="", page="search")
+        return render_title_template('search.html', searchterm="", title=_(u"Search"), page="search")
 
 
 @web.route("/advanced_search", methods=['GET'])


### PR DESCRIPTION
Hola. 
I've noticed that when the search template is rendered the page's tab title is incomplete. 
Even if the query GET param is empty or has a value, no title parameter was passed in the render function.

![Screenshot 2019-11-14 at 12 02 11](https://user-images.githubusercontent.com/21315004/68848111-6840c800-06d8-11ea-88ed-904399f0d36d.png)
![Screenshot 2019-11-14 at 12 02 53](https://user-images.githubusercontent.com/21315004/68848113-6840c800-06d8-11ea-9f2c-b4a1ddc7c1a7.png)

My fix was adding the parameter. Take a look and let me know what you think 