### PR TITLE
Fix metadata display when there's results from comicvin

### DIFF
--- a/cps/static/js/get_meta.js
+++ b/cps/static/js/get_meta.js
@@ -73,7 +73,7 @@ $(function () {
         if (showFlag === 1) {
             $("#meta-info").html("<ul id=\"book-list\" class=\"media-list\"></ul>");
         }
-        if (!ggDone && !dbDone) {
+        if (showFlag === 0) {
             $("#meta-info").html("<p class=\"text-danger\">" + msg.no_result + "</p>");
             return;
         }


### PR DESCRIPTION
When there is some results from comicvin, the current logic will replace the book list with `nothing found`, since `showResults()` revoked previously has reset `ggData` or `dbData` to `0`.