### PR TITLE
[Kobo] Fix issue with covers

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -535,16 +535,16 @@ def get_current_bookmark_response(current_bookmark):
     return resp
 
 
-@kobo.route("/<book_uuid>/image.jpg")
+@kobo.route("/<book_uuid>/<width>/<height>/image.jpg")
 @requires_kobo_auth
-def HandleCoverImageRequest(book_uuid):
+def HandleCoverImageRequest(book_uuid, width, height):
     book_cover = helper.get_book_cover_with_uuid(
         book_uuid, use_generic_cover_on_failure=False
     )
     if not book_cover:
         if config.config_kobo_proxy:
             log.debug("Cover for unknown book: %s proxied to kobo" % book_uuid)
-            return redirect(get_store_url_for_current_request(), 307)
+            return redirect("https://kbimages1-a.akamaihd.net/{book_uuid}/{width}/{height}/false/image.jpg".format(book_uuid=book_uuid, width=width, height=height), 307)
         else:
             log.debug("Cover for unknown book: %s requested" % book_uuid)
             return redirect_or_proxy_request()
@@ -655,17 +655,22 @@ def HandleAuthRequest():
     return make_calibre_web_auth_response()
 
 
-def make_calibre_web_init_response(calibre_web_url):
-        resources = NATIVE_KOBO_RESOURCES(calibre_web_url)
-        response = make_response(jsonify({"Resources": resources}))
-        response.headers["x-kobo-apitoken"] = "e30="
-        return response
-
-
 @kobo.route("/v1/initialization")
 @requires_kobo_auth
 def HandleInitRequest():
     log.info('Init')
+
+    kobo_resources = None
+    if config.config_kobo_proxy:
+        try:
+            store_response = make_request_to_kobo_store()
+            store_response_json = store_response.json()
+            if "Resources" in store_response_json:
+                kobo_resources = store_response_json["Resources"]
+        except:
+            log.error("Failed to receive or parse response from Kobo's init endpoint. Falling back to un-proxied mode.")
+    if not kobo_resources:
+        kobo_resources = NATIVE_KOBO_RESOURCES()
 
     if not current_app.wsgi_app.is_proxied:
         log.debug('Kobo: Received unproxied request, changed request port to server port')
@@ -678,33 +683,42 @@ def HandleInitRequest():
             url_base=host,
             url_port=config.config_port
         )
+        kobo_resources["image_host"] = calibre_web_url
+        kobo_resources["image_url_quality_template"] = unquote(calibre_web_url + url_for("kobo.HandleCoverImageRequest",
+                                                                                         auth_token=kobo_auth.get_auth_token(),
+                                                                                         book_uuid="{ImageId}",
+                                                                                         width="{width}",
+                                                                                         height="{height}",
+                                                                                         _external=True))
+        kobo_resources["image_url_template"] = unquote(calibre_web_url + url_for("kobo.HandleCoverImageRequest",
+                                                                                 auth_token=kobo_auth.get_auth_token(),
+                                                                                 book_uuid="{ImageId}",
+                                                                                 width="{width}",
+                                                                                 height="{height}",
+                                                                                 _external=True))
     else:
-        calibre_web_url = url_for("web.index", _external=True).strip("/")
-
-    if config.config_kobo_proxy:
-        try:
-            store_response = make_request_to_kobo_store()
-
-            store_response_json = store_response.json()
-            if "Resources" in store_response_json:
-                kobo_resources = store_response_json["Resources"]
-                # calibre_web_url = url_for("web.index", _external=True).strip("/")
-                kobo_resources["image_host"] = calibre_web_url
-                kobo_resources["image_url_quality_template"] = unquote(calibre_web_url + url_for("kobo.HandleCoverImageRequest",
-                    auth_token = kobo_auth.get_auth_token(),
-                    book_uuid="{ImageId}"))
-                kobo_resources["image_url_template"] = unquote(calibre_web_url + url_for("kobo.HandleCoverImageRequest",
-                    auth_token = kobo_auth.get_auth_token(),
-                    book_uuid="{ImageId}"))
-
-            return make_response(store_response_json, store_response.status_code)
-        except:
-            log.error("Failed to receive or parse response from Kobo's init endpoint. Falling back to un-proxied mode.")
-
-    return make_calibre_web_init_response(calibre_web_url)
+        kobo_resources["image_host"] = url_for("web.index", _external=True).strip("/")
+        kobo_resources["image_url_quality_template"] = unquote(url_for("kobo.HandleCoverImageRequest",
+                                                                       auth_token=kobo_auth.get_auth_token(),
+                                                                       book_uuid="{ImageId}",
+                                                                       width="{width}",
+                                                                       height="{height}",
+                                                                       _external=True))
+        kobo_resources["image_url_template"] = unquote(url_for("kobo.HandleCoverImageRequest",
+                                                               auth_token=kobo_auth.get_auth_token(),
+                                                               book_uuid="{ImageId}",
+                                                               width="{width}",
+                                                               height="{height}",
+                                                               _external=True))
 
 
-def NATIVE_KOBO_RESOURCES(calibre_web_url):
+    response = make_response(jsonify({"Resources": kobo_resources}))
+    response.headers["x-kobo-apitoken"] = "e30="
+
+    return response
+
+
+def NATIVE_KOBO_RESOURCES():
     return {
         "account_page": "https://secure.kobobooks.com/profile",
         "account_page_rakuten": "https://my.rakuten.co.jp/",
@@ -755,13 +769,6 @@ def NATIVE_KOBO_RESOURCES(calibre_web_url):
         "giftcard_epd_redeem_url": "https://www.kobo.com/{storefront}/{language}/redeem-ereader",
         "giftcard_redeem_url": "https://www.kobo.com/{storefront}/{language}/redeem",
         "help_page": "http://www.kobo.com/help",
-        "image_host": calibre_web_url,
-        "image_url_quality_template": unquote(calibre_web_url + url_for("kobo.HandleCoverImageRequest",
-                auth_token = kobo_auth.get_auth_token(),
-                book_uuid="{ImageId}")),
-        "image_url_template":  unquote(calibre_web_url + url_for("kobo.HandleCoverImageRequest",
-                auth_token = kobo_auth.get_auth_token(),
-                book_uuid="{ImageId}")),
         "kobo_audiobooks_enabled": "False",
         "kobo_audiobooks_orange_deal_enabled": "False",
         "kobo_audiobooks_subscriptions_enabled": "False",


### PR DESCRIPTION
- The image_url_template and image_url_quality_template do not resolve correctly for me when wsgi_app.is_proxied is true. I serve the library under https://<ip>/calibre, and the image_url_template would end up as <ip>/calibre/calibre/etc.
- We weren't generating a request to the correct endpoint when redirecting cover requests to the official Kobo store.