### PR TITLE
edit book: manage identifiers

### DIFF
--- a/cps/templates/book_edit.html
+++ b/cps/templates/book_edit.html
@@ -61,6 +61,21 @@
       <label for="description">{{_('Description')}}</label>
       <textarea class="form-control" name="description" id="description" rows="7">{% if book.comments %}{{book.comments[0].text}}{%endif%}</textarea>
     </div>
+
+    <div class="form-group">
+      <label>{{_('Identifiers')}}</label>
+      <table class="table" id="identifier-table">
+	{% for identifier in book.identifiers %}
+	<tr>
+          <td><input type="text" class="form-control" name="identifier-type-{{identifier.type}}" value="{{identifier.type}}" required="required" placeholder="{{_('Identifier Type')}}"></td>
+	  <td><input type="text" class="form-control" name="identifier-val-{{identifier.type}}" value="{{identifier.val}}" required="required" placeholder="{{_('Identifier Value')}}"></td>
+	  <td><a class="btn btn-default" onclick="removeIdentifierLine(this)">{{_('Remove')}}</a></td>
+	</tr>
+	{% endfor %}
+      </table>
+      <a id="add-identifier-line" class="btn btn-default">{{_('Add Identifier')}}</a>
+    </div>
+
     <div class="form-group">
       <label for="tags">{{_('Tags')}}</label>
       <input type="text" class="form-control typeahead" name="tags" id="tags" value="{% for tag in book.tags %}{{tag.name.strip()}}{% if not loop.last %}, {% endif %}{% endfor %}">
@@ -274,6 +289,21 @@
     'source': {{_('Source')|safe|tojson}},
   };
   var language = '{{ g.user.locale }}';
+
+  $("#add-identifier-line").click(function() {
+    // create a random identifier type to have a valid name in form. This will not be used when dealing with the form
+    var rand_id = Math.floor(Math.random() * 1000000).toString();
+    var line = '<tr>';
+    line += '<td><input type="text" class="form-control" name="identifier-type-'+ rand_id +'" required="required" placeholder="{{_('Identifier Type')}}"></td>';
+    line += '<td><input type="text" class="form-control" name="identifier-val-'+ rand_id +'" required="required" placeholder="{{_('Identifier Value')}}"></td>';
+    line += '<td><a class="btn btn-default" onclick="removeIdentifierLine(this)">{{_('Remove')}}</a></td>';
+    line += '</tr>';
+    $("#identifier-table").append(line);
+  });
+  function removeIdentifierLine(el) {
+    $(el).parent().parent().remove();
+  } 
+
 </script>
 <script src="{{ url_for('static', filename='js/libs/typeahead.bundle.js') }}"></script>
 <script src="{{ url_for('static', filename='js/libs/bootstrap-rating-input.min.js') }}"></script>


### PR DESCRIPTION
Adds a simple way of editing identifiers on a book.

Implementation remark: I tried to modify the `modify_database_object`, but it seems this function is clearly designed to manage fields that are a list of strings (author, tags, series, languages, etc.), and not key/value based fields.
In the end, I created a new function to avoid polluting the original function.
If you have some ideas on how to merge both "generic" modify_database_object and the identifiers one, I would be interested.

Note: this is my first "draft" pull request, I am very unsure of its consequences (I hope it is the same as "WIP" merge request on gitlab)