### PR TITLE
restricted_tags -> denied_tags

### DIFF
--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -345,6 +345,6 @@ def load_configuration(session):
         conf.config_denied_tags = conf.config_mature_content_tags
         conf.save()
         session.query(ub.User).filter(ub.User.mature_content != True). \
-            update({"restricted_tags": conf.config_mature_content_tags}, synchronize_session=False)
+            update({"denied_tags": conf.config_mature_content_tags}, synchronize_session=False)
         session.commit()
     return conf


### PR DESCRIPTION
Fix for the next error after update:
Traceback (most recent call last):
  File "cps.py", line 34, in <module>
    from cps import create_app
  File "/home/rewerson/lib/web/cps/__init__.py", line 68, in <module>
    config = config_sql.load_configuration(ub.session)
  File "/home/rewerson/lib/web/cps/config_sql.py", line 348, in load_configuration
    update({"restricted_tags": conf.config_mature_content_tags}, synchronize_session=False)
  File "/home/rewerson/.local/lib/python2.7/site-packages/sqlalchemy/orm/query.py", line 3862, in update
    update_op.exec_()
  File "/home/rewerson/.local/lib/python2.7/site-packages/sqlalchemy/orm/persistence.py", line 1693, in exec_
    self._do_exec()
  File "/home/rewerson/.local/lib/python2.7/site-packages/sqlalchemy/orm/persistence.py", line 1874, in _do_exec
    values = self._resolved_values
  File "/home/rewerson/.local/lib/python2.7/site-packages/sqlalchemy/orm/persistence.py", line 1840, in _resolved_values
    desc = _entity_descriptor(self.mapper, k)
  File "/home/rewerson/.local/lib/python2.7/site-packages/sqlalchemy/orm/base.py", line 402, in _entity_descriptor
    "Entity '%s' has no property '%s'" % (description, key)
sqlalchemy.exc.InvalidRequestError: Entity '<class 'cps.ub.User'>' has no property 'restricted_tags'