### PR TITLE
Fix for viewing error logfile in admin

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -672,7 +672,7 @@ def view_logfile():
     logfiles[0] = logger.get_logfile(config.config_logfile)
     logfiles[1] = logger.get_accesslogfile(config.config_access_logfile)
     return render_title_template("logviewer.html",title=_(u"Logfile viewer"), accesslog_enable=config.config_access_log,
-                                 logfiles=logfiles, page="logfile")
+                                 log_enable=True, logfiles=logfiles, page="logfile")
 
 
 @admi.route("/ajax/log/<int:logtype>")

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -672,7 +672,7 @@ def view_logfile():
     logfiles[0] = logger.get_logfile(config.config_logfile)
     logfiles[1] = logger.get_accesslogfile(config.config_access_logfile)
     return render_title_template("logviewer.html",title=_(u"Logfile viewer"), accesslog_enable=config.config_access_log,
-                                 log_enable=True, logfiles=logfiles, page="logfile")
+                                 log_enable=bool(config.config_logfile != logger.LOG_TO_STDOUT), logfiles=logfiles, page="logfile")
 
 
 @admi.route("/ajax/log/<int:logtype>")


### PR DESCRIPTION
Hello again.

The view logfiles feature works as expected for accesslog file, but for calibre-web.log, /admin/logfile returns always the "Stream output, can't be displayed" message.

![Screenshot 2020-01-26 at 20 25 38](https://user-images.githubusercontent.com/21315004/73139856-0fe45a00-407b-11ea-94aa-68a5c84d498b.png)

Template logviewer.html expects a log_enable parameter `{% if log_enable %}` , but in the render function it's totally missing.

Because the **View logfiles** button is always visible, and i couldn't find any setting that could disable the logfile view, i assumed that this parameter should be True as default.

Hope I'm clear. All the best