### PR TITLE
allows same names for public/private shelves

### DIFF
--- a/cps/shelf.py
+++ b/cps/shelf.py
@@ -204,12 +204,24 @@ def create_shelf():
             shelf.is_public = 1
         shelf.name = to_save["title"]
         shelf.user_id = int(current_user.id)
-        existing_shelf = ub.session.query(ub.Shelf).filter(
-            or_((ub.Shelf.name == to_save["title"]) & (ub.Shelf.is_public == 1),
-                (ub.Shelf.name == to_save["title"]) & (ub.Shelf.user_id == int(current_user.id)))).first()
-        if existing_shelf:
-            flash(_(u"A shelf with the name '%(title)s' already exists.", title=to_save["title"]), category="error")
+
+        is_shelf_name_unique = False
+        if shelf.is_public == 1:
+            is_shelf_name_unique = ub.session.query(ub.Shelf) \
+                .filter((ub.Shelf.name == to_save["title"]) & (ub.Shelf.is_public == 1)) \
+                .first() is None
+
+            if not is_shelf_name_unique:
+                flash(_(u"A public shelf with the name '%(title)s' already exists.", title=to_save["title"]), category="error")
         else:
+            is_shelf_name_unique = ub.session.query(ub.Shelf) \
+                .filter((ub.Shelf.name == to_save["title"]) & (ub.Shelf.is_public == 0) & (ub.Shelf.user_id == int(current_user.id))) \
+                .first() is None
+
+            if not is_shelf_name_unique:
+                flash(_(u"A private shelf with the name '%(title)s' already exists.", title=to_save["title"]), category="error")
+
+        if is_shelf_name_unique:
             try:
                 ub.session.add(shelf)
                 ub.session.commit()
@@ -227,13 +239,26 @@ def edit_shelf(shelf_id):
     shelf = ub.session.query(ub.Shelf).filter(ub.Shelf.id == shelf_id).first()
     if request.method == "POST":
         to_save = request.form.to_dict()
-        existing_shelf = ub.session.query(ub.Shelf).filter(
-            or_((ub.Shelf.name == to_save["title"]) & (ub.Shelf.is_public == 1),
-                (ub.Shelf.name == to_save["title"]) & (ub.Shelf.user_id == int(current_user.id)))).filter(
-            ub.Shelf.id != shelf_id).first()
-        if existing_shelf:
-            flash(_(u"A shelf with the name '%(title)s' already exists.", title=to_save["title"]), category="error")
+
+        is_shelf_name_unique = False
+        if shelf.is_public == 1:
+            is_shelf_name_unique = ub.session.query(ub.Shelf) \
+                .filter((ub.Shelf.name == to_save["title"]) & (ub.Shelf.is_public == 1)) \
+                .filter(ub.Shelf.id != shelf_id) \
+                .first() is None
+
+            if not is_shelf_name_unique:
+                flash(_(u"A public shelf with the name '%(title)s' already exists.", title=to_save["title"]), category="error")
         else:
+            is_shelf_name_unique = ub.session.query(ub.Shelf) \
+                .filter((ub.Shelf.name == to_save["title"]) & (ub.Shelf.is_public == 0) & (ub.Shelf.user_id == int(current_user.id))) \
+                .filter(ub.Shelf.id != shelf_id) \
+                .first() is None
+
+            if not is_shelf_name_unique:
+                flash(_(u"A private shelf with the name '%(title)s' already exists.", title=to_save["title"]), category="error")
+
+        if is_shelf_name_unique:
             shelf.name = to_save["title"]
             if "is_public" in to_save:
                 shelf.is_public = 1

--- a/cps/templates/feed.xml
+++ b/cps/templates/feed.xml
@@ -75,7 +75,11 @@
   {% endif %}
   {% for entry in listelements %}
   <entry>
+    {% if entry.__class__.__name__ == 'Shelf' and entry.is_public == 1 %}
+    <title>{{entry.name}} (public)</title>
+    {% else %}
     <title>{{entry.name}}</title>
+    {% endif %}
     <id>{{ url_for(folder, book_id=entry.id) }}</id>
     <link rel="subsection" type="application/atom+xml;profile=opds-catalog" href="{{url_for(folder, book_id=entry.id)}}"/>
   </entry>

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -140,7 +140,7 @@
                 {% endfor %}
                 <li class="nav-head hidden-xs your-shelves">{{_('Your Shelves')}}</li>
                 {% for shelf in g.user.shelf %}
-                  <li><a href="{{url_for('shelf.show_shelf', shelf_id=shelf.id)}}"><span class="glyphicon glyphicon-list private_shelf"></span>{{shelf.name|shortentitle(40)}}</a></li>
+                  <li><a href="{{url_for('shelf.show_shelf', shelf_id=shelf.id)}}"><span class="glyphicon glyphicon-list private_shelf"></span>{{shelf.name|shortentitle(40)}}{% if shelf.is_public == 1 %} (public){% endif %}</a></li>
                 {% endfor %}
               {% if not g.user.is_anonymous %}
                 <li id="nav_createshelf" class="create-shelf"><a href="{{url_for('shelf.create_shelf')}}">{{_('Create a Shelf')}}</a></li>


### PR DESCRIPTION
This addresses #645, in summary:

### Changed logic when shelf is created:
- A user can create a private shelf with any name so long that they don't already have a private shelf that has that same exact name.
- A user can create a public shelf with any name so long as there is not already a public shelf that has that same exact name.
- Tests (ran sequentially after setting up preconditions):
    - Preconditions
        - 0 shelves of any kind in the system
    - User A 
         - Try create private shelf X = shelf created
         - Try create private shelf X = error
         - Try create public shelf X = shelf created
         - Try create public shelf X = error
         - Remove private shelf X, create private shelf X = shelf created
     - User B 
          - Try create private shelf X = shelf created
          - Try create public shelf X = error
### Changed logic when a shelf is updated:
- Same as create=> the new name should obey the same rules
- Tests (ran sequentially after settings up precondition prior to running every scenario):
    - Preconditions
        - 0 shelves of any kind in the system
    - User A
         - Scenario 1:
             - Create private shelf X and private shelf Y
             - Try changing the name of shelf Y to shelf X = error
         - Scenario 2:
             - Create public shelf X and public shelf Y
             - Try changing the name of shelf Y to shelf X = error
         - Scenario 3:
             - Create public shelf X and private shelf Y
             - Try changing the name of shelf Y to shelf X = success
         - Scenario 4:
             - Create private shelf X and public shelf Y
             - Try changing the name of shelf Y to shelf X = success
    - User A and User B
         - Scenario 1:
             - User A - create public shelf X
             - User B - create public shelf Y, try changing shelf Y to name X = error
         - Scenario 2:
             - User A - create public shelf X
             - User A - edit to update name of X to Y = success (regression)
		
### Changed shelf display for the user
- Should display "(public)" next to shelf in "Your Shelves" list if that public shelf is managed by the user
- Tested by creating 1 public and 1 private shelf =  both shelves are displayed and the public shelf has "(public)" next to it.
![image](https://user-images.githubusercontent.com/184821/74624894-2761b080-5118-11ea-8af6-eaa6a76c80a9.png)

### Changed OPDS feed
- Same idea, now displays "(public)" next to shelf name in OPDS feed
- Tested by creating 1 public and 1 private shelf =  both shelves are displayed in the feed and the public shelf has "(public)" next to it. The non-shelf feeds are not affected
![image](https://user-images.githubusercontent.com/184821/74624916-3ba5ad80-5118-11ea-8917-47fc350c034b.png)
