### PR TITLE
LDAP Import Users + Usability/Bug Fixes

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -44,7 +44,7 @@ from .gdriveutils import is_gdrive_ready, gdrive_support
 from .web import admin_required, render_title_template, before_request, unconfigured, login_required_if_no_ano
 
 feature_support = {
-        'ldap': False, # bool(services.ldap),
+        'ldap': bool(services.ldap),
         'goodreads': bool(services.goodreads_support)
     }
 
@@ -326,13 +326,16 @@ def _configuration_update_helper():
             return _configuration_result('Please enter a LDAP service account and password', gdriveError)
         config.set_from_dictionary(to_save, "config_ldap_serv_password", base64.b64encode)
 
-    _config_checkbox("config_ldap_use_ssl")
-    _config_checkbox("config_ldap_use_tls")
-    _config_checkbox("config_ldap_openldap")
-    _config_checkbox("config_ldap_require_cert")
-    _config_string("config_ldap_cert_path")
-    if config.config_ldap_cert_path and not os.path.isfile(config.config_ldap_cert_path):
-        return _configuration_result('LDAP Certfile location is not valid, please enter correct path', gdriveError)
+        _config_string("config_ldap_group_object_filter")
+        _config_string("config_ldap_group_members_field")
+        _config_string("config_ldap_group_name")
+        _config_checkbox("config_ldap_use_ssl")
+        _config_checkbox("config_ldap_use_tls")
+        _config_checkbox("config_ldap_openldap")
+        _config_checkbox("config_ldap_require_cert")
+        _config_string("config_ldap_cert_path")
+        if config.config_ldap_cert_path and not os.path.isfile(config.config_ldap_cert_path):
+            return _configuration_result('LDAP Certfile location is not valid, please enter correct path', gdriveError)
 
     # Remote login configuration
     _config_checkbox("config_remote_login")

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -37,6 +37,8 @@ _Base = declarative_base()
 class _Settings(_Base):
     __tablename__ = 'settings'
 
+    config_is_initial = Column(Boolean, default=True)
+    
     id = Column(Integer, primary_key=True)
     mail_server = Column(String, default='mail.example.org')
     mail_port = Column(Integer, default=25)
@@ -86,18 +88,21 @@ class _Settings(_Base):
 
     # config_oauth_provider = Column(Integer)
 
-    config_ldap_provider_url = Column(String, default='localhost')
+    config_ldap_provider_url = Column(String, default='example.org')
     config_ldap_port = Column(SmallInteger, default=389)
     config_ldap_schema = Column(String, default='ldap')
-    config_ldap_serv_username = Column(String)
+    config_ldap_serv_username = Column(String, default='cn=admin,dc=example,dc=org')
     config_ldap_serv_password = Column(String)
     config_ldap_use_ssl = Column(Boolean, default=False)
     config_ldap_use_tls = Column(Boolean, default=False)
     config_ldap_require_cert = Column(Boolean, default=False)
     config_ldap_cert_path = Column(String)
-    config_ldap_dn = Column(String)
-    config_ldap_user_object = Column(String)
-    config_ldap_openldap = Column(Boolean, default=False)
+    config_ldap_dn = Column(String, default='dc=example,dc=org')
+    config_ldap_user_object = Column(String, default='uid=%s')
+    config_ldap_openldap = Column(Boolean, default=True)
+    config_ldap_group_object_filter = Column(String, default='(&(objectclass=posixGroup)(cn=%s))')
+    config_ldap_group_members_field = Column(String, default='memberUid')
+    config_ldap_group_name = Column(String, default='calibreweb')
 
     config_ebookconverter = Column(Integer, default=0)
     config_converterpath = Column(String)

--- a/cps/opds.py
+++ b/cps/opds.py
@@ -318,7 +318,6 @@ def feed_shelf(book_id):
 
 @opds.route("/opds/download/<book_id>/<book_format>/")
 @requires_basic_auth_if_no_ano
-@download_required
 def opds_download_link(book_id, book_format):
     return get_download_link(book_id,book_format)
 

--- a/cps/services/simpleldap.py
+++ b/cps/services/simpleldap.py
@@ -35,8 +35,7 @@ def init_app(app, config):
     app.config['LDAP_HOST'] = config.config_ldap_provider_url
     app.config['LDAP_PORT'] = config.config_ldap_port
     app.config['LDAP_SCHEMA'] = config.config_ldap_schema
-    app.config['LDAP_USERNAME'] = config.config_ldap_user_object.replace('%s', config.config_ldap_serv_username)\
-                                  + ',' + config.config_ldap_dn
+    app.config['LDAP_USERNAME'] = config.config_ldap_serv_username
     app.config['LDAP_PASSWORD'] = base64.b64decode(config.config_ldap_serv_password)
     app.config['LDAP_REQUIRE_CERT'] = bool(config.config_ldap_require_cert)
     if config.config_ldap_require_cert:
@@ -46,9 +45,22 @@ def init_app(app, config):
     app.config['LDAP_USE_SSL'] = bool(config.config_ldap_use_ssl)
     app.config['LDAP_USE_TLS'] = bool(config.config_ldap_use_tls)
     app.config['LDAP_OPENLDAP'] = bool(config.config_ldap_openldap)
+    app.config['LDAP_GROUP_OBJECT_FILTER'] = config.config_ldap_group_object_filter
+    app.config['LDAP_GROUP_MEMBERS_FIELD'] = config.config_ldap_group_members_field
 
     _ldap.init_app(app)
 
+
+def get_object_details(user=None, group=None, query_filter=None, dn_only=False):
+    return _ldap.get_object_details(user, group, query_filter, dn_only)
+
+
+def bind():
+    return _ldap.bind()
+
+
+def get_group_members(group):
+    return _ldap.get_group_members(group)
 
 
 def basic_auth_required(func):
@@ -56,7 +68,6 @@ def basic_auth_required(func):
 
 
 def bind_user(username, password):
-    # ulf= _ldap.get_object_details('admin')
     '''Attempts a LDAP login.
 
     :returns: True if login succeeded, False if login failed, None if server unavailable.

--- a/cps/templates/admin.html
+++ b/cps/templates/admin.html
@@ -32,7 +32,11 @@
           {% endif %}
         {% endfor %}
       </table>
-      <div class="btn btn-default" id="admin_new_user"><a href="{{url_for('admin.new_user')}}">{{_('Add new user')}}</a></div>
+      {% if not (config.config_login_type == 1) %}
+        <div class="btn btn-default" id="admin_new_user"><a href="{{url_for('admin.new_user')}}">{{_('Add new user')}}</a></div>
+      {% else %}
+        <a href=# id=import_ldap_users name=import_ldap_users><button type="submit" class="btn btn-default">{{_('Import LDAP Users')}}</button></a>
+      {% endif %}
     </div>
   </div>
 
@@ -189,4 +193,16 @@
     </div>
   </div>
 </div>
+{% endblock %}
+{% block js %}
+<script type="text/javascript">
+    $(function() {
+        $('a#import_ldap_users').bind('click', function() {
+            $.getJSON('/import_ldap_users',
+                function(data) {}
+            );
+            location.reload();
+        });
+    });
+</script>
 {% endblock %}

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -186,6 +186,7 @@
       </div>
     </div>
     {% endif %}
+    {% if not config.config_is_initial %}
     {% if feature_support['ldap'] or feature_support['oauth'] %}
       <div class="form-group">
         <label for="config_login_type">{{_('Login type')}}</label>
@@ -199,59 +200,71 @@
            {% endif %}
         </select>
       </div>
-        {% if feature_support['ldap'] %}
-       <div data-related="login-settings-1">
-        <div class="form-group">
-          <label for="config_ldap_provider_url">{{_('LDAP Server Host Name or IP Address')}}</label>
-          <input type="text" class="form-control" id="config_ldap_provider_url" name="config_ldap_provider_url" value="{% if config.config_ldap_provider_url != None %}{{ config.config_ldap_provider_url }}{% endif %}" autocomplete="off">
-        </div>
-        <div class="form-group">
-          <label for="config_ldap_port">{{_('LDAP Server Port')}}</label>
-          <input type="text" class="form-control" id="config_ldap_port" name="config_ldap_port" value="{% if config.config_ldap_port != None %}{{ config.config_ldap_port }}{% endif %}" autocomplete="off">
-        </div>
-        <div class="form-group">
-          <label for="config_ldap_schema">{{_('LDAP schema (ldap or ldaps)')}}</label>
-          <input type="text" class="form-control" id="config_ldap_schema" name="config_ldap_schema" value="{% if config.config_ldap_schema != None %}{{ config.config_ldap_schema }}{% endif %}" autocomplete="off">
-        </div>
-        <div class="form-group">
-          <label for="config_ldap_serv_username">{{_('LDAP Admin username')}}</label>
-          <input type="text" class="form-control" id="config_ldap_serv_username" name="config_ldap_serv_username" value="{% if config.config_ldap_serv_username != None %}{{ config.config_ldap_serv_username }}{% endif %}" autocomplete="off">
-        </div>
-        <div class="form-group">
-          <label for="config_ldap_serv_password">{{_('LDAP Admin password')}}</label>
-          <input type="password" class="form-control" id="config_ldap_serv_password" name="config_ldap_serv_password" value="{% if config.config_ldap_serv_password != None %}{{ config.config_ldap_serv_password }}{% endif %}" autocomplete="off">
-        </div>
-        <div class="form-group">
-          <input type="checkbox" id="config_ldap_use_ssl" name="config_ldap_use_ssl" {% if config.config_ldap_use_ssl %}checked{% endif %}>
-          <label for="config_ldap_use_ssl">{{_('LDAP Server use SSL')}}</label>
-        </div>
-        <div class="form-group">
-          <input type="checkbox" id="config_ldap_use_tls" name="config_ldap_use_tls" {% if config.config_ldap_use_tls %}checked{% endif %}>
-          <label for="config_ldap_use_tls">{{_('LDAP Server use TLS')}}</label>
-        </div>
-        <div class="form-group">
-          <input type="checkbox" id="config_ldap_require_cert" name="config_ldap_require_cert" data-control="ldap-cert-settings" {% if config.config_ldap_require_cert %}checked{% endif %}>
-          <label for="config_ldap_require_cert">{{_('LDAP Server Certificate')}}</label>
-        </div>
-        <div data-related="ldap-cert-settings">
+      {% if feature_support['ldap'] %}
+          <div data-related="login-settings-1">
           <div class="form-group">
-            <label for="config_ldap_cert_path">{{_('LDAP SSL Certificate Path')}}</label>
-            <input type="text" class="form-control" id="config_ldap_cert_path" name="config_ldap_cert_path" value="{% if config.config_ldap_cert_path != None and config.config_ldap_require_cert !=None %}{{ config.config_ldap_cert_path }}{% endif %}" autocomplete="off">
+            <label for="config_ldap_provider_url">{{_('LDAP Server Host Name or IP Address')}}</label>
+            <input type="text" class="form-control" id="config_ldap_provider_url" name="config_ldap_provider_url" value="{% if config.config_ldap_provider_url != None %}{{ config.config_ldap_provider_url }}{% endif %}" autocomplete="off">
+          </div>
+          <div class="form-group">
+            <label for="config_ldap_port">{{_('LDAP Server Port')}}</label>
+            <input type="text" class="form-control" id="config_ldap_port" name="config_ldap_port" value="{% if config.config_ldap_port != None %}{{ config.config_ldap_port }}{% endif %}" autocomplete="off">
+          </div>
+          <div class="form-group">
+            <label for="config_ldap_schema">{{_('LDAP schema (ldap or ldaps)')}}</label>
+            <input type="text" class="form-control" id="config_ldap_schema" name="config_ldap_schema" value="{% if config.config_ldap_schema != None %}{{ config.config_ldap_schema }}{% endif %}" autocomplete="off">
+          </div>
+          <div class="form-group">
+            <label for="config_ldap_serv_username">{{_('LDAP Admin username')}}</label>
+            <input type="text" class="form-control" id="config_ldap_serv_username" name="config_ldap_serv_username" value="{% if config.config_ldap_serv_username != None %}{{ config.config_ldap_serv_username }}{% endif %}" autocomplete="off">
+          </div>
+          <div class="form-group">
+            <label for="config_ldap_serv_password">{{_('LDAP Admin password')}}</label>
+            <input type="password" class="form-control" id="config_ldap_serv_password" name="config_ldap_serv_password" autocomplete="off">
+          </div>
+          <div class="form-group">
+            <input type="checkbox" id="config_ldap_use_ssl" name="config_ldap_use_ssl" {% if config.config_ldap_use_ssl %}checked{% endif %}>
+            <label for="config_ldap_use_ssl">{{_('LDAP Server use SSL')}}</label>
+          </div>
+          <div class="form-group">
+            <input type="checkbox" id="config_ldap_use_tls" name="config_ldap_use_tls" {% if config.config_ldap_use_tls %}checked{% endif %}>
+            <label for="config_ldap_use_tls">{{_('LDAP Server use TLS')}}</label>
+          </div>
+          <div class="form-group">
+            <input type="checkbox" id="config_ldap_require_cert" name="config_ldap_require_cert" data-control="ldap-cert-settings" {% if config.config_ldap_require_cert %}checked{% endif %}>
+            <label for="config_ldap_require_cert">{{_('LDAP Server Certificate')}}</label>
+          </div>
+          <div data-related="ldap-cert-settings">
+            <div class="form-group">
+              <label for="config_ldap_cert_path">{{_('LDAP SSL Certificate Path')}}</label>
+              <input type="text" class="form-control" id="config_ldap_cert_path" name="config_ldap_cert_path" value="{% if config.config_ldap_cert_path != None and config.config_ldap_require_cert !=None %}{{ config.config_ldap_cert_path }}{% endif %}" autocomplete="off">
+            </div>
+          </div>
+          <div class="form-group">
+            <label for="config_ldap_dn">{{_('LDAP Distinguished Name (DN)')}}</label>
+            <input type="text" class="form-control" id="config_ldap_dn" name="config_ldap_dn" value="{% if config.config_ldap_dn != None %}{{ config.config_ldap_dn }}{% endif %}" autocomplete="off">
+          </div>
+          <div class="form-group">
+            <label for="config_ldap_user_object">{{_('LDAP User object filter')}}</label>
+            <input type="text" class="form-control" id="config_ldap_user_object" name="config_ldap_user_object" value="{% if config.config_ldap_user_object != None %}{{ config.config_ldap_user_object }}{% endif %}" autocomplete="off">
+          </div>
+          <div class="form-group">
+            <input type="checkbox" id="config_ldap_openldap" name="config_ldap_openldap" {% if config.config_ldap_openldap %}checked{% endif %}>
+            <label for="config_ldap_openldap">{{_('LDAP Server is OpenLDAP?')}}</label>
+          </div>
+          <div class="form-group">
+            <label for="config_ldap_group_object_filter">{{_('LDAP Group Object Filter')}}</label>
+            <input type="text" class="form-control" id="config_ldap_group_object_filter" name="config_ldap_group_object_filter" value="{% if config.config_ldap_group_object_filter != None %}{{ config.config_ldap_group_object_filter }}{% endif %}" autocomplete="off">
+          </div>
+          <div class="form-group">
+            <label for="config_ldap_group_members_field">{{_('LDAP Group Members Field')}}</label>
+            <input type="text" class="form-control" id="config_ldap_group_members_field" name="config_ldap_group_members_field" value="{% if config.config_ldap_group_members_field != None %}{{ config.config_ldap_group_members_field }}{% endif %}" autocomplete="off">
+          </div>
+          <div class="form-group">
+            <label for="config_ldap_group_name">{{_('LDAP Group Name')}}</label>
+            <input type="text" class="form-control" id="config_ldap_group_name" name="config_ldap_group_name" value="{% if config.config_ldap_group_name != None %}{{ config.config_ldap_group_name }}{% endif %}" autocomplete="off">
           </div>
         </div>
-        <div class="form-group">
-          <label for="config_ldap_dn">{{_('LDAP Distinguished Name (DN)')}}</label>
-          <input type="text" class="form-control" id="config_ldap_dn" name="config_ldap_dn" value="{% if config.config_ldap_dn != None %}{{ config.config_ldap_dn }}{% endif %}" autocomplete="off">
-        </div>
-        <div class="form-group">
-          <label for="config_ldap_user_object">{{_('LDAP User object filter')}}</label>
-          <input type="text" class="form-control" id="config_ldap_user_object" name="config_ldap_user_object" value="{% if config.config_ldap_user_object != None %}{{ config.config_ldap_user_object }}{% endif %}" autocomplete="off">
-        </div>
-        <div class="form-group">
-          <input type="checkbox" id="config_ldap_openldap" name="config_ldap_openldap" {% if config.config_ldap_openldap %}checked{% endif %}>
-          <label for="config_ldap_openldap">{{_('LDAP Server is OpenLDAP?')}}</label>
-        </div>
-      </div>
       {% endif %}
       {% if feature_support['oauth'] %}
         <div data-related="login-settings-2">
@@ -269,6 +282,7 @@
           </div>
         {% endfor %}
         </div>
+      {% endif %}
       {% endif %}
     {% endif %}
       </div>

--- a/cps/web.py
+++ b/cps/web.py
@@ -1155,7 +1155,11 @@ def login():
                 flash(_(u"you are now logged in as: '%(nickname)s'", nickname=user.nickname),
                       category="success")
                 return redirect_back(url_for("web.index"))
-            if login_result is None:
+            elif user and check_password_hash(str(user.password), form['password']) and user.nickname != "Guest":
+                login_user(user, remember=True)
+                flash(_(u"You are now logged in as: '%(nickname)s'", nickname=user.nickname), category="success")
+                return redirect_back(url_for("web.index"))
+            elif login_result is None:
                 flash(_(u"Could not login. LDAP server down, please contact your administrator"), category="error")
             else:
                 ipAdress = request.headers.get('X-Forwarded-For', request.remote_addr)


### PR DESCRIPTION
Hey there, I've been wanting to use this functionality for awhile as it's the last part of my home server that isn't integrated with LDAP. I attempted enabling and using the existing code and got it to work, but I ran into a couple of problems. I started to fix them as I came across them, and ending up adding additional functionality along the way. I'd like to address the main questions you asked in #956 so that we can get this enabled for more calibre-web users. #263 

The main thing I added was an LDAP User Import which replaces the create user button when selecting LDAP as the login type. It works by querying an LDAP group (everyone in the supplied ldap group is added), so there's a few extra parameters that are needed. It'll pull in username, password, email, (if there's a secondary email, it'll pull it in as a kindle email), and set the permissions/views to the defaults. This works well enough as a test, since it wont import if your settings aren't configured properly, and it'll query your LDAP database, so you'll be able to see the ldap search results in your ldap log files in order to debug your configuration.

The flow I've been using for setup is to ignore the ldap settings on the initial setup and log in with the default admin, and then tweak them from there. This better prevents you from locking yourself out in case you import an admin credential that you don't know (unlikely but still) and lets you test/import/tweak user settings. I've hidden the ldap option on initial setup.

If ldap login fails, it now tries basic auth before throwing ldap errors, so even if you swap to ldap login and then logout with a bad config, you can still log into the gui with the admin user. #837 

As for ssl/tls/ldaps/cert options, I think its best to leave these as there may be people with dated ldap configs that might need them. I'm not an ldap expert myself, but from what I understand this is the gist of how these options work:

ldap - doesn't restrict the port, defaults to 389
ldaps - must be a secure port (636)
ssl - outdated option that requires cert and will establish a secure connection using ssl
tls - similar to ssl with newer tls standard though still the dated way to configure your ldap database
cert is needed for those options

I use starttls which is an ldapv3 option that creates a secure connection with the ldap database after an initial query (that doesn't expose any unencrypted passwords if you set it up properly) I also use port 636 so my settings look like this:
ldaps
no ssl or tls or cert
If I check the additional options, it'll establish a tls connection with starttls and then error upon trying to encrypt it a second time with either ssl or tls. So basically if you are using an ldap database with a recommended config, then you won't use ssl or tls or cert options since you should be using starttls. That being said, I'm sure some people have their databases configured to use those options, so it's best to leave the options there.

Some other stuff I changed due to bugs:
The ldap database admin username field was unnecessarily restricted. It autofilled some information from other fields instead of letting you configure it separately. This doesn't work for openldap defaults, since you typically want to search for uid for your users and use cn=admin for your admin login. I removed the restrictions, and put various openldap examples in for the defaults to help people out. I haven't tested this with AD, but there's no reason it won't work so long as you know how to filter your options for AD.
Password doesn't autofill and must be reentered on changing config. I ran into a bug where the encrypted version of the password was being filled in, and I wasn't sure how to fill in the decrypted one if that's possible. In addition, after the first configuration, calibre-web must be restarted for ldap settings to register because of how the settings are being initialized. Not sure how you want to handle this. Maybe just have an alert saying restart required or something.

I didn't add much real time feedback to the forms as I was having some difficultly getting it to work when I did, but I figured some prefilled examples along with the import button should be adequate for an initial release. I don't believe it's possible to lock yourself out of an admin account now either unless you successfully import an ldap user named admin which you don't know the password to.

Let me know what else I can do to get my changes into a release.