### PR TITLE
fix binascii.Error with reverse proxy bearer token

### DIFF
--- a/cps/web.py
+++ b/cps/web.py
@@ -132,7 +132,7 @@ def load_user_from_request(request):
                 user = _fetch_user_by_name(rp_header_username)
                 if user:
                     return user
-    
+
     auth_header = request.headers.get("Authorization")
     if auth_header:
         user = load_user_from_auth_header(auth_header)

--- a/cps/web.py
+++ b/cps/web.py
@@ -123,13 +123,7 @@ def load_user(user_id):
 
 
 @lm.request_loader
-def load_user_from_request(request):
-    auth_header = request.headers.get("Authorization")
-    if auth_header:
-        user = load_user_from_auth_header(auth_header)
-        if user:
-            return user
-
+def load_user_from_request(request):    
     if config.config_allow_reverse_proxy_header_login:
         rp_header_name = config.config_reverse_proxy_login_header_name
         if rp_header_name:
@@ -138,6 +132,12 @@ def load_user_from_request(request):
                 user = _fetch_user_by_name(rp_header_username)
                 if user:
                     return user
+    
+    auth_header = request.headers.get("Authorization")
+    if auth_header:
+        user = load_user_from_auth_header(auth_header)
+        if user:
+            return user
 
     return
 


### PR DESCRIPTION
When an authenticating reverse proxy (e.g. Keycloak Gatekeeper) adds a Bearer token in the Authorization header, every request fails with HTTP status code 500.  The corresponding error in the logs is: binascii.Error: Incorrect padding. 
Despite "reverse_proxy_header_login" is enabled, calibre-web tries first to base64decode the bearer token and fails. This patch just reverses the order in which the authentication methods  are checked.