### PR TITLE
Login via header sent from proxy

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -347,6 +347,10 @@ def _configuration_update_helper():
 
     _config_int("config_updatechannel")
 
+    # Reverse proxy login configuration
+    _config_checkbox("config_allow_reverse_proxy_header_login")
+    _config_string("config_reverse_proxy_login_header_name")
+
     # GitHub OAuth configuration
     if config.config_login_type == constants.LOGIN_OAUTH:
         active_oauths = 0

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -104,6 +104,9 @@ class _Settings(_Base):
     config_calibre = Column(String)
     config_rarfile_location = Column(String)
 
+    config_allow_reverse_proxy_header_login = Column(Boolean, default=False)
+    config_reverse_proxy_login_header_name = Column(String)
+
     config_updatechannel = Column(Integer, default=constants.UPDATE_STABLE)
 
     def __repr__(self):

--- a/cps/templates/admin.html
+++ b/cps/templates/admin.html
@@ -100,6 +100,16 @@
             <div class="col-xs-6 col-sm-7">{{_('Remote login')}}</div>
             <div class="col-xs-6 col-sm-5">{{ display_bool_setting(config.config_remote_login) }}</div>
         </div>
+        <div class="row">
+            <div class="col-xs-6 col-sm-7">{{_('Reverse proxy login')}}</div>
+            <div class="col-xs-6 col-sm-5">{{ display_bool_setting(config.config_allow_reverse_proxy_header_login) }}</div>
+        </div>
+        {% if config.config_allow_reverse_proxy_header_login %}
+        <div class="row">
+            <div class="col-xs-6 col-sm-7">{{_('Reverse proxy header name')}}</div>
+            <div class="col-xs-6 col-sm-5">{{ config.config_reverse_proxy_login_header_name }}</div>
+        </div>
+        {% endif %}
       </div>
       <div class="btn btn-default"><a id="basic_config" href="{{url_for('admin.configuration')}}">{{_('Basic Configuration')}}</a></div>
       <div class="btn btn-default"><a id="view_config" href="{{url_for('admin.view_configuration')}}">{{_('UI Configuration')}}</a></div>

--- a/cps/templates/admin.html
+++ b/cps/templates/admin.html
@@ -1,4 +1,7 @@
 {% extends "layout.html" %}
+{% macro display_bool_setting(setting_value) -%}
+    {% if setting_value %}<span class="glyphicon glyphicon-ok"></span>{% else %}<span class="glyphicon glyphicon-remove"></span>{% endif %}
+{%- endmacro %}
 {% block body %}
 <div class="container-fluid">
   <div class="row">
@@ -23,11 +26,11 @@
             <td>{{user.email}}</td>
             <td>{{user.kindle_mail}}</td>
             <td>{{user.downloads.count()}}</td>
-            <td class="hidden-xs">{% if user.role_admin() %}<span class="glyphicon glyphicon-ok"></span>{% else %}<span class="glyphicon glyphicon-remove"></span>{% endif %}</td>
-            <td class="hidden-xs">{% if user.role_download() %}<span class="glyphicon glyphicon-ok"></span>{% else %}<span class="glyphicon glyphicon-remove"></span>{% endif %}</td>
-            <td class="hidden-xs">{% if user.role_viewer() %}<span class="glyphicon glyphicon-ok"></span>{% else %}<span class="glyphicon glyphicon-remove"></span>{% endif %}</td>
-            <td class="hidden-xs">{% if user.role_upload() %}<span class="glyphicon glyphicon-ok"></span>{% else %}<span class="glyphicon glyphicon-remove"></span>{% endif %}</td>
-            <td class="hidden-xs">{% if user.role_edit() %}<span class="glyphicon glyphicon-ok"></span>{% else %}<span class="glyphicon glyphicon-remove"></span>{% endif %}</td>
+            <td class="hidden-xs">{{ display_bool_setting(user.role_admin()) }}</td>
+            <td class="hidden-xs">{{ display_bool_setting(user.role_download()) }}</td>
+            <td class="hidden-xs">{{ display_bool_setting(user.role_viewer()) }}</td>
+            <td class="hidden-xs">{{ display_bool_setting(user.role_upload()) }}</td>
+            <td class="hidden-xs">{{ display_bool_setting(user.role_edit()) }}</td>
           </tr>
           {% endif %}
         {% endfor %}
@@ -83,19 +86,19 @@
         </div>
         <div class="row">
             <div class="col-xs-6 col-sm-7">{{_('Uploading')}}</div>
-            <div class="col-xs-6 col-sm-5">{% if config.config_uploading %}<span class="glyphicon glyphicon-ok"></span>{% else %}<span class="glyphicon glyphicon-remove"></span>{% endif %}</div>
+            <div class="col-xs-6 col-sm-5">{{ display_bool_setting(config.config_uploading) }}</div>
         </div>
         <div class="row">
             <div class="col-xs-6 col-sm-7">{{_('Anonymous browsing')}}</div>
-            <div class="col-xs-6 col-sm-5">{% if config.config_anonbrowse %}<span class="glyphicon glyphicon-ok"></span>{% else %}<span class="glyphicon glyphicon-remove"></span>{% endif %}</div>
+            <div class="col-xs-6 col-sm-5">{{ display_bool_setting(config.config_anonbrowse) }}</div>
         </div>
         <div class="row">
             <div class="col-xs-6 col-sm-7">{{_('Public registration')}}</div>
-            <div class="col-xs-6 col-sm-5">{% if config.config_public_reg %}<span class="glyphicon glyphicon-ok"></span>{% else %}<span class="glyphicon glyphicon-remove"></span>{% endif %}</div>
+            <div class="col-xs-6 col-sm-5">{{ display_bool_setting(config.config_public_reg) }}</div>
         </div>
         <div class="row">
             <div class="col-xs-6 col-sm-7">{{_('Remote login')}}</div>
-            <div class="col-xs-6 col-sm-5">{% if config.config_remote_login %}<span class="glyphicon glyphicon-ok"></span>{% else %}<span class="glyphicon glyphicon-remove"></span>{% endif %}</div>
+            <div class="col-xs-6 col-sm-5">{{ display_bool_setting(config.config_remote_login) }}</div>
         </div>
       </div>
       <div class="btn btn-default"><a id="basic_config" href="{{url_for('admin.configuration')}}">{{_('Basic Configuration')}}</a></div>

--- a/cps/templates/admin.html
+++ b/cps/templates/admin.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 {% macro display_bool_setting(setting_value) -%}
-    {% if setting_value %}<span class="glyphicon glyphicon-ok"></span>{% else %}<span class="glyphicon glyphicon-remove"></span>{% endif %}
+  {% if setting_value %}<span class="glyphicon glyphicon-ok"></span>{% else %}<span class="glyphicon glyphicon-remove"></span>{% endif %}
 {%- endmacro %}
 {% block body %}
 <div class="container-fluid">

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -200,7 +200,7 @@
         </select>
       </div>
         {% if feature_support['ldap'] %}
-       <div data-related="login-settings-1">
+      <div data-related="login-settings-1">
         <div class="form-group">
           <label for="config_ldap_provider_url">{{_('LDAP Server Host Name or IP Address')}}</label>
           <input type="text" class="form-control" id="config_ldap_provider_url" name="config_ldap_provider_url" value="{% if config.config_ldap_provider_url != None %}{{ config.config_ldap_provider_url }}{% endif %}" autocomplete="off">

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -271,6 +271,16 @@
         </div>
       {% endif %}
     {% endif %}
+        <div class="form-group">
+          <input type="checkbox" id="config_allow_reverse_proxy_header_login" name="config_allow_reverse_proxy_header_login" data-control="reverse-proxy-login-settings" {% if config.config_allow_reverse_proxy_header_login %}checked{% endif %}>
+          <label for="config_allow_reverse_proxy_header_login">{{_('Allow Reverse Proxy Authentication')}}</label>
+        </div>
+        <div data-related="reverse-proxy-login-settings">
+          <div class="form-group">
+            <label for="config_reverse_proxy_login_header_name">{{_('Reverse Proxy Header Name')}}</label>
+            <input type="text" class="form-control" id="config_reverse_proxy_login_header_name" name="config_reverse_proxy_login_header_name" value="{% if config.config_reverse_proxy_login_header_name != None %}{{ config.config_reverse_proxy_login_header_name }}{% endif %}" autocomplete="off">
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/cps/web.py
+++ b/cps/web.py
@@ -135,7 +135,7 @@ def load_user_from_request(request):
     if config.config_allow_reverse_proxy_header_login:
         rp_header_name = config.config_reverse_proxy_login_header_name
         if rp_header_name:
-            rp_header = request.headers.get(rp_header_name)
+            rp_header_username = request.headers.get(rp_header_name)
             if rp_header_username:
                 user = _fetch_user_by_name(rp_header_username)
                 if user:

--- a/cps/web.py
+++ b/cps/web.py
@@ -116,14 +116,35 @@ web = Blueprint('web', __name__)
 log = logger.create()
 
 # ################################### Login logic and rights management ###############################################
+def _fetch_user_by_name(username):
+    return ub.session.query(ub.User).filter(func.lower(ub.User.nickname) == username.lower()).first()
 
 @lm.user_loader
 def load_user(user_id):
     return ub.session.query(ub.User).filter(ub.User.id == int(user_id)).first()
 
 
-@lm.header_loader
-def load_user_from_header(header_val):
+@lm.request_loader
+def load_user_from_request(request):
+    auth_header = request.headers.get("Authorization")
+    if auth_header:
+        user = load_user_from_auth_header(auth_header)
+        if user:
+            return user
+
+    if config.config_allow_reverse_proxy_header_login:
+        rp_header_name = config.config_reverse_proxy_login_header_name
+        if rp_header_name:
+            rp_header = request.headers.get(rp_header_name)
+            if rp_header_username:
+                user = _fetch_user_by_name(rp_header_username)
+                if user:
+                    return user
+
+    return
+
+
+def load_user_from_auth_header(header_val):
     if header_val.startswith('Basic '):
         header_val = header_val.replace('Basic ', '', 1)
     basic_username = basic_password = ''
@@ -133,7 +154,7 @@ def load_user_from_header(header_val):
         basic_password = header_val.split(':')[1]
     except TypeError:
         pass
-    user = ub.session.query(ub.User).filter(func.lower(ub.User.nickname) == basic_username.lower()).first()
+    user = _fetch_user_by_name(basic_username)
     if user and check_password_hash(str(user.password), basic_password):
         return user
     return


### PR DESCRIPTION
This PR enables login via the contents of a header set by some upstream proxy.

If you're using this feature, it's assumed that there's no access to the calibre-web service without going through the proxy responsible for setting the headers, as it allows for unchallenged login (i.e., it assumes the login challenge happens upstream, in some SSO flow).

Fixes #1105 