### PR TITLE
new user: disable kobo token on new user page

### DIFF
--- a/cps/templates/user_edit.html
+++ b/cps/templates/user_edit.html
@@ -55,7 +55,7 @@
       {% endfor %}
     </div>
     {% endif %}
-    {% if feature_support['kobo'] %}
+    {% if feature_support['kobo'] and not new_user %}
     <label>{{ _('Kobo Sync Token')}}</label>
     <div class="form-group col">
       <a class="btn btn-default" id="config_create_kobo_token" data-toggle="modal" data-target="#modal_kobo_token" data-remote="false" href="{{ url_for('kobo_auth.generate_auth_token', user_id=content.id) }}">{{_('Create/View')}}</a>


### PR DESCRIPTION
kobo token generator function 'kobo_auth.generate_auth_token' is related to a user id, which is not
present on new user page.

Disable the Kobo token part when creating a new user.