### PR TITLE
Improve read status visibility

### DIFF
--- a/cps/helper.py
+++ b/cps/helper.py
@@ -803,16 +803,20 @@ def get_search_results(term):
             func.lower(db.Books.title).ilike("%" + term + "%")
             )).all()
 
-def get_cc_columns():
+def get_cc_columns(filter_config_custom_read=False):
     tmpcc = db.session.query(db.Custom_Columns).filter(db.Custom_Columns.datatype.notin_(db.cc_exceptions)).all()
+    cc = []
+    r = None
     if config.config_columns_to_ignore:
-        cc = []
-        for col in tmpcc:
-            r = re.compile(config.config_columns_to_ignore)
-            if not r.match(col.name):
-                cc.append(col)
-    else:
-        cc = tmpcc
+        r = re.compile(config.config_columns_to_ignore)
+
+    for col in tmpcc:
+        if filter_config_custom_read and config.config_read_column and config.config_read_column == col.id:
+            continue
+        if r and r.match(col.label):
+            continue
+        cc.append(col)
+
     return cc
 
 def get_download_link(book_id, book_format):

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -855,6 +855,20 @@ def check_exists_book(authr,title):
             func.lower(db.Books.title).ilike("%" + title + "%")
             )).first()
 
+def get_readbooks_ids():
+    if not config.config_read_column:
+        readBooks = ub.session.query(ub.ReadBook).filter(ub.ReadBook.user_id == int(current_user.id))\
+            .filter(ub.ReadBook.is_read == True).all()
+        return [x.book_id for x in readBooks]
+    else:
+        try:
+            readBooks = db.session.query(db.cc_classes[config.config_read_column])\
+                .filter(db.cc_classes[config.config_read_column].value == True).all()
+            return [x.book for x in readBooks]
+        except KeyError:
+            log.error("Custom Column No.%d is not existing in calibre database", config.config_read_column)
+            return []
+
 ############### Database Helper functions
 
 def lcase(s):

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -801,7 +801,7 @@ def get_search_results(term):
             db.Books.authors.any(and_(*q)),
             db.Books.publishers.any(func.lower(db.Publishers.name).ilike("%" + term + "%")),
             func.lower(db.Books.title).ilike("%" + term + "%")
-            )).all()
+            )).order_by(db.Books.sort).all()
 
 def get_cc_columns(filter_config_custom_read=False):
     tmpcc = db.session.query(db.Custom_Columns).filter(db.Custom_Columns.datatype.notin_(db.cc_exceptions)).all()

--- a/cps/templates/author.html
+++ b/cps/templates/author.html
@@ -83,7 +83,7 @@
         </div>
         {% endif %}
         <div class="read">
-          <span>Read:</span>
+          <span>{{_('Read')}}:</span>
         {% if entry.id in readBookIds %}
           <span class="glyphicon glyphicon-ok"></span>
         {% else %}
@@ -133,7 +133,7 @@
           {% endfor %}
         </div>
         <div class="read">
-          <span>Read:</span>
+          <span>{{_('Read')}}:</span>
         {% if entry.id in readBookIds %}
           <span class="glyphicon glyphicon-ok"></span>
         {% else %}

--- a/cps/templates/author.html
+++ b/cps/templates/author.html
@@ -82,6 +82,14 @@
           {% endfor %}
         </div>
         {% endif %}
+        <div class="read">
+          <span>Read:</span>
+        {% if entry.id in readBookIds %}
+          <span class="glyphicon glyphicon-ok"></span>
+        {% else %}
+          <span class="glyphicon glyphicon-remove"></span>
+        {% endif %}
+        </div>        
       </div>
     </div>
     {% endfor %}
@@ -123,6 +131,14 @@
           {% endfor %}
           {% endif %}
           {% endfor %}
+        </div>
+        <div class="read">
+          <span>Read:</span>
+        {% if entry.id in readBookIds %}
+          <span class="glyphicon glyphicon-ok"></span>
+        {% else %}
+          <span class="glyphicon glyphicon-remove"></span>
+        {% endif %}
         </div>
       </div>
     </div>

--- a/cps/templates/discover.html
+++ b/cps/templates/discover.html
@@ -46,6 +46,14 @@
           {% endfor %}
         </div>
         {% endif %}
+        <div class="read">
+          <span>Read:</span>
+        {% if entry.id in readBookIds %}
+          <span class="glyphicon glyphicon-ok"></span>
+        {% else %}
+          <span class="glyphicon glyphicon-remove"></span>
+        {% endif %}
+        </div>
       </div>
     </div>
     {% endfor %}

--- a/cps/templates/discover.html
+++ b/cps/templates/discover.html
@@ -47,7 +47,7 @@
         </div>
         {% endif %}
         <div class="read">
-          <span>Read:</span>
+          <span>{{_('Read')}}:</span>
         {% if entry.id in readBookIds %}
           <span class="glyphicon glyphicon-ok"></span>
         {% else %}

--- a/cps/templates/index.html
+++ b/cps/templates/index.html
@@ -46,7 +46,7 @@
         </div>
         {% endif %}
         <div class="read">
-          <span>Read:</span>
+          <span>{{_('Read')}}:</span>
         {% if entry.id in readBookIds %}
           <span class="glyphicon glyphicon-ok"></span>
         {% else %}
@@ -122,7 +122,7 @@
         </div>
         {% endif %}
         <div class="read">
-          <span>Read:</span>
+          <span>{{_('Read')}}:</span>
         {% if entry.id in readBookIds %}
           <span class="glyphicon glyphicon-ok"></span>
         {% else %}

--- a/cps/templates/index.html
+++ b/cps/templates/index.html
@@ -20,7 +20,7 @@
             {% if loop.index > g.config_authors_max and g.config_authors_max != 0 %}
               {% if not loop.first %}
                 <span class="author-hidden-divider">&amp;</span>
-			  {% endif %}
+			        {% endif %}
               <a class="author-name author-hidden" href="{{url_for('web.books_list',  data='author', sort='new', book_id=author.id) }}">{{author.name.replace('|',',')|shortentitle(30)}}</a>
               {% if loop.last %}
                 <a href="#" class="author-expand" data-authors-max="{{g.config_authors_max}}" data-collapse-caption="({{_('reduce')}})">(...)</a>
@@ -45,6 +45,14 @@
           {% endfor %}
         </div>
         {% endif %}
+        <div class="read">
+          <span>Read:</span>
+        {% if entry.id in readBookIds %}
+          <span class="glyphicon glyphicon-ok"></span>
+        {% else %}
+          <span class="glyphicon glyphicon-remove"></span>
+        {% endif %}
+        </div>
       </div>
     </div>
     {% endfor %}
@@ -113,6 +121,14 @@
           {% endfor %}
         </div>
         {% endif %}
+        <div class="read">
+          <span>Read:</span>
+        {% if entry.id in readBookIds %}
+          <span class="glyphicon glyphicon-ok"></span>
+        {% else %}
+          <span class="glyphicon glyphicon-remove"></span>
+        {% endif %}
+      </div>
       </div>
     </div>
     {% endfor %}

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -42,7 +42,7 @@
           <form class="navbar-form navbar-left" role="search" action="{{url_for('web.search')}}" method="GET">
             <div class="form-group input-group input-group-sm">
               <label for="query" class="sr-only">{{_('Search')}}</label>
-              <input type="text" class="form-control" id="query" name="query" placeholder="{{_('Search Library')}}">
+              <input type="text" class="form-control" id="query" name="query" placeholder="{{_('Search Library')}}" value="{{searchterm}}">
               <span class="input-group-btn">
                 <button type="submit" id="query_submit" class="btn btn-default">{{_('Search')}}</button>
               </span>
@@ -226,6 +226,11 @@
             $("#btn-upload").change(function() {
                 $("#form-upload").submit();
             });
+            $(document).ready(function() {
+              var inp = $('#query').first()
+              var val = inp.val()
+              inp.val('').blur().focus().val(val)
+            })
         });
     </script>
     {% block js %}{% endblock %}

--- a/cps/templates/search.html
+++ b/cps/templates/search.html
@@ -91,6 +91,14 @@
           {% endfor %}
         </div>
         {% endif %}
+        <div class="read">
+          <span>Read:</span>
+        {% if entry.id in readBookIds %}
+          <span class="glyphicon glyphicon-ok"></span>
+        {% else %}
+          <span class="glyphicon glyphicon-remove"></span>
+        {% endif %}
+        </div>
       </div>
     </div>
     {% endfor %}

--- a/cps/templates/search.html
+++ b/cps/templates/search.html
@@ -92,7 +92,7 @@
         </div>
         {% endif %}
         <div class="read">
-          <span>Read:</span>
+          <span>{{_('Read')}}:</span>
         {% if entry.id in readBookIds %}
           <span class="glyphicon glyphicon-ok"></span>
         {% else %}

--- a/cps/web.py
+++ b/cps/web.py
@@ -830,7 +830,7 @@ def advanced_search():
     # Build custom columns names
     cc = get_cc_columns()
     db.session.connection().connection.connection.create_function("lower", 1, lcase)
-    q = db.session.query(db.Books).filter(common_filters())
+    q = db.session.query(db.Books).filter(common_filters()).order_by(db.Books.sort)
 
     include_tag_inputs = request.args.getlist('include_tag')
     exclude_tag_inputs = request.args.getlist('exclude_tag')

--- a/cps/web.py
+++ b/cps/web.py
@@ -1438,7 +1438,7 @@ def show_book(book_id):
             except UnknownLocaleError:
                 entries.languages[index].language_name = _(
                     isoLanguages.get(part3=entries.languages[index].lang_code).name)
-        cc = get_cc_columns()
+        cc = get_cc_columns(filter_config_custom_read=True)
         book_in_shelfs = []
         shelfs = ub.session.query(ub.BookShelf).filter(ub.BookShelf.book_id == book_id).all()
         for entry in shelfs:


### PR DESCRIPTION
This patch contains:
 - fixed for get_cc_columns (it was inverted)
 - auto filter custom columns Read if selected in settings but keep the advanced search possible! (it does not display the read custom header in the book details, but allow advance search on it because we don't filter it from everywhere)
 - factorization of the code for the list of readBookIds.
 - Display of read status on every template
 - Keep search term and focus on page reload
 - Order by "sort" (great when looking for a series)

<img width="669" alt="Capture d’écran 2020-02-22 à 19 50 58" src="https://user-images.githubusercontent.com/65178/75097586-a89fc400-55ac-11ea-89a1-5eb6eeedff29.png">

