### PR TITLE
[Kobo] Add Shelf/Collection support.

### DIFF
--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -179,7 +179,7 @@ def delete_book(book_id, book_format):
                 # delete book from Shelfs, Downloads, Read list
                 ub.session.query(ub.BookShelf).filter(ub.BookShelf.book_id == book_id).delete()
                 ub.session.query(ub.ReadBook).filter(ub.ReadBook.book_id == book_id).delete()
-                ub.session.query(ub.ArchivedBook).filter(ub.ReadBook.book_id == book_id).delete()
+                ub.session.query(ub.ArchivedBook).filter(ub.ArchivedBook.book_id == book_id).delete()
                 ub.delete_download(book_id)
                 ub.session.commit()
 

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -407,7 +407,7 @@ def HandleTagCreate():
         log.debug("Received malformed v1/library/tags request.")
         abort(400, description="Malformed tags POST request. Data is missing 'Name' or 'Items' field")
 
-    shelf = ub.session.query(ub.Shelf).filter(and_(ub.Shelf.name) == name, ub.Shelf.user_id ==
+    shelf = ub.session.query(ub.Shelf).filter(ub.Shelf.name == name, ub.Shelf.user_id ==
                                               current_user.id).one_or_none()
     if shelf and not shelf_lib.check_shelf_edit_permissions(shelf):
         abort(401, description="User is unauthaurized to edit shelf.")
@@ -426,7 +426,7 @@ def HandleTagCreate():
 
 @kobo.route("/v1/library/tags/<tag_id>", methods=["DELETE", "PUT"])
 def HandleTagUpdate(tag_id):
-    shelf = ub.session.query(ub.Shelf).filter(and_(ub.Shelf.uuid) == tag_id,
+    shelf = ub.session.query(ub.Shelf).filter(ub.Shelf.uuid == tag_id,
                                               ub.Shelf.user_id == current_user.id).one_or_none()
     if not shelf:
         log.debug("Received Kobo tag update request on a collection unknown to CalibreWeb")
@@ -487,7 +487,7 @@ def HandleTagAddItem(tag_id):
         log.debug("Received malformed v1/library/tags/<tag_id>/items/delete request.")
         abort(400, description="Malformed tags POST request. Data is missing 'Items' field")
 
-    shelf = ub.session.query(ub.Shelf).filter(and_(ub.Shelf.uuid) == tag_id,
+    shelf = ub.session.query(ub.Shelf).filter(ub.Shelf.uuid == tag_id,
                                               ub.Shelf.user_id == current_user.id).one_or_none()
     if not shelf:
         log.debug("Received Kobo request on a collection unknown to CalibreWeb")
@@ -498,7 +498,7 @@ def HandleTagAddItem(tag_id):
 
     items_unknown_to_calibre = add_items_to_shelf(items, shelf)
     if items_unknown_to_calibre:
-        log.debug("Received request to add an unknown book to a collecition. Silently ignoring item.")
+        log.debug("Received request to add an unknown book to a collection. Silently ignoring item.")
 
     ub.session.merge(shelf)
     ub.session.commit()
@@ -600,7 +600,7 @@ def create_kobo_tag(shelf):
         book = db.session.query(db.Books).filter(db.Books.id == book_shelf.book_id).one_or_none()
         if not book:
             log.info(u"Book (id: %s) in BookShelf (id: %s) not found in book database",  book_shelf.book_id, shelf.id)
-            return None
+            continue
         tag["Items"].append(
             {
                 "RevisionId": book.uuid,

--- a/cps/opds.py
+++ b/cps/opds.py
@@ -326,12 +326,12 @@ def feed_shelfindex():
 def feed_shelf(book_id):
     off = request.args.get("offset") or 0
     if current_user.is_anonymous:
-        shelf = ub.session.query(ub.Shelf).filter(ub.Shelf.is_public == 1, ub.Shelf.id == book_id).first()
+        shelf = ub.session.query(ub.Shelf).filter(ub.Shelf.is_public == 1, ub.Shelf.id == book_id, not ub.Shelf.deleted).first()
     else:
         shelf = ub.session.query(ub.Shelf).filter(or_(and_(ub.Shelf.user_id == int(current_user.id),
                                                            ub.Shelf.id == book_id),
                                                       and_(ub.Shelf.is_public == 1,
-                                                           ub.Shelf.id == book_id))).first()
+                                                           ub.Shelf.id == book_id)), not ub.Shelf.deleted).first()
     result = list()
     # user is allowed to access shelf
     if shelf:

--- a/cps/services/SyncToken.py
+++ b/cps/services/SyncToken.py
@@ -78,6 +78,7 @@ class SyncToken():
             "books_last_created": {"type": "string"},
             "archive_last_modified": {"type": "string"},
             "reading_state_last_modified": {"type": "string"},
+            "tags_last_modified": {"type": "string"},
         },
     }
 
@@ -88,13 +89,14 @@ class SyncToken():
         books_last_modified=datetime.min,
         archive_last_modified=datetime.min,
         reading_state_last_modified=datetime.min,
+        tags_last_modified=datetime.min,
     ):
         self.raw_kobo_store_token = raw_kobo_store_token
         self.books_last_created = books_last_created
         self.books_last_modified = books_last_modified
         self.archive_last_modified = archive_last_modified
         self.reading_state_last_modified = reading_state_last_modified
-
+        self.tags_last_modified = tags_last_modified
 
     @staticmethod
     def from_headers(headers):
@@ -128,6 +130,7 @@ class SyncToken():
             books_last_created = get_datetime_from_json(data_json, "books_last_created")
             archive_last_modified = get_datetime_from_json(data_json, "archive_last_modified")
             reading_state_last_modified = get_datetime_from_json(data_json, "reading_state_last_modified")
+            tags_last_modified = get_datetime_from_json(data_json, "tags_last_modified")
         except TypeError:
             log.error("SyncToken timestamps don't parse to a datetime.")
             return SyncToken(raw_kobo_store_token=raw_kobo_store_token)
@@ -137,7 +140,8 @@ class SyncToken():
             books_last_created=books_last_created,
             books_last_modified=books_last_modified,
             archive_last_modified=archive_last_modified,
-            reading_state_last_modified=reading_state_last_modified
+            reading_state_last_modified=reading_state_last_modified,
+            tags_last_modified=tags_last_modified
         )
 
     def set_kobo_store_header(self, store_headers):
@@ -159,7 +163,8 @@ class SyncToken():
                 "books_last_modified": to_epoch_timestamp(self.books_last_modified),
                 "books_last_created": to_epoch_timestamp(self.books_last_created),
                 "archive_last_modified": to_epoch_timestamp(self.archive_last_modified),
-                "reading_state_last_modified": to_epoch_timestamp(self.reading_state_last_modified)
+                "reading_state_last_modified": to_epoch_timestamp(self.reading_state_last_modified),
+                "tags_last_modified": to_epoch_timestamp(self.tags_last_modified)
             },
         }
         return b64encode_json(token)

--- a/cps/shelf.py
+++ b/cps/shelf.py
@@ -240,7 +240,7 @@ def create_shelf():
 @login_required
 def edit_shelf(shelf_id):
     shelf = ub.session.query(ub.Shelf).filter(ub.Shelf.id == shelf_id).first()
-    if request.method == "POST":            
+    if request.method == "POST":
         to_save = request.form.to_dict()
 
         is_shelf_name_unique = False

--- a/cps/shelf.py
+++ b/cps/shelf.py
@@ -283,7 +283,7 @@ def delete_shelf_helper(cur_shelf):
     shelf_id = cur_shelf.id
     ub.session.delete(cur_shelf)
     ub.session.query(ub.BookShelf).filter(ub.BookShelf.shelf == shelf_id).delete()
-    ub.session.add(ub.ShelfArchive(uuid = cur_shelf.uuid, user_id = cur_shelf.uuid))
+    ub.session.add(ub.ShelfArchive(uuid = cur_shelf.uuid, user_id = cur_shelf.user_id))
     ub.session.commit()
     log.info("successfully deleted %s", cur_shelf)
 


### PR DESCRIPTION
Implements the v1/library/tags set of endpoints to sync CalibreWeb
shelves with the Kobo device.

Drive-by: Refactors shelf.py to consolidate how user permissions are checked.
Drive-by: Fix issue with the sync endpoint that arrises when a book is
hard-deleted.

Tested: I've been using this for the past week without noticable issues, although I'll admit I don't use Shelves as much now that Kobo has added the Series tab.