### PR TITLE
Fix opds format errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ settings.yaml
 gdrive_credentials
 client_secrets.json
 
+.vscode/settings.json
+.vscode/launch.json

--- a/cps/templates/feed.xml
+++ b/cps/templates/feed.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom" xmlns:dcterms="http://purl.org/dc/terms/">
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/terms/">
   <id>urn:uuid:2853dacf-ed79-42f5-8e8a-a7bb3d1ae6a2</id>
   <updated>{{ current_time }}</updated>
   <link rel="self"
@@ -49,17 +49,23 @@
       </author>
     {% endif %}
     {% if entry.publishers.__len__() > 0 %}
-      <publisher>
+      <dc:publisher>
         <name>{{entry.publishers[0].name}}</name>
-      </publisher>
+      </dc:publisher>
+    {% endif %}
+    {% if entry.pubdate %}
+      <dc:issued>{{entry.pubdate}}</dc:issued>
     {% endif %}
     {% for lang in entry.languages %}
-      <dcterms:language>{{lang.lang_code}}</dcterms:language>
+      <dc:language>{{lang.lang_code}}</dc:language>
     {% endfor %}
     {% for tag in entry.tags %}
     <category scheme="http://www.bisg.org/standards/bisac_subject/index.html"
               term="{{tag.name}}"
               label="{{tag.name}}"/>
+    {% endfor %}
+    {% for identifier in entry.identifiers %}
+    <dc:identifier>{{identifier.val}}</dc:identifier>
     {% endfor %}
     {% if entry.comments[0] %}<summary>{{entry.comments[0].text|striptags}}</summary>{% endif %}
     {% if entry.has_cover %}
@@ -68,7 +74,7 @@
     {% endif %}
     {% for format in entry.data %}
     <link rel="http://opds-spec.org/acquisition" href="{{ url_for('opds.opds_download_link', book_id=entry.id, book_format=format.format|lower)}}"
-          length="{{format.uncompressed_size}}" mtime="{{entry.atom_timestamp}}" type="{{format.format|lower|mimetype}}"/>
+          length="{{format.uncompressed_size}}" type="{{format.format|lower|mimetype}}"/>
     {% endfor %}
   </entry>
   {% endfor %}

--- a/cps/templates/index.xml
+++ b/cps/templates/index.xml
@@ -15,28 +15,28 @@
   </author>
   <entry>
     <title>{{_('Hot Books')}}</title>
-    <link href="{{url_for('opds.feed_hot')}}" type="application/atom+xml;profile=opds-catalog"/>
+    <link href="{{url_for('opds.feed_hot')}}" type="application/atom+xml;profile=opds-catalog;kind=acquisition"/>
     <id>{{url_for('opds.feed_hot')}}</id>
     <updated>{{ current_time }}</updated>
     <content type="text">{{_('Popular publications from this catalog based on Downloads.')}}</content>
   </entry>
   <entry>
     <title>{{_('Top Rated Books')}}</title>
-    <link href="{{url_for('opds.feed_best_rated')}}" type="application/atom+xml;profile=opds-catalog"/>
+    <link href="{{url_for('opds.feed_best_rated')}}" type="application/atom+xml;profile=opds-catalog;kind=acquisition"/>
     <id>{{url_for('opds.feed_best_rated')}}</id>
     <updated>{{ current_time }}</updated>
     <content type="text">{{_('Popular publications from this catalog based on Rating.')}}</content>
   </entry>
   <entry>
     <title>{{_('Recently added Books')}}</title>
-    <link href="{{url_for('opds.feed_new')}}" type="application/atom+xml;profile=opds-catalog"/>
+    <link href="{{url_for('opds.feed_new')}}" type="application/atom+xml;profile=opds-catalog;kind=acquisition"/>
     <id>{{url_for('opds.feed_new')}}</id>
     <updated>{{ current_time }}</updated>
     <content type="text">{{_('The latest Books')}}</content>
   </entry>
   <entry>
     <title>{{_('Random Books')}}</title>
-    <link href="{{url_for('opds.feed_discover')}}" type="application/atom+xml;profile=opds-catalog"/>
+    <link href="{{url_for('opds.feed_discover')}}" type="application/atom+xml;profile=opds-catalog;kind=acquisition"/>
     <id>{{url_for('opds.feed_discover')}}</id>
     <updated>{{ current_time }}</updated>
     <content type="text">{{_('Show Random Books')}}</content>
@@ -44,57 +44,57 @@
   {% if not current_user.is_anonymous %}
   <entry>
     <title>{{_('Read Books')}}</title>
-    <link href="{{url_for('opds.feed_read_books')}}" type="application/atom+xml;profile=opds-catalog"/>
+    <link href="{{url_for('opds.feed_read_books')}}" type="application/atom+xml;profile=opds-catalog;kind=acquisition"/>
     <id>{{url_for('opds.feed_read_books')}}</id>
     <updated>{{ current_time }}</updated>
-    <content type="text">{{_('Read Books')}}</content>
+    <content type="text">{{_('Show Read Books')}}</content>
   </entry>
   <entry>
     <title>{{_('Unread Books')}}</title>
-    <link href="{{url_for('opds.feed_unread_books')}}" type="application/atom+xml;profile=opds-catalog"/>
+    <link href="{{url_for('opds.feed_unread_books')}}" type="application/atom+xml;profile=opds-catalog;kind=acquisition"/>
     <id>{{url_for('opds.feed_unread_books')}}</id>
     <updated>{{ current_time }}</updated>
-    <content type="text">{{_('Unread Books')}}</content>
+    <content type="text">{{_('Show Unread Books')}}</content>
   </entry>
   {% endif %}
   <entry>
     <title>{{_('Authors')}}</title>
-    <link href="{{url_for('opds.feed_authorindex')}}" type="application/atom+xml;profile=opds-catalog"/>
+    <link href="{{url_for('opds.feed_authorindex')}}" type="application/atom+xml;profile=opds-catalog;kind=acquisition"/>
     <id>{{url_for('opds.feed_authorindex')}}</id>
     <updated>{{ current_time }}</updated>
     <content type="text">{{_('Books ordered by Author')}}</content>
   </entry>
   <entry>
     <title>{{_('Publishers')}}</title>
-    <link href="{{url_for('opds.feed_publisherindex')}}" type="application/atom+xml;profile=opds-catalog"/>
+    <link href="{{url_for('opds.feed_publisherindex')}}" type="application/atom+xml;profile=opds-catalog;kind=acquisition"/>
     <id>{{url_for('opds.feed_publisherindex')}}</id>
     <updated>{{ current_time }}</updated>
     <content type="text">{{_('Books ordered by publisher')}}</content>
   </entry>
   <entry>
     <title>{{_('Categories')}}</title>
-    <link href="{{url_for('opds.feed_categoryindex')}}" type="application/atom+xml;profile=opds-catalog"/>
+    <link href="{{url_for('opds.feed_categoryindex')}}" type="application/atom+xml;profile=opds-catalog;kind=acquisition"/>
     <id>{{url_for('opds.feed_categoryindex')}}</id>
     <updated>{{ current_time }}</updated>
     <content type="text">{{_('Books ordered by category')}}</content>
   </entry>
   <entry>
     <title>{{_('Series')}}</title>
-    <link href="{{url_for('opds.feed_seriesindex')}}" type="application/atom+xml;profile=opds-catalog"/>
+    <link href="{{url_for('opds.feed_seriesindex')}}" type="application/atom+xml;profile=opds-catalog;kind=acquisition"/>
     <id>{{url_for('opds.feed_seriesindex')}}</id>
     <updated>{{ current_time }}</updated>
     <content type="text">{{_('Books ordered by series')}}</content>
   </entry>
   <entry>
     <title>{{_('Languages')}}</title>
-    <link href="{{url_for('opds.feed_languagesindex')}}" type="application/atom+xml;profile=opds-catalog"/>
+    <link href="{{url_for('opds.feed_languagesindex')}}" type="application/atom+xml;profile=opds-catalog;kind=acquisition"/>
     <id>{{url_for('opds.feed_languagesindex')}}</id>
     <updated>{{ current_time }}</updated>
     <content type="text">{{_('Books ordered by Languages')}}</content>
   </entry>
   <entry>
     <title>{{_('Ratings')}}</title>
-    <link href="{{url_for('opds.feed_ratingindex')}}" type="application/atom+xml;profile=opds-catalog"/>
+    <link href="{{url_for('opds.feed_ratingindex')}}" type="application/atom+xml;profile=opds-catalog;kind=acquisition"/>
     <id>{{url_for('opds.feed_ratingindex')}}</id>
     <updated>{{ current_time }}</updated>
     <content type="text">{{_('Books ordered by Rating')}}</content>
@@ -102,14 +102,14 @@
 
   <entry>
     <title>{{_('File formats')}}</title>
-    <link href="{{url_for('opds.feed_formatindex')}}" type="application/atom+xml;profile=opds-catalog"/>
+    <link href="{{url_for('opds.feed_formatindex')}}" type="application/atom+xml;profile=opds-catalog;kind=navigation"/>
     <id>{{url_for('opds.feed_formatindex')}}</id>
     <updated>{{ current_time }}</updated>
     <content type="text">{{_('Books ordered by file formats')}}</content>
   </entry>
   <entry>
     <title>{{_('Shelves')}}</title>
-    <link  href="{{url_for('opds.feed_shelfindex')}}" type="application/atom+xml;profile=opds-catalog"/>
+    <link  href="{{url_for('opds.feed_shelfindex')}}" type="application/atom+xml;profile=opds-catalog;kind=navigation"/>
     <id>{{url_for('opds.feed_shelfindex')}}</id>
     <updated>{{ current_time }}</updated>
     <content type="text">{{_('Books organized in shelves')}}</content>

--- a/cps/translations/cs/LC_MESSAGES/messages.po
+++ b/cps/translations/cs/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Calibre-Web\n"
 "Report-Msgid-Bugs-To: https://github.com/janeczku/Calibre-Web\n"
-"POT-Creation-Date: 2020-04-03 19:49+0200\n"
+"POT-Creation-Date: 2020-04-08 23:10+0800\n"
 "PO-Revision-Date: 2020-01-08 11:37+0000\n"
 "Last-Translator: Lukas Heroudek <lukas.heroudek@gmail.com>\n"
 "Language: cs_CZ\n"
@@ -272,8 +272,12 @@ msgid "File %(filename)s could not saved to temp dir"
 msgstr "Soubor %(filename)s nemohl být uložen do dočasného adresáře"
 
 #: cps/editbooks.py:598
-msgid "Uploaded book probably exists in the library, consider to change before upload new: "
-msgstr "Nahraná kniha pravděpodobně existuje v knihovně, zvažte prosím změnu před nahráním nové: "
+msgid ""
+"Uploaded book probably exists in the library, consider to change before "
+"upload new: "
+msgstr ""
+"Nahraná kniha pravděpodobně existuje v knihovně, zvažte prosím změnu před"
+" nahráním nové: "
 
 #: cps/editbooks.py:613
 #, python-format
@@ -305,12 +309,20 @@ msgid "There was an error converting this book: %(res)s"
 msgstr "Při převodu této knihy došlo k chybě: %(res)s"
 
 #: cps/gdrive.py:61
-msgid "Google Drive setup not completed, try to deactivate and activate Google Drive again"
-msgstr "Google Drive nastavení nebylo dokončeno, zkuste  znovu deaktivovat a aktivovat Google Drive"
+msgid ""
+"Google Drive setup not completed, try to deactivate and activate Google "
+"Drive again"
+msgstr ""
+"Google Drive nastavení nebylo dokončeno, zkuste  znovu deaktivovat a "
+"aktivovat Google Drive"
 
 #: cps/gdrive.py:103
-msgid "Callback domain is not verified, please follow steps to verify domain in google developer console"
-msgstr "Doména zpětného volání není ověřena, postupujte podle pokynů k ověření domény v konzole pro vývojáře google"
+msgid ""
+"Callback domain is not verified, please follow steps to verify domain in "
+"google developer console"
+msgstr ""
+"Doména zpětného volání není ověřena, postupujte podle pokynů k ověření "
+"domény v konzole pro vývojáře google"
 
 #: cps/helper.py:80
 #, python-format
@@ -386,7 +398,9 @@ msgstr "Přejmenovat autora z: '%(src)s' na '%(dest)s' selhalo chybou: %(error)s
 #: cps/helper.py:346
 #, python-format
 msgid "Rename file in path '%(src)s' to '%(dest)s' failed with error: %(error)s"
-msgstr "Přejmenování souboru v cestě '%(src)s' na '%(dest)s' selhalo  chybou: %(error)s"
+msgstr ""
+"Přejmenování souboru v cestě '%(src)s' na '%(dest)s' selhalo  chybou: "
+"%(error)s"
 
 #: cps/helper.py:372 cps/helper.py:382 cps/helper.py:390
 #, python-format
@@ -455,7 +469,9 @@ msgid "Unknown Task: "
 msgstr "Neznámá úloha:"
 
 #: cps/kobo_auth.py:127
-msgid "PLease access calibre-web from non localhost to get valid api_endpoint for kobo device"
+msgid ""
+"PLease access calibre-web from non localhost to get valid api_endpoint "
+"for kobo device"
 msgstr ""
 
 #: cps/kobo_auth.py:130 cps/kobo_auth.py:150
@@ -621,7 +637,7 @@ msgstr "Nedávno přidáné"
 msgid "Show recent books"
 msgstr "Zobrazit nedávné knihy"
 
-#: cps/templates/index.xml:17 cps/ub.py:59
+#: cps/ub.py:59
 msgid "Hot Books"
 msgstr "Žhavé knihy"
 
@@ -629,7 +645,7 @@ msgstr "Žhavé knihy"
 msgid "Show Hot Books"
 msgstr ""
 
-#: cps/templates/index.xml:24 cps/ub.py:63 cps/web.py:508
+#: cps/ub.py:63 cps/web.py:508
 msgid "Top Rated Books"
 msgstr ""
 
@@ -637,8 +653,7 @@ msgstr ""
 msgid "Show Top Rated Books"
 msgstr ""
 
-#: cps/templates/index.xml:46 cps/templates/index.xml:50 cps/ub.py:66
-#: cps/web.py:1005
+#: cps/ub.py:66 cps/web.py:1005
 msgid "Read Books"
 msgstr "Přečtené knihy"
 
@@ -646,8 +661,7 @@ msgstr "Přečtené knihy"
 msgid "Show read and unread"
 msgstr "Zobrazit prečtené a nepřečtené"
 
-#: cps/templates/index.xml:53 cps/templates/index.xml:57 cps/ub.py:70
-#: cps/web.py:1009
+#: cps/ub.py:70 cps/web.py:1009
 msgid "Unread Books"
 msgstr "Nepřečtené knihy"
 
@@ -663,7 +677,7 @@ msgstr "Objevte"
 msgid "Show random books"
 msgstr "Zobrazit náhodné knihy"
 
-#: cps/templates/index.xml:75 cps/ub.py:76 cps/web.py:787
+#: cps/ub.py:76 cps/web.py:787
 msgid "Categories"
 msgstr "Kategorie"
 
@@ -671,8 +685,8 @@ msgstr "Kategorie"
 msgid "Show category selection"
 msgstr "Zobrazit výběr kategorie"
 
-#: cps/templates/book_edit.html:69 cps/templates/index.xml:82
-#: cps/templates/search_form.html:53 cps/ub.py:79 cps/web.py:715
+#: cps/templates/book_edit.html:69 cps/templates/search_form.html:53
+#: cps/ub.py:79 cps/web.py:715
 msgid "Series"
 msgstr "Série"
 
@@ -680,7 +694,7 @@ msgstr "Série"
 msgid "Show series selection"
 msgstr "Zobrazit  výběr sérií"
 
-#: cps/templates/index.xml:61 cps/ub.py:82
+#: cps/ub.py:82
 msgid "Authors"
 msgstr "Autoři"
 
@@ -688,7 +702,7 @@ msgstr "Autoři"
 msgid "Show author selection"
 msgstr "Zobrazit výběr autora"
 
-#: cps/templates/index.xml:68 cps/ub.py:86 cps/web.py:699
+#: cps/ub.py:86 cps/web.py:699
 msgid "Publishers"
 msgstr "Vydavatelé"
 
@@ -696,8 +710,7 @@ msgstr "Vydavatelé"
 msgid "Show publisher selection"
 msgstr "Zobrazit výběr vydavatele"
 
-#: cps/templates/index.xml:89 cps/templates/search_form.html:74 cps/ub.py:89
-#: cps/web.py:770
+#: cps/templates/search_form.html:74 cps/ub.py:89 cps/web.py:770
 msgid "Languages"
 msgstr "Jazyky"
 
@@ -705,7 +718,7 @@ msgstr "Jazyky"
 msgid "Show language selection"
 msgstr "Zobrazit výběr jazyka"
 
-#: cps/templates/index.xml:96 cps/ub.py:93
+#: cps/ub.py:93
 msgid "Ratings"
 msgstr "Hodnocení"
 
@@ -713,7 +726,7 @@ msgstr "Hodnocení"
 msgid "Show ratings selection"
 msgstr "Zobrazit výběr hodnocení"
 
-#: cps/templates/index.xml:104 cps/ub.py:96
+#: cps/ub.py:96
 msgid "File formats"
 msgstr "Formáty souborů"
 
@@ -730,8 +743,12 @@ msgid "No update available. You already have the latest version installed"
 msgstr "Aktualizace není k dispozici. Máte nainstalovanou nejnovější verzi"
 
 #: cps/updater.py:333
-msgid "A new update is available. Click on the button below to update to the latest version."
-msgstr "Nová aktualizace k dispozici. Klepnutím na tlačítko níže aktualizujte na nejnovější verzi."
+msgid ""
+"A new update is available. Click on the button below to update to the "
+"latest version."
+msgstr ""
+"Nová aktualizace k dispozici. Klepnutím na tlačítko níže aktualizujte na "
+"nejnovější verzi."
 
 #: cps/updater.py:385
 msgid "Could not fetch update information"
@@ -743,8 +760,12 @@ msgstr "Nejsou k dispozici žádné informace o verzi"
 
 #: cps/updater.py:456 cps/updater.py:467 cps/updater.py:486
 #, python-format
-msgid "A new update is available. Click on the button below to update to version: %(version)s"
-msgstr "Nová aktualizace k dispozici. Klepnutím na tlačítko níže aktualizujte na verzi: %(version)s"
+msgid ""
+"A new update is available. Click on the button below to update to "
+"version: %(version)s"
+msgstr ""
+"Nová aktualizace k dispozici. Klepnutím na tlačítko níže aktualizujte na "
+"verzi: %(version)s"
 
 #: cps/updater.py:477
 msgid "Click on the button below to update to the latest stable version."
@@ -767,7 +788,9 @@ msgid "Hot Books (Most Downloaded)"
 msgstr ""
 
 #: cps/web.py:580
-msgid "Oops! Selected book title is unavailable. File does not exist or is not accessible"
+msgid ""
+"Oops! Selected book title is unavailable. File does not exist or is not "
+"accessible"
 msgstr ""
 
 #: cps/web.py:593
@@ -817,9 +840,9 @@ msgstr "Seznam formátů"
 msgid "Tasks"
 msgstr "Úlohy"
 
-#: cps/templates/book_edit.html:212 cps/templates/feed.xml:33
-#: cps/templates/layout.html:44 cps/templates/layout.html:47
-#: cps/templates/search_form.html:170 cps/web.py:821 cps/web.py:823
+#: cps/templates/book_edit.html:212 cps/templates/layout.html:44
+#: cps/templates/layout.html:47 cps/templates/search_form.html:170
+#: cps/web.py:821 cps/web.py:823
 msgid "Search"
 msgstr "Hledat"
 
@@ -958,189 +981,189 @@ msgstr "Převaděč eknih selhal: %(error)s"
 msgid "Kindlegen failed with Error %(error)s. Message: %(message)s"
 msgstr "Kindlegen selhal chybou %(error)s. Zpráva: %(message)s"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html:8
 msgid "Users"
 msgstr "Seznam uživatelů"
 
-#: cps/templates/admin.html:12 cps/templates/login.html:8
+#: cps/templates/admin.html:11 cps/templates/login.html:8
 #: cps/templates/login.html:9 cps/templates/register.html:7
 #: cps/templates/user_edit.html:8
 msgid "Username"
 msgstr "Přezdívka"
 
-#: cps/templates/admin.html:13 cps/templates/register.html:11
+#: cps/templates/admin.html:12 cps/templates/register.html:11
 #: cps/templates/user_edit.html:13
 msgid "E-mail Address"
 msgstr "E-mail"
 
-#: cps/templates/admin.html:14 cps/templates/user_edit.html:26
+#: cps/templates/admin.html:13 cps/templates/user_edit.html:26
 msgid "Send to Kindle E-mail Address"
 msgstr "Kindle"
 
-#: cps/templates/admin.html:15
+#: cps/templates/admin.html:14
 msgid "Downloads"
 msgstr "Staženo"
 
-#: cps/templates/admin.html:16 cps/templates/layout.html:76
+#: cps/templates/admin.html:15 cps/templates/layout.html:76
 msgid "Admin"
 msgstr "Správce"
 
-#: cps/templates/admin.html:17 cps/templates/detail.html:18
+#: cps/templates/admin.html:16 cps/templates/detail.html:18
 #: cps/templates/detail.html:27 cps/templates/shelf.html:6
 #: cps/templates/shelfdown.html:62
 msgid "Download"
 msgstr "Stahovat"
 
-#: cps/templates/admin.html:18
+#: cps/templates/admin.html:17
 msgid "View Books"
 msgstr ""
 
-#: cps/templates/admin.html:19 cps/templates/layout.html:65
+#: cps/templates/admin.html:18 cps/templates/layout.html:65
 msgid "Upload"
 msgstr "Nahrávat"
 
-#: cps/templates/admin.html:20
+#: cps/templates/admin.html:19
 msgid "Edit"
 msgstr "Upravovat"
 
-#: cps/templates/admin.html:38
+#: cps/templates/admin.html:37
 msgid "Add New User"
 msgstr ""
 
-#: cps/templates/admin.html:44
+#: cps/templates/admin.html:43
 msgid "E-mail Server Settings"
 msgstr "Nastavení e-mailového serveru SMTP"
 
-#: cps/templates/admin.html:47 cps/templates/email_edit.html:11
+#: cps/templates/admin.html:46 cps/templates/email_edit.html:11
 msgid "SMTP Hostname"
 msgstr "SMTP hostitel"
 
-#: cps/templates/admin.html:48 cps/templates/email_edit.html:15
+#: cps/templates/admin.html:47 cps/templates/email_edit.html:15
 msgid "SMTP Port"
 msgstr "SMTP port"
 
-#: cps/templates/admin.html:49 cps/templates/email_edit.html:19
+#: cps/templates/admin.html:48 cps/templates/email_edit.html:19
 msgid "Encryption"
 msgstr "SSL"
 
-#: cps/templates/admin.html:50 cps/templates/email_edit.html:27
+#: cps/templates/admin.html:49 cps/templates/email_edit.html:27
 msgid "SMTP Login"
 msgstr "SMTP přihlášení"
 
-#: cps/templates/admin.html:51 cps/templates/email_edit.html:35
+#: cps/templates/admin.html:50 cps/templates/email_edit.html:35
 msgid "From E-mail"
 msgstr "Z e-mailu"
 
-#: cps/templates/admin.html:61
+#: cps/templates/admin.html:60
 msgid "Edit E-mail Server Settings"
 msgstr "Změnit SMTP nastavení"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html:66
 msgid "Configuration"
 msgstr "Konfigurace"
 
-#: cps/templates/admin.html:70
+#: cps/templates/admin.html:69
 msgid "Calibre Database Directory"
 msgstr "Calibre DB adresář"
 
-#: cps/templates/admin.html:74 cps/templates/config_edit.html:122
+#: cps/templates/admin.html:73 cps/templates/config_edit.html:122
 msgid "Log Level"
 msgstr "Úroveň logu"
 
-#: cps/templates/admin.html:78
+#: cps/templates/admin.html:77
 msgid "Port"
 msgstr "Port"
 
-#: cps/templates/admin.html:84 cps/templates/config_view_edit.html:27
+#: cps/templates/admin.html:83 cps/templates/config_view_edit.html:27
 msgid "Books per Page"
 msgstr "Knihy na stránku"
 
-#: cps/templates/admin.html:88
+#: cps/templates/admin.html:87
 msgid "Uploads"
 msgstr "Nahrávání"
 
-#: cps/templates/admin.html:92
+#: cps/templates/admin.html:91
 msgid "Anonymous Browsing"
 msgstr "Anonymní prohlížení"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html:95
 msgid "Public Registration"
 msgstr "Veřejná registrace"
 
-#: cps/templates/admin.html:100
+#: cps/templates/admin.html:99
 msgid "Magic Link Remote Login"
 msgstr "Vzdálené přihlášení"
 
-#: cps/templates/admin.html:104
+#: cps/templates/admin.html:103
 msgid "Reverse Proxy Login"
 msgstr "Reverzní proxy přihlášení"
 
-#: cps/templates/admin.html:109
+#: cps/templates/admin.html:108
 msgid "Reverse proxy header name"
 msgstr "Název záhlaví reverzního prixy"
 
-#: cps/templates/admin.html:114
+#: cps/templates/admin.html:113
 msgid "Edit Basic Configuration"
 msgstr ""
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html:114
 msgid "Edit UI Configuration"
 msgstr ""
 
-#: cps/templates/admin.html:121
+#: cps/templates/admin.html:120
 msgid "Administration"
 msgstr "Správa"
 
-#: cps/templates/admin.html:122
+#: cps/templates/admin.html:121
 msgid "View Logs"
 msgstr "Zobrazit log"
 
-#: cps/templates/admin.html:123
+#: cps/templates/admin.html:122
 msgid "Reconnect Calibre Database"
 msgstr "Znovupřipojení ke Calibre DB"
 
-#: cps/templates/admin.html:124
+#: cps/templates/admin.html:123
 msgid "Restart"
 msgstr "Restartovat Calibre-Web"
 
-#: cps/templates/admin.html:125
+#: cps/templates/admin.html:124
 msgid "Shutdown"
 msgstr "Zastavit Calibre-Web"
 
-#: cps/templates/admin.html:131
+#: cps/templates/admin.html:130
 msgid "Update"
 msgstr "Aktualizovat"
 
-#: cps/templates/admin.html:135
+#: cps/templates/admin.html:134
 msgid "Version"
 msgstr "Verze"
 
-#: cps/templates/admin.html:136
+#: cps/templates/admin.html:135
 msgid "Details"
 msgstr "Detaily"
 
-#: cps/templates/admin.html:142
+#: cps/templates/admin.html:141
 msgid "Current version"
 msgstr "Současná verze"
 
-#: cps/templates/admin.html:148
+#: cps/templates/admin.html:147
 msgid "Check for Update"
 msgstr "Zkontrolovat aktualizace"
 
-#: cps/templates/admin.html:149
+#: cps/templates/admin.html:148
 msgid "Perform Update"
 msgstr "Provést aktualizaci"
 
-#: cps/templates/admin.html:161
+#: cps/templates/admin.html:160
 msgid "Are you sure you want to restart?"
 msgstr "Opravdu chcete restartovat Calibre-Web?"
 
-#: cps/templates/admin.html:166 cps/templates/admin.html:180
-#: cps/templates/admin.html:200 cps/templates/shelf.html:72
+#: cps/templates/admin.html:165 cps/templates/admin.html:179
+#: cps/templates/admin.html:199 cps/templates/shelf.html:72
 msgid "OK"
 msgstr "OK"
 
-#: cps/templates/admin.html:167 cps/templates/admin.html:181
+#: cps/templates/admin.html:166 cps/templates/admin.html:180
 #: cps/templates/book_edit.html:172 cps/templates/book_edit.html:194
 #: cps/templates/config_edit.html:346 cps/templates/config_view_edit.html:151
 #: cps/templates/email_edit.html:40 cps/templates/email_edit.html:92
@@ -1149,11 +1172,11 @@ msgstr "OK"
 msgid "Cancel"
 msgstr ""
 
-#: cps/templates/admin.html:179
+#: cps/templates/admin.html:178
 msgid "Are you sure you want to shutdown?"
 msgstr "Opravdu chcete zastavit Calibre-Web?"
 
-#: cps/templates/admin.html:191
+#: cps/templates/admin.html:190
 msgid "Updating, please do not reload this page"
 msgstr "Probíhá aktualizace, prosím nenačítejte stránku znovu"
 
@@ -1242,8 +1265,12 @@ msgid "Rating"
 msgstr "Hodnocení"
 
 #: cps/templates/book_edit.html:81
-msgid "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
-msgstr "Adresa URL obalu (jpg, obal je stažen a uložen v databázi, pole je potom opět prázdné)"
+msgid ""
+"Fetch Cover from URL (JPEG - Image will be downloaded and stored in "
+"database)"
+msgstr ""
+"Adresa URL obalu (jpg, obal je stažen a uložen v databázi, pole je potom "
+"opět prázdné)"
 
 #: cps/templates/book_edit.html:85
 msgid "Upload Cover from Local Disk"
@@ -1776,15 +1803,6 @@ msgstr "Zakázané domény pro registraci"
 msgid "Are you sure you want to delete this domain?"
 msgstr "Opravdu chcete odstranit toto pravidlo domény?"
 
-#: cps/templates/feed.xml:21 cps/templates/layout.html:173
-msgid "Next"
-msgstr "Další"
-
-#: cps/templates/feed.xml:79 cps/templates/layout.html:136
-#: cps/templates/layout.html:140
-msgid "(Public)"
-msgstr ""
-
 #: cps/templates/generate_kobo_auth_url.html:5
 msgid "Open the .kobo/Kobo eReader.conf file in a text editor and add (or edit):"
 msgstr ""
@@ -1800,70 +1818,6 @@ msgstr "Zpět domů"
 #: cps/templates/index.html:64
 msgid "Group by series"
 msgstr "Seřadit podle serií"
-
-#: cps/templates/index.xml:6
-msgid "Start"
-msgstr "Start"
-
-#: cps/templates/index.xml:21
-msgid "Popular publications from this catalog based on Downloads."
-msgstr "Oblíbené publikace z tohoto katalogu založené na počtu stažení."
-
-#: cps/templates/index.xml:28
-msgid "Popular publications from this catalog based on Rating."
-msgstr "Oblíbené publikace z tohoto katalogu založené na hodnocení."
-
-#: cps/templates/index.xml:31
-msgid "Recently added Books"
-msgstr "Nedávno přidané knihy"
-
-#: cps/templates/index.xml:35
-msgid "The latest Books"
-msgstr "Nejnovější knihy"
-
-#: cps/templates/index.xml:38
-msgid "Random Books"
-msgstr "Náhodné knihy"
-
-#: cps/templates/index.xml:42 cps/templates/user_edit.html:80
-msgid "Show Random Books"
-msgstr "Zobrazit náhodné knihy"
-
-#: cps/templates/index.xml:65
-msgid "Books ordered by Author"
-msgstr "Knihy seřazené podle autora"
-
-#: cps/templates/index.xml:72
-msgid "Books ordered by publisher"
-msgstr "Knihy seřazené podle vydavatele"
-
-#: cps/templates/index.xml:79
-msgid "Books ordered by category"
-msgstr "Knihy seřazené podle kategorie"
-
-#: cps/templates/index.xml:86
-msgid "Books ordered by series"
-msgstr "Knihy seřazené podle série"
-
-#: cps/templates/index.xml:93
-msgid "Books ordered by Languages"
-msgstr "Knihy seřazené podle jazyků"
-
-#: cps/templates/index.xml:100
-msgid "Books ordered by Rating"
-msgstr ""
-
-#: cps/templates/index.xml:108
-msgid "Books ordered by file formats"
-msgstr "Knihy seřazené podle soboru formátů"
-
-#: cps/templates/index.xml:111 cps/templates/layout.html:134
-msgid "Shelves"
-msgstr ""
-
-#: cps/templates/index.xml:115
-msgid "Books organized in shelves"
-msgstr ""
 
 #: cps/templates/layout.html:28
 msgid "Home"
@@ -1915,6 +1869,14 @@ msgstr "prosím neobnovujte stránku"
 msgid "Browse"
 msgstr "Procházet"
 
+#: cps/templates/layout.html:134
+msgid "Shelves"
+msgstr ""
+
+#: cps/templates/layout.html:136 cps/templates/layout.html:140
+msgid "(Public)"
+msgstr ""
+
 #: cps/templates/layout.html:138
 msgid "Your Shelves"
 msgstr "Vaše police"
@@ -1926,6 +1888,10 @@ msgstr "O Calibre-Web"
 #: cps/templates/layout.html:158
 msgid "Previous"
 msgstr "Předchozí"
+
+#: cps/templates/layout.html:173
+msgid "Next"
+msgstr "Další"
 
 #: cps/templates/layout.html:185
 msgid "Book Details"
@@ -2308,6 +2274,10 @@ msgstr ""
 msgid "Create/View"
 msgstr ""
 
+#: cps/templates/user_edit.html:80
+msgid "Show Random Books"
+msgstr "Zobrazit náhodné knihy"
+
 #: cps/templates/user_edit.html:84
 msgid "Add allowed/Denied Custom Column Values"
 msgstr ""
@@ -2327,4 +2297,208 @@ msgstr ""
 #: cps/templates/user_edit.html:176
 msgid "Do you really want to delete the Kobo Token?"
 msgstr ""
+
+#: vendor/tornado/locale.py:285
+msgid "January"
+msgstr ""
+
+#: vendor/tornado/locale.py:286
+msgid "February"
+msgstr ""
+
+#: vendor/tornado/locale.py:287
+msgid "March"
+msgstr ""
+
+#: vendor/tornado/locale.py:288
+msgid "April"
+msgstr ""
+
+#: vendor/tornado/locale.py:289
+msgid "May"
+msgstr ""
+
+#: vendor/tornado/locale.py:290
+msgid "June"
+msgstr ""
+
+#: vendor/tornado/locale.py:291
+msgid "July"
+msgstr ""
+
+#: vendor/tornado/locale.py:292
+msgid "August"
+msgstr ""
+
+#: vendor/tornado/locale.py:293
+msgid "September"
+msgstr ""
+
+#: vendor/tornado/locale.py:294
+msgid "October"
+msgstr ""
+
+#: vendor/tornado/locale.py:295
+msgid "November"
+msgstr ""
+
+#: vendor/tornado/locale.py:296
+msgid "December"
+msgstr ""
+
+#: vendor/tornado/locale.py:299
+msgid "Monday"
+msgstr ""
+
+#: vendor/tornado/locale.py:300
+msgid "Tuesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:301
+msgid "Wednesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:302
+msgid "Thursday"
+msgstr ""
+
+#: vendor/tornado/locale.py:303
+msgid "Friday"
+msgstr ""
+
+#: vendor/tornado/locale.py:304
+msgid "Saturday"
+msgstr ""
+
+#: vendor/tornado/locale.py:305
+msgid "Sunday"
+msgstr ""
+
+#: vendor/tornado/locale.py:368
+msgid "1 second ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:374
+msgid "1 minute ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:379
+msgid "1 hour ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:382
+#, python-format
+msgid "%(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+msgid "yesterday"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+#, python-format
+msgid "yesterday at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:389 vendor/tornado/locale.py:442
+#, python-format
+msgid "%(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:391
+#, python-format
+msgid "%(month_name)s %(day)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:396
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:398
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:436
+#, python-format
+msgid "%(weekday)s, %(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:459
+#, python-format
+msgid "%(commas)s and %(last)s"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:68
+msgctxt "law"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:69
+msgctxt "good"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:71 vendor/tornado/test/locale_test.py:74
+msgctxt "organization"
+msgid "club"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:76 vendor/tornado/test/locale_test.py:77
+msgctxt "stick"
+msgid "club"
+msgstr ""
+
+#~ msgid "Start"
+#~ msgstr "Start"
+
+#~ msgid "Popular publications from this catalog based on Downloads."
+#~ msgstr "Oblíbené publikace z tohoto katalogu založené na počtu stažení."
+
+#~ msgid "Popular publications from this catalog based on Rating."
+#~ msgstr "Oblíbené publikace z tohoto katalogu založené na hodnocení."
+
+#~ msgid "Recently added Books"
+#~ msgstr "Nedávno přidané knihy"
+
+#~ msgid "The latest Books"
+#~ msgstr "Nejnovější knihy"
+
+#~ msgid "Random Books"
+#~ msgstr "Náhodné knihy"
+
+#~ msgid "Books ordered by Author"
+#~ msgstr "Knihy seřazené podle autora"
+
+#~ msgid "Books ordered by publisher"
+#~ msgstr "Knihy seřazené podle vydavatele"
+
+#~ msgid "Books ordered by category"
+#~ msgstr "Knihy seřazené podle kategorie"
+
+#~ msgid "Books ordered by series"
+#~ msgstr "Knihy seřazené podle série"
+
+#~ msgid "Books ordered by Languages"
+#~ msgstr "Knihy seřazené podle jazyků"
+
+#~ msgid "Books ordered by Rating"
+#~ msgstr ""
+
+#~ msgid "Books ordered by file formats"
+#~ msgstr "Knihy seřazené podle soboru formátů"
+
+#~ msgid "Books organized in shelves"
+#~ msgstr ""
 

--- a/cps/translations/de/LC_MESSAGES/messages.po
+++ b/cps/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Calibre-Web\n"
 "Report-Msgid-Bugs-To: https://github.com/janeczku/Calibre-Web\n"
-"POT-Creation-Date: 2020-04-03 19:49+0200\n"
+"POT-Creation-Date: 2020-04-08 23:10+0800\n"
 "PO-Revision-Date: 2020-04-03 19:49+0200\n"
 "Last-Translator: Ozzie Isaacs\n"
 "Language: de\n"
@@ -84,7 +84,9 @@ msgstr "E-Mail bezieht sich nicht auf eine gültige Domain"
 
 #: cps/admin.py:710 cps/admin.py:725
 msgid "Found an existing account for this e-mail address or nickname."
-msgstr "Es existiert bereits ein Account für diese E-Mailadresse oder diesen Benutzernamen."
+msgstr ""
+"Es existiert bereits ein Account für diese E-Mailadresse oder diesen "
+"Benutzernamen."
 
 #: cps/admin.py:721
 #, python-format
@@ -220,7 +222,9 @@ msgstr "Nicht konfiguriert"
 
 #: cps/editbooks.py:214 cps/editbooks.py:396
 msgid "Error opening eBook. File does not exist or file is not accessible"
-msgstr "Öffnen des Buchs fehlgeschlagen. Datei existiert nicht oder ist nicht zugänglich"
+msgstr ""
+"Öffnen des Buchs fehlgeschlagen. Datei existiert nicht oder ist nicht "
+"zugänglich"
 
 #: cps/editbooks.py:242
 msgid "edit metadata"
@@ -270,10 +274,14 @@ msgstr "Fehler beim Editieren des Buchs, Details im Logfile"
 #: cps/editbooks.py:581
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
-msgstr "Die Datei %(filename)s konnte nicht im temporären Ordner gespeichert werden"
+msgstr ""
+"Die Datei %(filename)s konnte nicht im temporären Ordner gespeichert "
+"werden"
 
 #: cps/editbooks.py:598
-msgid "Uploaded book probably exists in the library, consider to change before upload new: "
+msgid ""
+"Uploaded book probably exists in the library, consider to change before "
+"upload new: "
 msgstr "Das hochgeladene Buch existiert evtl. schon in der Bibliothek: "
 
 #: cps/editbooks.py:613
@@ -298,7 +306,9 @@ msgstr "Quell- oder Zielformat für Konvertierung fehlt"
 #: cps/editbooks.py:746
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
-msgstr "Buch wurde erfolgreich für die Konvertierung nach %(book_format)s eingereiht"
+msgstr ""
+"Buch wurde erfolgreich für die Konvertierung nach %(book_format)s "
+"eingereiht"
 
 #: cps/editbooks.py:750
 #, python-format
@@ -306,12 +316,20 @@ msgid "There was an error converting this book: %(res)s"
 msgstr "Es trat ein Fehler beim Konvertieren des Buches auf: %(res)s"
 
 #: cps/gdrive.py:61
-msgid "Google Drive setup not completed, try to deactivate and activate Google Drive again"
-msgstr "Google Drive Setup is nicht komplett, bitte versuche Google Drive zu deaktivieren und aktiviere es anschließend erneut"
+msgid ""
+"Google Drive setup not completed, try to deactivate and activate Google "
+"Drive again"
+msgstr ""
+"Google Drive Setup is nicht komplett, bitte versuche Google Drive zu "
+"deaktivieren und aktiviere es anschließend erneut"
 
 #: cps/gdrive.py:103
-msgid "Callback domain is not verified, please follow steps to verify domain in google developer console"
-msgstr "Callback Domain ist nicht verifiziert, bitte Domain in der Google Developer Console verifizieren"
+msgid ""
+"Callback domain is not verified, please follow steps to verify domain in "
+"google developer console"
+msgstr ""
+"Callback Domain ist nicht verifiziert, bitte Domain in der Google "
+"Developer Console verifizieren"
 
 #: cps/helper.py:80
 #, python-format
@@ -372,7 +390,9 @@ msgstr "E-Mail: %(book)s"
 
 #: cps/helper.py:215
 msgid "The requested file could not be read. Maybe wrong permissions?"
-msgstr "Die angeforderte Datei konnte nicht gelesen werden. Evtl. falsche Zugriffsrechte?"
+msgstr ""
+"Die angeforderte Datei konnte nicht gelesen werden. Evtl. falsche "
+"Zugriffsrechte?"
 
 #: cps/helper.py:322
 #, python-format
@@ -387,7 +407,9 @@ msgstr "Umbenennen des Authors '%(src)s' zu '%(dest)s' schlug fehl: %(error)s"
 #: cps/helper.py:346
 #, python-format
 msgid "Rename file in path '%(src)s' to '%(dest)s' failed with error: %(error)s"
-msgstr "Umbenennen der Datei im Pfad '%(src)s' nach '%(dest)s' ist fehlgeschlagen: %(error)s"
+msgstr ""
+"Umbenennen der Datei im Pfad '%(src)s' nach '%(dest)s' ist "
+"fehlgeschlagen: %(error)s"
 
 #: cps/helper.py:372 cps/helper.py:382 cps/helper.py:390
 #, python-format
@@ -456,8 +478,12 @@ msgid "Unknown Task: "
 msgstr "Unbekannte Aufgabe: "
 
 #: cps/kobo_auth.py:127
-msgid "PLease access calibre-web from non localhost to get valid api_endpoint for kobo device"
-msgstr "Bitte nicht von \"localhost\" auf Calibre-Web zugreifen, um einen gültigen  api_endpoint für Kobo Geräte zu erhalten"
+msgid ""
+"PLease access calibre-web from non localhost to get valid api_endpoint "
+"for kobo device"
+msgstr ""
+"Bitte nicht von \"localhost\" auf Calibre-Web zugreifen, um einen "
+"gültigen  api_endpoint für Kobo Geräte zu erhalten"
 
 #: cps/kobo_auth.py:130 cps/kobo_auth.py:150
 msgid "Kobo Setup"
@@ -514,7 +540,9 @@ msgstr "Ungültiges Bücherregal angegeben"
 #: cps/shelf.py:54
 #, python-format
 msgid "Sorry you are not allowed to add a book to the the shelf: %(shelfname)s"
-msgstr "Du hast keine Berechtigung, ein Buch zu diesem Bücherregal hinzuzufügen: %(shelfname)s"
+msgstr ""
+"Du hast keine Berechtigung, ein Buch zu diesem Bücherregal hinzuzufügen: "
+"%(shelfname)s"
 
 #: cps/shelf.py:62
 msgid "You are not allowed to edit public shelves"
@@ -562,7 +590,9 @@ msgstr "Das Buch wurde aus dem Bücherregal: %(sname)s entfernt"
 #: cps/shelf.py:190
 #, python-format
 msgid "Sorry you are not allowed to remove a book from this shelf: %(sname)s"
-msgstr "Dir ist es nicht erlaubt, Bücher aus dem Bücherregal %(sname)s zu entfernen"
+msgstr ""
+"Dir ist es nicht erlaubt, Bücher aus dem Bücherregal %(sname)s zu "
+"entfernen"
 
 #: cps/shelf.py:215 cps/shelf.py:252
 #, python-format
@@ -603,7 +633,9 @@ msgstr "Bücherregal: '%(name)s'"
 
 #: cps/shelf.py:330
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
-msgstr "Fehler beim Öffnen des Bücherregals. Bücherregal exisitert nicht oder ist nicht zugänglich"
+msgstr ""
+"Fehler beim Öffnen des Bücherregals. Bücherregal exisitert nicht oder ist"
+" nicht zugänglich"
 
 #: cps/shelf.py:368
 msgid "Hidden Book"
@@ -622,7 +654,7 @@ msgstr "Kürzlich hinzugefügt"
 msgid "Show recent books"
 msgstr "Zeige kürzlich hinzugefügte Bücher"
 
-#: cps/templates/index.xml:17 cps/ub.py:59
+#: cps/ub.py:59
 msgid "Hot Books"
 msgstr "Beliebte Bücher"
 
@@ -630,7 +662,7 @@ msgstr "Beliebte Bücher"
 msgid "Show Hot Books"
 msgstr "Zeige beliebte Bücher"
 
-#: cps/templates/index.xml:24 cps/ub.py:63 cps/web.py:508
+#: cps/ub.py:63 cps/web.py:508
 msgid "Top Rated Books"
 msgstr "Best bewertete Bücher"
 
@@ -638,8 +670,7 @@ msgstr "Best bewertete Bücher"
 msgid "Show Top Rated Books"
 msgstr "Bestbewertete Bücher anzeigen"
 
-#: cps/templates/index.xml:46 cps/templates/index.xml:50 cps/ub.py:66
-#: cps/web.py:1005
+#: cps/ub.py:66 cps/web.py:1005
 msgid "Read Books"
 msgstr "Gelesene Bücher"
 
@@ -647,8 +678,7 @@ msgstr "Gelesene Bücher"
 msgid "Show read and unread"
 msgstr "Zeige gelesene/ungelesene Bücher"
 
-#: cps/templates/index.xml:53 cps/templates/index.xml:57 cps/ub.py:70
-#: cps/web.py:1009
+#: cps/ub.py:70 cps/web.py:1009
 msgid "Unread Books"
 msgstr "Ungelesene Bücher"
 
@@ -664,7 +694,7 @@ msgstr "Entdecke"
 msgid "Show random books"
 msgstr "Zeige zufällige Bücher"
 
-#: cps/templates/index.xml:75 cps/ub.py:76 cps/web.py:787
+#: cps/ub.py:76 cps/web.py:787
 msgid "Categories"
 msgstr "Kategorien"
 
@@ -672,8 +702,8 @@ msgstr "Kategorien"
 msgid "Show category selection"
 msgstr "Zeige Kategorienauswahl"
 
-#: cps/templates/book_edit.html:69 cps/templates/index.xml:82
-#: cps/templates/search_form.html:53 cps/ub.py:79 cps/web.py:715
+#: cps/templates/book_edit.html:69 cps/templates/search_form.html:53
+#: cps/ub.py:79 cps/web.py:715
 msgid "Series"
 msgstr "Serien"
 
@@ -681,7 +711,7 @@ msgstr "Serien"
 msgid "Show series selection"
 msgstr "Zeige Serienauswahl"
 
-#: cps/templates/index.xml:61 cps/ub.py:82
+#: cps/ub.py:82
 msgid "Authors"
 msgstr "Autoren"
 
@@ -689,7 +719,7 @@ msgstr "Autoren"
 msgid "Show author selection"
 msgstr "Zeige Autorenauswahl"
 
-#: cps/templates/index.xml:68 cps/ub.py:86 cps/web.py:699
+#: cps/ub.py:86 cps/web.py:699
 msgid "Publishers"
 msgstr "Verleger"
 
@@ -697,8 +727,7 @@ msgstr "Verleger"
 msgid "Show publisher selection"
 msgstr "Zeige Verlegerauswahl"
 
-#: cps/templates/index.xml:89 cps/templates/search_form.html:74 cps/ub.py:89
-#: cps/web.py:770
+#: cps/templates/search_form.html:74 cps/ub.py:89 cps/web.py:770
 msgid "Languages"
 msgstr "Sprachen"
 
@@ -706,7 +735,7 @@ msgstr "Sprachen"
 msgid "Show language selection"
 msgstr "Zeige Sprachauswahl"
 
-#: cps/templates/index.xml:96 cps/ub.py:93
+#: cps/ub.py:93
 msgid "Ratings"
 msgstr "Bewertungen"
 
@@ -714,7 +743,7 @@ msgstr "Bewertungen"
 msgid "Show ratings selection"
 msgstr "Zeige Bewertungsauswahl"
 
-#: cps/templates/index.xml:104 cps/ub.py:96
+#: cps/ub.py:96
 msgid "File formats"
 msgstr "Dateiformate"
 
@@ -731,8 +760,12 @@ msgid "No update available. You already have the latest version installed"
 msgstr "Kein Update verfügbar. Es ist bereits die aktuellste Version installiert"
 
 #: cps/updater.py:333
-msgid "A new update is available. Click on the button below to update to the latest version."
-msgstr "Es sind Updates verfügbar. Klicke auf den Button unten, um auf die aktuellste Version zu aktualisieren."
+msgid ""
+"A new update is available. Click on the button below to update to the "
+"latest version."
+msgstr ""
+"Es sind Updates verfügbar. Klicke auf den Button unten, um auf die "
+"aktuellste Version zu aktualisieren."
 
 #: cps/updater.py:385
 msgid "Could not fetch update information"
@@ -744,12 +777,18 @@ msgstr "Keine Releaseinformationen verfügbar"
 
 #: cps/updater.py:456 cps/updater.py:467 cps/updater.py:486
 #, python-format
-msgid "A new update is available. Click on the button below to update to version: %(version)s"
-msgstr "Ein neues Update ist verfügbar. Klicke auf den Button unten, um auf Version: %(version)s zu aktualisieren"
+msgid ""
+"A new update is available. Click on the button below to update to "
+"version: %(version)s"
+msgstr ""
+"Ein neues Update ist verfügbar. Klicke auf den Button unten, um auf "
+"Version: %(version)s zu aktualisieren"
 
 #: cps/updater.py:477
 msgid "Click on the button below to update to the latest stable version."
-msgstr "Klicke auf den Button unten, um auf die letzte stabile Version zu aktualisieren."
+msgstr ""
+"Klicke auf den Button unten, um auf die letzte stabile Version zu "
+"aktualisieren."
 
 #: cps/web.py:480
 msgid "Recently Added Books"
@@ -768,8 +807,12 @@ msgid "Hot Books (Most Downloaded)"
 msgstr "Beliebte Bücher (am meisten Downloads)"
 
 #: cps/web.py:580
-msgid "Oops! Selected book title is unavailable. File does not exist or is not accessible"
-msgstr "Öffnen des Buchs fehlgeschlagen. Datei existiert nicht oder ist nicht zugänglich"
+msgid ""
+"Oops! Selected book title is unavailable. File does not exist or is not "
+"accessible"
+msgstr ""
+"Öffnen des Buchs fehlgeschlagen. Datei existiert nicht oder ist nicht "
+"zugänglich"
 
 #: cps/web.py:593
 #, python-format
@@ -818,9 +861,9 @@ msgstr "Liste der Dateiformate"
 msgid "Tasks"
 msgstr "Aufgaben"
 
-#: cps/templates/book_edit.html:212 cps/templates/feed.xml:33
-#: cps/templates/layout.html:44 cps/templates/layout.html:47
-#: cps/templates/search_form.html:170 cps/web.py:821 cps/web.py:823
+#: cps/templates/book_edit.html:212 cps/templates/layout.html:44
+#: cps/templates/layout.html:47 cps/templates/search_form.html:170
+#: cps/web.py:821 cps/web.py:823
 msgid "Search"
 msgstr "Suche"
 
@@ -862,7 +905,9 @@ msgstr "Bitte zuerst die Kindle E-Mailadresse konfigurieren..."
 
 #: cps/web.py:1083
 msgid "E-Mail server is not configured, please contact your administrator!"
-msgstr "Der E-Mail Server ist nicht konfigurierte, bitte den Administrator kontaktieren!"
+msgstr ""
+"Der E-Mail Server ist nicht konfigurierte, bitte den Administrator "
+"kontaktieren!"
 
 #: cps/web.py:1084 cps/web.py:1090 cps/web.py:1115 cps/web.py:1119
 #: cps/web.py:1124 cps/web.py:1128
@@ -892,7 +937,9 @@ msgstr "Du bist nun eingeloggt als '%(nickname)s'"
 
 #: cps/web.py:1155
 msgid "Could not login. LDAP server down, please contact your administrator"
-msgstr "Login nicht erfolgreich, LDAP Server nicht erreichbar, bitte Administrator kontaktieren"
+msgstr ""
+"Login nicht erfolgreich, LDAP Server nicht erreichbar, bitte "
+"Administrator kontaktieren"
 
 #: cps/web.py:1159 cps/web.py:1182
 msgid "Wrong Username or Password"
@@ -938,7 +985,9 @@ msgstr "Profil aktualisiert"
 
 #: cps/web.py:1384 cps/web.py:1480
 msgid "Error opening eBook. File does not exist or file is not accessible:"
-msgstr "Fehler beim Öffnen des eBooks. Datei existiert nicht oder ist nicht zugänglich:"
+msgstr ""
+"Fehler beim Öffnen des eBooks. Datei existiert nicht oder ist nicht "
+"zugänglich:"
 
 #: cps/web.py:1396 cps/web.py:1399 cps/web.py:1402 cps/web.py:1409
 #: cps/web.py:1414
@@ -947,7 +996,9 @@ msgstr "Lese ein Buch"
 
 #: cps/web.py:1425
 msgid "Error opening eBook. File does not exist or file is not accessible."
-msgstr "Fehler beim Öffnen des eBooks. Datei existiert nicht oder ist nicht zugänglich."
+msgstr ""
+"Fehler beim Öffnen des eBooks. Datei existiert nicht oder ist nicht "
+"zugänglich."
 
 #: cps/worker.py:335
 #, python-format
@@ -959,189 +1010,189 @@ msgstr "Fehler des EBook-Converters: %(error)s"
 msgid "Kindlegen failed with Error %(error)s. Message: %(message)s"
 msgstr "Kindlegen-Aufruf mit Fehler %(error)s. Text: %(message)s fehlgeschlagen"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html:8
 msgid "Users"
 msgstr "Benutzerliste"
 
-#: cps/templates/admin.html:12 cps/templates/login.html:8
+#: cps/templates/admin.html:11 cps/templates/login.html:8
 #: cps/templates/login.html:9 cps/templates/register.html:7
 #: cps/templates/user_edit.html:8
 msgid "Username"
 msgstr "Benutzername"
 
-#: cps/templates/admin.html:13 cps/templates/register.html:11
+#: cps/templates/admin.html:12 cps/templates/register.html:11
 #: cps/templates/user_edit.html:13
 msgid "E-mail Address"
 msgstr "E-Mail"
 
-#: cps/templates/admin.html:14 cps/templates/user_edit.html:26
+#: cps/templates/admin.html:13 cps/templates/user_edit.html:26
 msgid "Send to Kindle E-mail Address"
 msgstr "Kindle"
 
-#: cps/templates/admin.html:15
+#: cps/templates/admin.html:14
 msgid "Downloads"
 msgstr "Downloads"
 
-#: cps/templates/admin.html:16 cps/templates/layout.html:76
+#: cps/templates/admin.html:15 cps/templates/layout.html:76
 msgid "Admin"
 msgstr "Admin"
 
-#: cps/templates/admin.html:17 cps/templates/detail.html:18
+#: cps/templates/admin.html:16 cps/templates/detail.html:18
 #: cps/templates/detail.html:27 cps/templates/shelf.html:6
 #: cps/templates/shelfdown.html:62
 msgid "Download"
 msgstr "Download"
 
-#: cps/templates/admin.html:18
+#: cps/templates/admin.html:17
 msgid "View Books"
 msgstr "Bücher ansehen"
 
-#: cps/templates/admin.html:19 cps/templates/layout.html:65
+#: cps/templates/admin.html:18 cps/templates/layout.html:65
 msgid "Upload"
 msgstr "Upload"
 
-#: cps/templates/admin.html:20
+#: cps/templates/admin.html:19
 msgid "Edit"
 msgstr "Editieren"
 
-#: cps/templates/admin.html:38
+#: cps/templates/admin.html:37
 msgid "Add New User"
 msgstr "Neuen Benutzer hinzufügen"
 
-#: cps/templates/admin.html:44
+#: cps/templates/admin.html:43
 msgid "E-mail Server Settings"
 msgstr "Einstellungen des SMTP-Servers"
 
-#: cps/templates/admin.html:47 cps/templates/email_edit.html:11
+#: cps/templates/admin.html:46 cps/templates/email_edit.html:11
 msgid "SMTP Hostname"
 msgstr "SMTP-Hostname"
 
-#: cps/templates/admin.html:48 cps/templates/email_edit.html:15
+#: cps/templates/admin.html:47 cps/templates/email_edit.html:15
 msgid "SMTP Port"
 msgstr "SMTP Port"
 
-#: cps/templates/admin.html:49 cps/templates/email_edit.html:19
+#: cps/templates/admin.html:48 cps/templates/email_edit.html:19
 msgid "Encryption"
 msgstr "Verschlüsselung"
 
-#: cps/templates/admin.html:50 cps/templates/email_edit.html:27
+#: cps/templates/admin.html:49 cps/templates/email_edit.html:27
 msgid "SMTP Login"
 msgstr "SMTP-Login"
 
-#: cps/templates/admin.html:51 cps/templates/email_edit.html:35
+#: cps/templates/admin.html:50 cps/templates/email_edit.html:35
 msgid "From E-mail"
 msgstr "Absenderadresse"
 
-#: cps/templates/admin.html:61
+#: cps/templates/admin.html:60
 msgid "Edit E-mail Server Settings"
 msgstr "SMTP-Einstellungen ändern"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html:66
 msgid "Configuration"
 msgstr "Konfiguration"
 
-#: cps/templates/admin.html:70
+#: cps/templates/admin.html:69
 msgid "Calibre Database Directory"
 msgstr "Ordner der Calibre-DB"
 
-#: cps/templates/admin.html:74 cps/templates/config_edit.html:122
+#: cps/templates/admin.html:73 cps/templates/config_edit.html:122
 msgid "Log Level"
 msgstr "Loglevel"
 
-#: cps/templates/admin.html:78
+#: cps/templates/admin.html:77
 msgid "Port"
 msgstr "Port"
 
-#: cps/templates/admin.html:84 cps/templates/config_view_edit.html:27
+#: cps/templates/admin.html:83 cps/templates/config_view_edit.html:27
 msgid "Books per Page"
 msgstr "Bücher pro Seite"
 
-#: cps/templates/admin.html:88
+#: cps/templates/admin.html:87
 msgid "Uploads"
 msgstr "Lade hoch"
 
-#: cps/templates/admin.html:92
+#: cps/templates/admin.html:91
 msgid "Anonymous Browsing"
 msgstr "Anonymes Durchsuchen"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html:95
 msgid "Public Registration"
 msgstr "Öffentliche Registrierung"
 
-#: cps/templates/admin.html:100
+#: cps/templates/admin.html:99
 msgid "Magic Link Remote Login"
 msgstr "Remotelogin ('Magischer Link')"
 
-#: cps/templates/admin.html:104
+#: cps/templates/admin.html:103
 msgid "Reverse Proxy Login"
 msgstr "Reverse Proxy Login"
 
-#: cps/templates/admin.html:109
+#: cps/templates/admin.html:108
 msgid "Reverse proxy header name"
 msgstr "Reverse Proxy Header Name"
 
-#: cps/templates/admin.html:114
+#: cps/templates/admin.html:113
 msgid "Edit Basic Configuration"
 msgstr "Basiskonfiguration"
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html:114
 msgid "Edit UI Configuration"
 msgstr "Benutzeroberflächenkonfiguration"
 
-#: cps/templates/admin.html:121
+#: cps/templates/admin.html:120
 msgid "Administration"
 msgstr "Administration"
 
-#: cps/templates/admin.html:122
+#: cps/templates/admin.html:121
 msgid "View Logs"
 msgstr "Logdateien ansehen"
 
-#: cps/templates/admin.html:123
+#: cps/templates/admin.html:122
 msgid "Reconnect Calibre Database"
 msgstr "Calibre-DB neu verbinden"
 
-#: cps/templates/admin.html:124
+#: cps/templates/admin.html:123
 msgid "Restart"
 msgstr "Neustart"
 
-#: cps/templates/admin.html:125
+#: cps/templates/admin.html:124
 msgid "Shutdown"
 msgstr "Calibre-Web beenden"
 
-#: cps/templates/admin.html:131
+#: cps/templates/admin.html:130
 msgid "Update"
 msgstr "Update"
 
-#: cps/templates/admin.html:135
+#: cps/templates/admin.html:134
 msgid "Version"
 msgstr "Version"
 
-#: cps/templates/admin.html:136
+#: cps/templates/admin.html:135
 msgid "Details"
 msgstr "Details"
 
-#: cps/templates/admin.html:142
+#: cps/templates/admin.html:141
 msgid "Current version"
 msgstr "Aktuelle Version"
 
-#: cps/templates/admin.html:148
+#: cps/templates/admin.html:147
 msgid "Check for Update"
 msgstr "Nach Update suchen"
 
-#: cps/templates/admin.html:149
+#: cps/templates/admin.html:148
 msgid "Perform Update"
 msgstr "Update durchführen"
 
-#: cps/templates/admin.html:161
+#: cps/templates/admin.html:160
 msgid "Are you sure you want to restart?"
 msgstr "Calibre-Web wirklich neustarten?"
 
-#: cps/templates/admin.html:166 cps/templates/admin.html:180
-#: cps/templates/admin.html:200 cps/templates/shelf.html:72
+#: cps/templates/admin.html:165 cps/templates/admin.html:179
+#: cps/templates/admin.html:199 cps/templates/shelf.html:72
 msgid "OK"
 msgstr "OK"
 
-#: cps/templates/admin.html:167 cps/templates/admin.html:181
+#: cps/templates/admin.html:166 cps/templates/admin.html:180
 #: cps/templates/book_edit.html:172 cps/templates/book_edit.html:194
 #: cps/templates/config_edit.html:346 cps/templates/config_view_edit.html:151
 #: cps/templates/email_edit.html:40 cps/templates/email_edit.html:92
@@ -1150,11 +1201,11 @@ msgstr "OK"
 msgid "Cancel"
 msgstr "Abbruch"
 
-#: cps/templates/admin.html:179
+#: cps/templates/admin.html:178
 msgid "Are you sure you want to shutdown?"
 msgstr "Calibre-Web wirklich anhalten?"
 
-#: cps/templates/admin.html:191
+#: cps/templates/admin.html:190
 msgid "Updating, please do not reload this page"
 msgstr "Updatevorgang, Seite bitte nicht neu laden"
 
@@ -1243,8 +1294,12 @@ msgid "Rating"
 msgstr "Bewertung"
 
 #: cps/templates/book_edit.html:81
-msgid "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
-msgstr "Cover-URL (jpg, Cover wird heruntergeladen und in der Datenbank gespeichert, Feld erscheint anschließend wieder leer)"
+msgid ""
+"Fetch Cover from URL (JPEG - Image will be downloaded and stored in "
+"database)"
+msgstr ""
+"Cover-URL (jpg, Cover wird heruntergeladen und in der Datenbank "
+"gespeichert, Feld erscheint anschließend wieder leer)"
 
 #: cps/templates/book_edit.html:85
 msgid "Upload Cover from Local Disk"
@@ -1777,18 +1832,11 @@ msgstr "Verbotene Domains für eine Registrierung"
 msgid "Are you sure you want to delete this domain?"
 msgstr "Soll diese Domain-Regel wirklich gelöscht werden?"
 
-#: cps/templates/feed.xml:21 cps/templates/layout.html:173
-msgid "Next"
-msgstr "Nächste"
-
-#: cps/templates/feed.xml:79 cps/templates/layout.html:136
-#: cps/templates/layout.html:140
-msgid "(Public)"
-msgstr "(Öffentlich)"
-
 #: cps/templates/generate_kobo_auth_url.html:5
 msgid "Open the .kobo/Kobo eReader.conf file in a text editor and add (or edit):"
-msgstr "Öffne ddie .kobo/Kobo eReader.conf Datei in einem Texteditor und füge hinzu (oder ersetze):"
+msgstr ""
+"Öffne ddie .kobo/Kobo eReader.conf Datei in einem Texteditor und füge "
+"hinzu (oder ersetze):"
 
 #: cps/templates/http_error.html:38
 msgid "Create Issue"
@@ -1801,70 +1849,6 @@ msgstr "Zurück zur Hauptseite"
 #: cps/templates/index.html:64
 msgid "Group by series"
 msgstr "Nach Serien gruppieren"
-
-#: cps/templates/index.xml:6
-msgid "Start"
-msgstr "Start"
-
-#: cps/templates/index.xml:21
-msgid "Popular publications from this catalog based on Downloads."
-msgstr "Beliebte Publikationen aus dieser Bibliothek basierend auf Anzahl der Downloads."
-
-#: cps/templates/index.xml:28
-msgid "Popular publications from this catalog based on Rating."
-msgstr "Beliebte Veröffentlichungen dieses Katalogs basierend auf Bewertung."
-
-#: cps/templates/index.xml:31
-msgid "Recently added Books"
-msgstr "Kürzlich hinzugefügte Bücher"
-
-#: cps/templates/index.xml:35
-msgid "The latest Books"
-msgstr "Die neuesten Bücher"
-
-#: cps/templates/index.xml:38
-msgid "Random Books"
-msgstr "Zufällige Bücher"
-
-#: cps/templates/index.xml:42 cps/templates/user_edit.html:80
-msgid "Show Random Books"
-msgstr "Zeige zufällige Bücher"
-
-#: cps/templates/index.xml:65
-msgid "Books ordered by Author"
-msgstr "Bücher nach Autoren sortiert"
-
-#: cps/templates/index.xml:72
-msgid "Books ordered by publisher"
-msgstr "Bücher nach Verlegern sortiert"
-
-#: cps/templates/index.xml:79
-msgid "Books ordered by category"
-msgstr "Bücher nach Kategorien sortiert"
-
-#: cps/templates/index.xml:86
-msgid "Books ordered by series"
-msgstr "Bücher nach Serien sortiert"
-
-#: cps/templates/index.xml:93
-msgid "Books ordered by Languages"
-msgstr "Bücher nach Sprache sortiert"
-
-#: cps/templates/index.xml:100
-msgid "Books ordered by Rating"
-msgstr "Bücher nach Bewertungen sortiert"
-
-#: cps/templates/index.xml:108
-msgid "Books ordered by file formats"
-msgstr "Bücher nach Dateiformaten sortiert"
-
-#: cps/templates/index.xml:111 cps/templates/layout.html:134
-msgid "Shelves"
-msgstr "Bücherregale"
-
-#: cps/templates/index.xml:115
-msgid "Books organized in shelves"
-msgstr "Bücher in Bücherregalen organisiert"
 
 #: cps/templates/layout.html:28
 msgid "Home"
@@ -1916,6 +1900,14 @@ msgstr "Bitte die Seite nicht neu laden"
 msgid "Browse"
 msgstr "Durchsuchen"
 
+#: cps/templates/layout.html:134
+msgid "Shelves"
+msgstr "Bücherregale"
+
+#: cps/templates/layout.html:136 cps/templates/layout.html:140
+msgid "(Public)"
+msgstr "(Öffentlich)"
+
 #: cps/templates/layout.html:138
 msgid "Your Shelves"
 msgstr "Deine Bücherregale"
@@ -1927,6 +1919,10 @@ msgstr "Über"
 #: cps/templates/layout.html:158
 msgid "Previous"
 msgstr "Vorheriger Eintrag"
+
+#: cps/templates/layout.html:173
+msgid "Next"
+msgstr "Nächste"
 
 #: cps/templates/layout.html:185
 msgid "Book Details"
@@ -2309,6 +2305,10 @@ msgstr "Kobo Sync Token"
 msgid "Create/View"
 msgstr "Erzeugen/Ansehen"
 
+#: cps/templates/user_edit.html:80
+msgid "Show Random Books"
+msgstr "Zeige zufällige Bücher"
+
 #: cps/templates/user_edit.html:84
 msgid "Add allowed/Denied Custom Column Values"
 msgstr "Erlaubte/Verbotene Calibre Spalten hinzufügen"
@@ -2328,4 +2328,210 @@ msgstr "Kobo Auth URL erzeugen"
 #: cps/templates/user_edit.html:176
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "Möchten Sie wirklich den Kobo Token löschen?"
+
+#: vendor/tornado/locale.py:285
+msgid "January"
+msgstr ""
+
+#: vendor/tornado/locale.py:286
+msgid "February"
+msgstr ""
+
+#: vendor/tornado/locale.py:287
+msgid "March"
+msgstr ""
+
+#: vendor/tornado/locale.py:288
+msgid "April"
+msgstr ""
+
+#: vendor/tornado/locale.py:289
+msgid "May"
+msgstr ""
+
+#: vendor/tornado/locale.py:290
+msgid "June"
+msgstr ""
+
+#: vendor/tornado/locale.py:291
+msgid "July"
+msgstr ""
+
+#: vendor/tornado/locale.py:292
+msgid "August"
+msgstr ""
+
+#: vendor/tornado/locale.py:293
+msgid "September"
+msgstr ""
+
+#: vendor/tornado/locale.py:294
+msgid "October"
+msgstr ""
+
+#: vendor/tornado/locale.py:295
+msgid "November"
+msgstr ""
+
+#: vendor/tornado/locale.py:296
+msgid "December"
+msgstr ""
+
+#: vendor/tornado/locale.py:299
+msgid "Monday"
+msgstr ""
+
+#: vendor/tornado/locale.py:300
+msgid "Tuesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:301
+msgid "Wednesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:302
+msgid "Thursday"
+msgstr ""
+
+#: vendor/tornado/locale.py:303
+msgid "Friday"
+msgstr ""
+
+#: vendor/tornado/locale.py:304
+msgid "Saturday"
+msgstr ""
+
+#: vendor/tornado/locale.py:305
+msgid "Sunday"
+msgstr ""
+
+#: vendor/tornado/locale.py:368
+msgid "1 second ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:374
+msgid "1 minute ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:379
+msgid "1 hour ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:382
+#, python-format
+msgid "%(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+msgid "yesterday"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+#, python-format
+msgid "yesterday at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:389 vendor/tornado/locale.py:442
+#, python-format
+msgid "%(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:391
+#, python-format
+msgid "%(month_name)s %(day)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:396
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:398
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:436
+#, python-format
+msgid "%(weekday)s, %(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:459
+#, python-format
+msgid "%(commas)s and %(last)s"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:68
+msgctxt "law"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:69
+msgctxt "good"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:71 vendor/tornado/test/locale_test.py:74
+msgctxt "organization"
+msgid "club"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:76 vendor/tornado/test/locale_test.py:77
+msgctxt "stick"
+msgid "club"
+msgstr ""
+
+#~ msgid "Start"
+#~ msgstr "Start"
+
+#~ msgid "Popular publications from this catalog based on Downloads."
+#~ msgstr ""
+#~ "Beliebte Publikationen aus dieser Bibliothek"
+#~ " basierend auf Anzahl der Downloads."
+
+#~ msgid "Popular publications from this catalog based on Rating."
+#~ msgstr "Beliebte Veröffentlichungen dieses Katalogs basierend auf Bewertung."
+
+#~ msgid "Recently added Books"
+#~ msgstr "Kürzlich hinzugefügte Bücher"
+
+#~ msgid "The latest Books"
+#~ msgstr "Die neuesten Bücher"
+
+#~ msgid "Random Books"
+#~ msgstr "Zufällige Bücher"
+
+#~ msgid "Books ordered by Author"
+#~ msgstr "Bücher nach Autoren sortiert"
+
+#~ msgid "Books ordered by publisher"
+#~ msgstr "Bücher nach Verlegern sortiert"
+
+#~ msgid "Books ordered by category"
+#~ msgstr "Bücher nach Kategorien sortiert"
+
+#~ msgid "Books ordered by series"
+#~ msgstr "Bücher nach Serien sortiert"
+
+#~ msgid "Books ordered by Languages"
+#~ msgstr "Bücher nach Sprache sortiert"
+
+#~ msgid "Books ordered by Rating"
+#~ msgstr "Bücher nach Bewertungen sortiert"
+
+#~ msgid "Books ordered by file formats"
+#~ msgstr "Bücher nach Dateiformaten sortiert"
+
+#~ msgid "Books organized in shelves"
+#~ msgstr "Bücher in Bücherregalen organisiert"
 

--- a/cps/translations/es/LC_MESSAGES/messages.po
+++ b/cps/translations/es/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Calibre-Web\n"
 "Report-Msgid-Bugs-To: https://github.com/janeczku/Calibre-Web\n"
-"POT-Creation-Date: 2020-04-03 19:49+0200\n"
+"POT-Creation-Date: 2020-04-08 23:10+0800\n"
 "PO-Revision-Date: 2019-07-26 11:44+0100\n"
 "Last-Translator: minakmostoles <xxx@xxx.com>\n"
 "Language: es\n"
@@ -86,7 +86,9 @@ msgstr "El correo electrónico no tiene un nombre de dominio válido"
 
 #: cps/admin.py:710 cps/admin.py:725
 msgid "Found an existing account for this e-mail address or nickname."
-msgstr "Encontrada una cuenta existente para este correo electrónico o nombre de usuario."
+msgstr ""
+"Encontrada una cuenta existente para este correo electrónico o nombre de "
+"usuario."
 
 #: cps/admin.py:721
 #, python-format
@@ -267,7 +269,9 @@ msgstr "Metadatos actualizados correctamente"
 
 #: cps/editbooks.py:534
 msgid "Error editing book, please check logfile for details"
-msgstr "Error al editar el libro, por favor compruebe el fichero de registro (logfile) para tener más detalles"
+msgstr ""
+"Error al editar el libro, por favor compruebe el fichero de registro "
+"(logfile) para tener más detalles"
 
 #: cps/editbooks.py:581
 #, python-format
@@ -275,7 +279,9 @@ msgid "File %(filename)s could not saved to temp dir"
 msgstr ""
 
 #: cps/editbooks.py:598
-msgid "Uploaded book probably exists in the library, consider to change before upload new: "
+msgid ""
+"Uploaded book probably exists in the library, consider to change before "
+"upload new: "
 msgstr ""
 
 #: cps/editbooks.py:613
@@ -308,12 +314,20 @@ msgid "There was an error converting this book: %(res)s"
 msgstr "Ocurrió un error al convertir este libro: %(res)s"
 
 #: cps/gdrive.py:61
-msgid "Google Drive setup not completed, try to deactivate and activate Google Drive again"
-msgstr "La instalación de Google Drive no se ha completado, intente desactivar y activar Google Drive nuevamente"
+msgid ""
+"Google Drive setup not completed, try to deactivate and activate Google "
+"Drive again"
+msgstr ""
+"La instalación de Google Drive no se ha completado, intente desactivar y "
+"activar Google Drive nuevamente"
 
 #: cps/gdrive.py:103
-msgid "Callback domain is not verified, please follow steps to verify domain in google developer console"
-msgstr "El dominio de devolución de llamada no se ha verificado, siga los pasos para verificar el dominio en la consola de desarrollador de Google"
+msgid ""
+"Callback domain is not verified, please follow steps to verify domain in "
+"google developer console"
+msgstr ""
+"El dominio de devolución de llamada no se ha verificado, siga los pasos "
+"para verificar el dominio en la consola de desarrollador de Google"
 
 #: cps/helper.py:80
 #, python-format
@@ -374,22 +388,30 @@ msgstr "Correo electrónico: %(book)s"
 
 #: cps/helper.py:215
 msgid "The requested file could not be read. Maybe wrong permissions?"
-msgstr "El fichero solicitado no puede ser leído. ¿Quizás existen problemas con los permisos?"
+msgstr ""
+"El fichero solicitado no puede ser leído. ¿Quizás existen problemas con "
+"los permisos?"
 
 #: cps/helper.py:322
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
-msgstr "El renombrado del título de: '%(src)s' a '%(dest)s' falló con errores: %(error)s"
+msgstr ""
+"El renombrado del título de: '%(src)s' a '%(dest)s' falló con errores: "
+"%(error)s"
 
 #: cps/helper.py:332
 #, python-format
 msgid "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
-msgstr "El renombrado del autor de: '%(src)s' a '%(dest)s' falló con errores: %(error)s"
+msgstr ""
+"El renombrado del autor de: '%(src)s' a '%(dest)s' falló con errores: "
+"%(error)s"
 
 #: cps/helper.py:346
 #, python-format
 msgid "Rename file in path '%(src)s' to '%(dest)s' failed with error: %(error)s"
-msgstr "Ha fallado el cambio de nombre del archivo '%(src)s' a '%(dest)s' con el error: %(error)s"
+msgstr ""
+"Ha fallado el cambio de nombre del archivo '%(src)s' a '%(dest)s' con el "
+"error: %(error)s"
 
 #: cps/helper.py:372 cps/helper.py:382 cps/helper.py:390
 #, python-format
@@ -458,7 +480,9 @@ msgid "Unknown Task: "
 msgstr "Tarea desconocida"
 
 #: cps/kobo_auth.py:127
-msgid "PLease access calibre-web from non localhost to get valid api_endpoint for kobo device"
+msgid ""
+"PLease access calibre-web from non localhost to get valid api_endpoint "
+"for kobo device"
 msgstr ""
 
 #: cps/kobo_auth.py:130 cps/kobo_auth.py:150
@@ -516,7 +540,9 @@ msgstr "Estante especificado inválido"
 #: cps/shelf.py:54
 #, python-format
 msgid "Sorry you are not allowed to add a book to the the shelf: %(shelfname)s"
-msgstr "Lo sentimos, no tiene permisos para agregar un libro al estante: %(shelfname)s"
+msgstr ""
+"Lo sentimos, no tiene permisos para agregar un libro al estante: "
+"%(shelfname)s"
 
 #: cps/shelf.py:62
 msgid "You are not allowed to edit public shelves"
@@ -624,7 +650,7 @@ msgstr "Añadido recientemente"
 msgid "Show recent books"
 msgstr "Mostrar libros recientes"
 
-#: cps/templates/index.xml:17 cps/ub.py:59
+#: cps/ub.py:59
 msgid "Hot Books"
 msgstr "Libros populares"
 
@@ -632,7 +658,7 @@ msgstr "Libros populares"
 msgid "Show Hot Books"
 msgstr "Mostrar libros populares"
 
-#: cps/templates/index.xml:24 cps/ub.py:63 cps/web.py:508
+#: cps/ub.py:63 cps/web.py:508
 msgid "Top Rated Books"
 msgstr "Libros mejor valorados"
 
@@ -640,8 +666,7 @@ msgstr "Libros mejor valorados"
 msgid "Show Top Rated Books"
 msgstr "Mostrar libros mejor valorados"
 
-#: cps/templates/index.xml:46 cps/templates/index.xml:50 cps/ub.py:66
-#: cps/web.py:1005
+#: cps/ub.py:66 cps/web.py:1005
 msgid "Read Books"
 msgstr "Libros leídos"
 
@@ -649,8 +674,7 @@ msgstr "Libros leídos"
 msgid "Show read and unread"
 msgstr "Mostrar leídos y no leídos"
 
-#: cps/templates/index.xml:53 cps/templates/index.xml:57 cps/ub.py:70
-#: cps/web.py:1009
+#: cps/ub.py:70 cps/web.py:1009
 msgid "Unread Books"
 msgstr "Libros no leídos"
 
@@ -666,7 +690,7 @@ msgstr "Descubrir"
 msgid "Show random books"
 msgstr "Mostrar libros al azar"
 
-#: cps/templates/index.xml:75 cps/ub.py:76 cps/web.py:787
+#: cps/ub.py:76 cps/web.py:787
 msgid "Categories"
 msgstr "Categorías"
 
@@ -674,8 +698,8 @@ msgstr "Categorías"
 msgid "Show category selection"
 msgstr "Mostrar selección de categorías"
 
-#: cps/templates/book_edit.html:69 cps/templates/index.xml:82
-#: cps/templates/search_form.html:53 cps/ub.py:79 cps/web.py:715
+#: cps/templates/book_edit.html:69 cps/templates/search_form.html:53
+#: cps/ub.py:79 cps/web.py:715
 msgid "Series"
 msgstr "Series"
 
@@ -683,7 +707,7 @@ msgstr "Series"
 msgid "Show series selection"
 msgstr "Mostrar selección de series"
 
-#: cps/templates/index.xml:61 cps/ub.py:82
+#: cps/ub.py:82
 msgid "Authors"
 msgstr "Autores"
 
@@ -691,7 +715,7 @@ msgstr "Autores"
 msgid "Show author selection"
 msgstr "Mostrar selección de autores"
 
-#: cps/templates/index.xml:68 cps/ub.py:86 cps/web.py:699
+#: cps/ub.py:86 cps/web.py:699
 msgid "Publishers"
 msgstr "Editoras"
 
@@ -699,8 +723,7 @@ msgstr "Editoras"
 msgid "Show publisher selection"
 msgstr "Mostrar selección de editores"
 
-#: cps/templates/index.xml:89 cps/templates/search_form.html:74 cps/ub.py:89
-#: cps/web.py:770
+#: cps/templates/search_form.html:74 cps/ub.py:89 cps/web.py:770
 msgid "Languages"
 msgstr "Idioma"
 
@@ -708,7 +731,7 @@ msgstr "Idioma"
 msgid "Show language selection"
 msgstr "Mostrar selección de idiomas"
 
-#: cps/templates/index.xml:96 cps/ub.py:93
+#: cps/ub.py:93
 msgid "Ratings"
 msgstr "Calificaciones"
 
@@ -716,7 +739,7 @@ msgstr "Calificaciones"
 msgid "Show ratings selection"
 msgstr "Mostrar selección de calificaciones"
 
-#: cps/templates/index.xml:104 cps/ub.py:96
+#: cps/ub.py:96
 msgid "File formats"
 msgstr "Formatos de archivo"
 
@@ -733,8 +756,12 @@ msgid "No update available. You already have the latest version installed"
 msgstr "Actualización no disponible. Ya tienes la versión más reciente instalada"
 
 #: cps/updater.py:333
-msgid "A new update is available. Click on the button below to update to the latest version."
-msgstr "Una nueva actualización está disponible. Haz clic en el botón inferior para actualizar a la versión más reciente."
+msgid ""
+"A new update is available. Click on the button below to update to the "
+"latest version."
+msgstr ""
+"Una nueva actualización está disponible. Haz clic en el botón inferior "
+"para actualizar a la versión más reciente."
 
 #: cps/updater.py:385
 msgid "Could not fetch update information"
@@ -746,8 +773,12 @@ msgstr "No hay información del lanzamiento disponible"
 
 #: cps/updater.py:456 cps/updater.py:467 cps/updater.py:486
 #, python-format
-msgid "A new update is available. Click on the button below to update to version: %(version)s"
-msgstr "Hay una nueva actualización disponible. Haz clic en el botón de abajo para actualizar a la versión: %(version)s"
+msgid ""
+"A new update is available. Click on the button below to update to "
+"version: %(version)s"
+msgstr ""
+"Hay una nueva actualización disponible. Haz clic en el botón de abajo "
+"para actualizar a la versión: %(version)s"
 
 #: cps/updater.py:477
 msgid "Click on the button below to update to the latest stable version."
@@ -770,7 +801,9 @@ msgid "Hot Books (Most Downloaded)"
 msgstr "Libros populares (los más descargados)"
 
 #: cps/web.py:580
-msgid "Oops! Selected book title is unavailable. File does not exist or is not accessible"
+msgid ""
+"Oops! Selected book title is unavailable. File does not exist or is not "
+"accessible"
 msgstr "Error al abrir eBook. El archivo no existe o no es accesible:"
 
 #: cps/web.py:593
@@ -820,9 +853,9 @@ msgstr "Lista de formatos"
 msgid "Tasks"
 msgstr "Tareas"
 
-#: cps/templates/book_edit.html:212 cps/templates/feed.xml:33
-#: cps/templates/layout.html:44 cps/templates/layout.html:47
-#: cps/templates/search_form.html:170 cps/web.py:821 cps/web.py:823
+#: cps/templates/book_edit.html:212 cps/templates/layout.html:44
+#: cps/templates/layout.html:47 cps/templates/search_form.html:170
+#: cps/web.py:821 cps/web.py:823
 msgid "Search"
 msgstr "Buscar"
 
@@ -877,7 +910,9 @@ msgstr "Su correo electrónico no está permitido para registrarse"
 
 #: cps/web.py:1120
 msgid "Confirmation e-mail was send to your e-mail account."
-msgstr "Se ha enviado un correo electrónico de verificación a su cuenta de correo electrónico."
+msgstr ""
+"Se ha enviado un correo electrónico de verificación a su cuenta de correo"
+" electrónico."
 
 #: cps/web.py:1123
 msgid "This username or e-mail address is already in use."
@@ -894,7 +929,9 @@ msgstr "Sesión iniciada como : '%(nickname)s'"
 
 #: cps/web.py:1155
 msgid "Could not login. LDAP server down, please contact your administrator"
-msgstr "No pude entrar a la cuenta. El servidor LDAP está inactivo, por favor contacte a su administrador"
+msgstr ""
+"No pude entrar a la cuenta. El servidor LDAP está inactivo, por favor "
+"contacte a su administrador"
 
 #: cps/web.py:1159 cps/web.py:1182
 msgid "Wrong Username or Password"
@@ -949,7 +986,9 @@ msgstr "Leer un libro"
 
 #: cps/web.py:1425
 msgid "Error opening eBook. File does not exist or file is not accessible."
-msgstr "Error al abrir el eBook. El archivo no existe o el archivo no es accesible."
+msgstr ""
+"Error al abrir el eBook. El archivo no existe o el archivo no es "
+"accesible."
 
 #: cps/worker.py:335
 #, python-format
@@ -961,189 +1000,189 @@ msgstr "Falló Ebook-converter: %(error)s"
 msgid "Kindlegen failed with Error %(error)s. Message: %(message)s"
 msgstr "Kindlegen falló con error %(error)s. Mensaje: %(message)s"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html:8
 msgid "Users"
 msgstr "Lista de usuarios"
 
-#: cps/templates/admin.html:12 cps/templates/login.html:8
+#: cps/templates/admin.html:11 cps/templates/login.html:8
 #: cps/templates/login.html:9 cps/templates/register.html:7
 #: cps/templates/user_edit.html:8
 msgid "Username"
 msgstr "Nickname"
 
-#: cps/templates/admin.html:13 cps/templates/register.html:11
+#: cps/templates/admin.html:12 cps/templates/register.html:11
 #: cps/templates/user_edit.html:13
 msgid "E-mail Address"
 msgstr "Correo electrónico"
 
-#: cps/templates/admin.html:14 cps/templates/user_edit.html:26
+#: cps/templates/admin.html:13 cps/templates/user_edit.html:26
 msgid "Send to Kindle E-mail Address"
 msgstr "Kindle"
 
-#: cps/templates/admin.html:15
+#: cps/templates/admin.html:14
 msgid "Downloads"
 msgstr "DLS"
 
-#: cps/templates/admin.html:16 cps/templates/layout.html:76
+#: cps/templates/admin.html:15 cps/templates/layout.html:76
 msgid "Admin"
 msgstr "Administración"
 
-#: cps/templates/admin.html:17 cps/templates/detail.html:18
+#: cps/templates/admin.html:16 cps/templates/detail.html:18
 #: cps/templates/detail.html:27 cps/templates/shelf.html:6
 #: cps/templates/shelfdown.html:62
 msgid "Download"
 msgstr "Descargar"
 
-#: cps/templates/admin.html:18
+#: cps/templates/admin.html:17
 msgid "View Books"
 msgstr "Ver libros electrónicos"
 
-#: cps/templates/admin.html:19 cps/templates/layout.html:65
+#: cps/templates/admin.html:18 cps/templates/layout.html:65
 msgid "Upload"
 msgstr "Subir archivo"
 
-#: cps/templates/admin.html:20
+#: cps/templates/admin.html:19
 msgid "Edit"
 msgstr "Editar"
 
-#: cps/templates/admin.html:38
+#: cps/templates/admin.html:37
 msgid "Add New User"
 msgstr ""
 
-#: cps/templates/admin.html:44
+#: cps/templates/admin.html:43
 msgid "E-mail Server Settings"
 msgstr "Ajustes SMTP del servidor de correo electrónico"
 
-#: cps/templates/admin.html:47 cps/templates/email_edit.html:11
+#: cps/templates/admin.html:46 cps/templates/email_edit.html:11
 msgid "SMTP Hostname"
 msgstr "Servidor SMTP"
 
-#: cps/templates/admin.html:48 cps/templates/email_edit.html:15
+#: cps/templates/admin.html:47 cps/templates/email_edit.html:15
 msgid "SMTP Port"
 msgstr "Puerto SMTP"
 
-#: cps/templates/admin.html:49 cps/templates/email_edit.html:19
+#: cps/templates/admin.html:48 cps/templates/email_edit.html:19
 msgid "Encryption"
 msgstr "SSL"
 
-#: cps/templates/admin.html:50 cps/templates/email_edit.html:27
+#: cps/templates/admin.html:49 cps/templates/email_edit.html:27
 msgid "SMTP Login"
 msgstr "Login SMTP"
 
-#: cps/templates/admin.html:51 cps/templates/email_edit.html:35
+#: cps/templates/admin.html:50 cps/templates/email_edit.html:35
 msgid "From E-mail"
 msgstr "Desde el correo"
 
-#: cps/templates/admin.html:61
+#: cps/templates/admin.html:60
 msgid "Edit E-mail Server Settings"
 msgstr "Cambiar parámetros SMTP"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html:66
 msgid "Configuration"
 msgstr "Configuración"
 
-#: cps/templates/admin.html:70
+#: cps/templates/admin.html:69
 msgid "Calibre Database Directory"
 msgstr "Dir DB Calibre"
 
-#: cps/templates/admin.html:74 cps/templates/config_edit.html:122
+#: cps/templates/admin.html:73 cps/templates/config_edit.html:122
 msgid "Log Level"
 msgstr "Nivel de registro"
 
-#: cps/templates/admin.html:78
+#: cps/templates/admin.html:77
 msgid "Port"
 msgstr "Puerto"
 
-#: cps/templates/admin.html:84 cps/templates/config_view_edit.html:27
+#: cps/templates/admin.html:83 cps/templates/config_view_edit.html:27
 msgid "Books per Page"
 msgstr "Libros por página"
 
-#: cps/templates/admin.html:88
+#: cps/templates/admin.html:87
 msgid "Uploads"
 msgstr "Subiendo"
 
-#: cps/templates/admin.html:92
+#: cps/templates/admin.html:91
 msgid "Anonymous Browsing"
 msgstr "Navegación anónima"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html:95
 msgid "Public Registration"
 msgstr "Registro público"
 
-#: cps/templates/admin.html:100
+#: cps/templates/admin.html:99
 msgid "Magic Link Remote Login"
 msgstr "Inicio de sesión remoto"
 
-#: cps/templates/admin.html:104
+#: cps/templates/admin.html:103
 msgid "Reverse Proxy Login"
 msgstr ""
 
-#: cps/templates/admin.html:109
+#: cps/templates/admin.html:108
 msgid "Reverse proxy header name"
 msgstr ""
 
-#: cps/templates/admin.html:114
+#: cps/templates/admin.html:113
 msgid "Edit Basic Configuration"
 msgstr ""
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html:114
 msgid "Edit UI Configuration"
 msgstr ""
 
-#: cps/templates/admin.html:121
+#: cps/templates/admin.html:120
 msgid "Administration"
 msgstr "Administración"
 
-#: cps/templates/admin.html:122
+#: cps/templates/admin.html:121
 msgid "View Logs"
 msgstr "Ver archivos de registro"
 
-#: cps/templates/admin.html:123
+#: cps/templates/admin.html:122
 msgid "Reconnect Calibre Database"
 msgstr "Reconectar a la BD Calibre"
 
-#: cps/templates/admin.html:124
+#: cps/templates/admin.html:123
 msgid "Restart"
 msgstr "Reiniciar Calibre-Web"
 
-#: cps/templates/admin.html:125
+#: cps/templates/admin.html:124
 msgid "Shutdown"
 msgstr "Detener Calibre-Web"
 
-#: cps/templates/admin.html:131
+#: cps/templates/admin.html:130
 msgid "Update"
 msgstr "Actualizar"
 
-#: cps/templates/admin.html:135
+#: cps/templates/admin.html:134
 msgid "Version"
 msgstr "Versión"
 
-#: cps/templates/admin.html:136
+#: cps/templates/admin.html:135
 msgid "Details"
 msgstr "Detalles"
 
-#: cps/templates/admin.html:142
+#: cps/templates/admin.html:141
 msgid "Current version"
 msgstr "Versión actual"
 
-#: cps/templates/admin.html:148
+#: cps/templates/admin.html:147
 msgid "Check for Update"
 msgstr "Comprobar actualizaciones"
 
-#: cps/templates/admin.html:149
+#: cps/templates/admin.html:148
 msgid "Perform Update"
 msgstr "Realizar actualización"
 
-#: cps/templates/admin.html:161
+#: cps/templates/admin.html:160
 msgid "Are you sure you want to restart?"
 msgstr "¿Realmente quiere reiniciar Calibre-Web?"
 
-#: cps/templates/admin.html:166 cps/templates/admin.html:180
-#: cps/templates/admin.html:200 cps/templates/shelf.html:72
+#: cps/templates/admin.html:165 cps/templates/admin.html:179
+#: cps/templates/admin.html:199 cps/templates/shelf.html:72
 msgid "OK"
 msgstr "Ok"
 
-#: cps/templates/admin.html:167 cps/templates/admin.html:181
+#: cps/templates/admin.html:166 cps/templates/admin.html:180
 #: cps/templates/book_edit.html:172 cps/templates/book_edit.html:194
 #: cps/templates/config_edit.html:346 cps/templates/config_view_edit.html:151
 #: cps/templates/email_edit.html:40 cps/templates/email_edit.html:92
@@ -1152,11 +1191,11 @@ msgstr "Ok"
 msgid "Cancel"
 msgstr ""
 
-#: cps/templates/admin.html:179
+#: cps/templates/admin.html:178
 msgid "Are you sure you want to shutdown?"
 msgstr "¿Realmente quiere detener Calibre-Web?"
 
-#: cps/templates/admin.html:191
+#: cps/templates/admin.html:190
 msgid "Updating, please do not reload this page"
 msgstr "Actualizando. Por favor, no recargue la página"
 
@@ -1245,8 +1284,12 @@ msgid "Rating"
 msgstr "Clasificación"
 
 #: cps/templates/book_edit.html:81
-msgid "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
-msgstr "URL de la portada (jpg, la portada es descargada y almacenada en la base de datos, el campo  está vacío de nuevo)"
+msgid ""
+"Fetch Cover from URL (JPEG - Image will be downloaded and stored in "
+"database)"
+msgstr ""
+"URL de la portada (jpg, la portada es descargada y almacenada en la base "
+"de datos, el campo  está vacío de nuevo)"
 
 #: cps/templates/book_edit.html:85
 msgid "Upload Cover from Local Disk"
@@ -1389,11 +1432,15 @@ msgstr "Puerto del servidor"
 
 #: cps/templates/config_edit.html:91
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
-msgstr "Ubicación del archivo de certificado SSL (dejar en blanco si no hay un servidor SSL)"
+msgstr ""
+"Ubicación del archivo de certificado SSL (dejar en blanco si no hay un "
+"servidor SSL)"
 
 #: cps/templates/config_edit.html:95
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
-msgstr "Ubicación del archivo clave SSL (dejar en blanco si no hay un servidor SSL)"
+msgstr ""
+"Ubicación del archivo clave SSL (dejar en blanco si no hay un servidor "
+"SSL)"
 
 #: cps/templates/config_edit.html:99
 msgid "Update Channel"
@@ -1421,7 +1468,9 @@ msgstr "Configuración del archivo de registro"
 
 #: cps/templates/config_edit.html:131
 msgid "Location and name of logfile (calibre-web.log for no entry)"
-msgstr "Ubicación y nombre del archivo de registro (si no se especifica será calibre-web.log)"
+msgstr ""
+"Ubicación y nombre del archivo de registro (si no se especifica será "
+"calibre-web.log)"
 
 #: cps/templates/config_edit.html:136
 msgid "Enable Access Log"
@@ -1429,7 +1478,9 @@ msgstr "Habilitar registro de acceso"
 
 #: cps/templates/config_edit.html:139
 msgid "Location and name of access logfile (access.log for no entry)"
-msgstr "Ubicación y nombre del archivo de registro de acceso (access.log no tiene ninguna entrada)"
+msgstr ""
+"Ubicación y nombre del archivo de registro de acceso (access.log no tiene"
+" ninguna entrada)"
 
 #: cps/templates/config_edit.html:150
 msgid "Feature Configuration"
@@ -1609,7 +1660,9 @@ msgstr "Número de libros aleatorios a mostrar"
 
 #: cps/templates/config_view_edit.html:35
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
-msgstr "Número de autores para mostrar antes de ocultar (0 = desactivar la ocultación)"
+msgstr ""
+"Número de autores para mostrar antes de ocultar (0 = desactivar la "
+"ocultación)"
 
 #: cps/templates/config_view_edit.html:39 cps/templates/readcbr.html:112
 msgid "Theme"
@@ -1779,15 +1832,6 @@ msgstr ""
 msgid "Are you sure you want to delete this domain?"
 msgstr "¿Realmente quiere eliminar esta regla de dominio?"
 
-#: cps/templates/feed.xml:21 cps/templates/layout.html:173
-msgid "Next"
-msgstr "Siguiente"
-
-#: cps/templates/feed.xml:79 cps/templates/layout.html:136
-#: cps/templates/layout.html:140
-msgid "(Public)"
-msgstr ""
-
 #: cps/templates/generate_kobo_auth_url.html:5
 msgid "Open the .kobo/Kobo eReader.conf file in a text editor and add (or edit):"
 msgstr ""
@@ -1803,70 +1847,6 @@ msgstr "Volver al inicio"
 #: cps/templates/index.html:64
 msgid "Group by series"
 msgstr "Grupo por serie"
-
-#: cps/templates/index.xml:6
-msgid "Start"
-msgstr "Iniciar"
-
-#: cps/templates/index.xml:21
-msgid "Popular publications from this catalog based on Downloads."
-msgstr "Publicaciones mas populares para este catálogo basadas en las descargas."
-
-#: cps/templates/index.xml:28
-msgid "Popular publications from this catalog based on Rating."
-msgstr "Publicaciones populares del catálogo basados en la clasificación."
-
-#: cps/templates/index.xml:31
-msgid "Recently added Books"
-msgstr ""
-
-#: cps/templates/index.xml:35
-msgid "The latest Books"
-msgstr "Libros recientes"
-
-#: cps/templates/index.xml:38
-msgid "Random Books"
-msgstr "Libros al azar"
-
-#: cps/templates/index.xml:42 cps/templates/user_edit.html:80
-msgid "Show Random Books"
-msgstr "Mostrar libros al azar"
-
-#: cps/templates/index.xml:65
-msgid "Books ordered by Author"
-msgstr "Libros ordenados por autor"
-
-#: cps/templates/index.xml:72
-msgid "Books ordered by publisher"
-msgstr "Libros ordenados por editor"
-
-#: cps/templates/index.xml:79
-msgid "Books ordered by category"
-msgstr "Libros ordenados por categorías"
-
-#: cps/templates/index.xml:86
-msgid "Books ordered by series"
-msgstr "Libros ordenados por series"
-
-#: cps/templates/index.xml:93
-msgid "Books ordered by Languages"
-msgstr ""
-
-#: cps/templates/index.xml:100
-msgid "Books ordered by Rating"
-msgstr ""
-
-#: cps/templates/index.xml:108
-msgid "Books ordered by file formats"
-msgstr ""
-
-#: cps/templates/index.xml:111 cps/templates/layout.html:134
-msgid "Shelves"
-msgstr ""
-
-#: cps/templates/index.xml:115
-msgid "Books organized in shelves"
-msgstr ""
 
 #: cps/templates/layout.html:28
 msgid "Home"
@@ -1918,6 +1898,14 @@ msgstr ""
 msgid "Browse"
 msgstr "Navegar"
 
+#: cps/templates/layout.html:134
+msgid "Shelves"
+msgstr ""
+
+#: cps/templates/layout.html:136 cps/templates/layout.html:140
+msgid "(Public)"
+msgstr ""
+
 #: cps/templates/layout.html:138
 msgid "Your Shelves"
 msgstr "Sus estantes"
@@ -1929,6 +1917,10 @@ msgstr "Acerca de"
 #: cps/templates/layout.html:158
 msgid "Previous"
 msgstr "Previo"
+
+#: cps/templates/layout.html:173
+msgid "Next"
+msgstr "Siguiente"
 
 #: cps/templates/layout.html:185
 msgid "Book Details"
@@ -2133,7 +2125,9 @@ msgstr "Utiliza tu otro dispositivo, inicia sesión y visita"
 
 #: cps/templates/remote_login.html:10
 msgid "Once verified, you will automatically be logged in on this device."
-msgstr "Una vez que lo realice, iniciará sesión automáticamente en ese dispositivo."
+msgstr ""
+"Una vez que lo realice, iniciará sesión automáticamente en ese "
+"dispositivo."
 
 #: cps/templates/remote_login.html:13
 msgid "This verification link will expire in 10 minutes."
@@ -2311,6 +2305,10 @@ msgstr ""
 msgid "Create/View"
 msgstr ""
 
+#: cps/templates/user_edit.html:80
+msgid "Show Random Books"
+msgstr "Mostrar libros al azar"
+
 #: cps/templates/user_edit.html:84
 msgid "Add allowed/Denied Custom Column Values"
 msgstr ""
@@ -2330,4 +2328,210 @@ msgstr ""
 #: cps/templates/user_edit.html:176
 msgid "Do you really want to delete the Kobo Token?"
 msgstr ""
+
+#: vendor/tornado/locale.py:285
+msgid "January"
+msgstr ""
+
+#: vendor/tornado/locale.py:286
+msgid "February"
+msgstr ""
+
+#: vendor/tornado/locale.py:287
+msgid "March"
+msgstr ""
+
+#: vendor/tornado/locale.py:288
+msgid "April"
+msgstr ""
+
+#: vendor/tornado/locale.py:289
+msgid "May"
+msgstr ""
+
+#: vendor/tornado/locale.py:290
+msgid "June"
+msgstr ""
+
+#: vendor/tornado/locale.py:291
+msgid "July"
+msgstr ""
+
+#: vendor/tornado/locale.py:292
+msgid "August"
+msgstr ""
+
+#: vendor/tornado/locale.py:293
+msgid "September"
+msgstr ""
+
+#: vendor/tornado/locale.py:294
+msgid "October"
+msgstr ""
+
+#: vendor/tornado/locale.py:295
+msgid "November"
+msgstr ""
+
+#: vendor/tornado/locale.py:296
+msgid "December"
+msgstr ""
+
+#: vendor/tornado/locale.py:299
+msgid "Monday"
+msgstr ""
+
+#: vendor/tornado/locale.py:300
+msgid "Tuesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:301
+msgid "Wednesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:302
+msgid "Thursday"
+msgstr ""
+
+#: vendor/tornado/locale.py:303
+msgid "Friday"
+msgstr ""
+
+#: vendor/tornado/locale.py:304
+msgid "Saturday"
+msgstr ""
+
+#: vendor/tornado/locale.py:305
+msgid "Sunday"
+msgstr ""
+
+#: vendor/tornado/locale.py:368
+msgid "1 second ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:374
+msgid "1 minute ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:379
+msgid "1 hour ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:382
+#, python-format
+msgid "%(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+msgid "yesterday"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+#, python-format
+msgid "yesterday at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:389 vendor/tornado/locale.py:442
+#, python-format
+msgid "%(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:391
+#, python-format
+msgid "%(month_name)s %(day)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:396
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:398
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:436
+#, python-format
+msgid "%(weekday)s, %(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:459
+#, python-format
+msgid "%(commas)s and %(last)s"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:68
+msgctxt "law"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:69
+msgctxt "good"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:71 vendor/tornado/test/locale_test.py:74
+msgctxt "organization"
+msgid "club"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:76 vendor/tornado/test/locale_test.py:77
+msgctxt "stick"
+msgid "club"
+msgstr ""
+
+#~ msgid "Start"
+#~ msgstr "Iniciar"
+
+#~ msgid "Popular publications from this catalog based on Downloads."
+#~ msgstr ""
+#~ "Publicaciones mas populares para este "
+#~ "catálogo basadas en las descargas."
+
+#~ msgid "Popular publications from this catalog based on Rating."
+#~ msgstr "Publicaciones populares del catálogo basados en la clasificación."
+
+#~ msgid "Recently added Books"
+#~ msgstr ""
+
+#~ msgid "The latest Books"
+#~ msgstr "Libros recientes"
+
+#~ msgid "Random Books"
+#~ msgstr "Libros al azar"
+
+#~ msgid "Books ordered by Author"
+#~ msgstr "Libros ordenados por autor"
+
+#~ msgid "Books ordered by publisher"
+#~ msgstr "Libros ordenados por editor"
+
+#~ msgid "Books ordered by category"
+#~ msgstr "Libros ordenados por categorías"
+
+#~ msgid "Books ordered by series"
+#~ msgstr "Libros ordenados por series"
+
+#~ msgid "Books ordered by Languages"
+#~ msgstr ""
+
+#~ msgid "Books ordered by Rating"
+#~ msgstr ""
+
+#~ msgid "Books ordered by file formats"
+#~ msgstr ""
+
+#~ msgid "Books organized in shelves"
+#~ msgstr ""
 

--- a/cps/translations/fi/LC_MESSAGES/messages.po
+++ b/cps/translations/fi/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Calibre-Web\n"
 "Report-Msgid-Bugs-To: https://github.com/janeczku/Calibre-Web\n"
-"POT-Creation-Date: 2020-04-03 19:49+0200\n"
+"POT-Creation-Date: 2020-04-08 23:10+0800\n"
 "PO-Revision-Date: 2020-01-12 13:56+0100\n"
 "Last-Translator: Samuli Valavuo <svalavuo@gmail.com>\n"
 "Language: fi\n"
@@ -229,7 +229,9 @@ msgstr "muokkaa metadataa"
 #: cps/editbooks.py:321 cps/editbooks.py:569
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
-msgstr "Tiedostopääte '%(ext)s' ei ole sallittujen palvelimelle ladattavien listalla"
+msgstr ""
+"Tiedostopääte '%(ext)s' ei ole sallittujen palvelimelle ladattavien "
+"listalla"
 
 #: cps/editbooks.py:325 cps/editbooks.py:573
 msgid "File to be uploaded must have an extension"
@@ -273,7 +275,9 @@ msgid "File %(filename)s could not saved to temp dir"
 msgstr ""
 
 #: cps/editbooks.py:598
-msgid "Uploaded book probably exists in the library, consider to change before upload new: "
+msgid ""
+"Uploaded book probably exists in the library, consider to change before "
+"upload new: "
 msgstr ""
 
 #: cps/editbooks.py:613
@@ -306,12 +310,20 @@ msgid "There was an error converting this book: %(res)s"
 msgstr "Kirjan muunnoksessa tapahtui virhe: %(res)s"
 
 #: cps/gdrive.py:61
-msgid "Google Drive setup not completed, try to deactivate and activate Google Drive again"
-msgstr "Google Drive asetukset ei ole valmiit. Koita poistaa Google Drive käytöstä ja ottaa se uudelleen käyttöön"
+msgid ""
+"Google Drive setup not completed, try to deactivate and activate Google "
+"Drive again"
+msgstr ""
+"Google Drive asetukset ei ole valmiit. Koita poistaa Google Drive "
+"käytöstä ja ottaa se uudelleen käyttöön"
 
 #: cps/gdrive.py:103
-msgid "Callback domain is not verified, please follow steps to verify domain in google developer console"
-msgstr "Paluuosoitteen domain ei ole varmistettu, seuraa ohjeita vamistaaksesi sen googlen kehittäjäkonsolissa"
+msgid ""
+"Callback domain is not verified, please follow steps to verify domain in "
+"google developer console"
+msgstr ""
+"Paluuosoitteen domain ei ole varmistettu, seuraa ohjeita vamistaaksesi "
+"sen googlen kehittäjäkonsolissa"
 
 #: cps/helper.py:80
 #, python-format
@@ -377,17 +389,23 @@ msgstr "Haettua tiedostoa ei pystytty lukemaan. Ehkä vaäärät oikeudet?"
 #: cps/helper.py:322
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
-msgstr "Tiedon muuttaminen arvosta: '%(src)s' arvoon '%(dest)s' epäonnistui virheeseen: %(error)s"
+msgstr ""
+"Tiedon muuttaminen arvosta: '%(src)s' arvoon '%(dest)s' epäonnistui "
+"virheeseen: %(error)s"
 
 #: cps/helper.py:332
 #, python-format
 msgid "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
-msgstr "Kirjailijan muuttaminen arvosta: \"%(src)s\" arvoon \"%(dest)s\" epäonnistui virheeseen: %(error)s"
+msgstr ""
+"Kirjailijan muuttaminen arvosta: \"%(src)s\" arvoon \"%(dest)s\" "
+"epäonnistui virheeseen: %(error)s"
 
 #: cps/helper.py:346
 #, python-format
 msgid "Rename file in path '%(src)s' to '%(dest)s' failed with error: %(error)s"
-msgstr "Tiedoston nimeäminen polusta '%(src)s' polkuun '%(dest)s' epäonnistui virheeseen: %(error)s"
+msgstr ""
+"Tiedoston nimeäminen polusta '%(src)s' polkuun '%(dest)s' epäonnistui "
+"virheeseen: %(error)s"
 
 #: cps/helper.py:372 cps/helper.py:382 cps/helper.py:390
 #, python-format
@@ -456,7 +474,9 @@ msgid "Unknown Task: "
 msgstr "Tuntematon tehtävä: "
 
 #: cps/kobo_auth.py:127
-msgid "PLease access calibre-web from non localhost to get valid api_endpoint for kobo device"
+msgid ""
+"PLease access calibre-web from non localhost to get valid api_endpoint "
+"for kobo device"
 msgstr ""
 
 #: cps/kobo_auth.py:130 cps/kobo_auth.py:150
@@ -514,7 +534,9 @@ msgstr "Virheellinen hylly valittu"
 #: cps/shelf.py:54
 #, python-format
 msgid "Sorry you are not allowed to add a book to the the shelf: %(shelfname)s"
-msgstr "Valitettavasti sinulla ei ole oikeutta lisätä kirjaa hyllyyn: %(shelfname)s"
+msgstr ""
+"Valitettavasti sinulla ei ole oikeutta lisätä kirjaa hyllyyn: "
+"%(shelfname)s"
 
 #: cps/shelf.py:62
 msgid "You are not allowed to edit public shelves"
@@ -622,7 +644,7 @@ msgstr "Viimeksi lisätty"
 msgid "Show recent books"
 msgstr "Näytä viimeisimmät kirjat"
 
-#: cps/templates/index.xml:17 cps/ub.py:59
+#: cps/ub.py:59
 msgid "Hot Books"
 msgstr "Kuumat kirjat"
 
@@ -630,7 +652,7 @@ msgstr "Kuumat kirjat"
 msgid "Show Hot Books"
 msgstr "Näytä kuumat kirjat"
 
-#: cps/templates/index.xml:24 cps/ub.py:63 cps/web.py:508
+#: cps/ub.py:63 cps/web.py:508
 msgid "Top Rated Books"
 msgstr "Parhaiten arvioidut kirjat"
 
@@ -638,8 +660,7 @@ msgstr "Parhaiten arvioidut kirjat"
 msgid "Show Top Rated Books"
 msgstr "Näytä parhaiten arvioidut kirjat"
 
-#: cps/templates/index.xml:46 cps/templates/index.xml:50 cps/ub.py:66
-#: cps/web.py:1005
+#: cps/ub.py:66 cps/web.py:1005
 msgid "Read Books"
 msgstr "Luetut kirjat"
 
@@ -647,8 +668,7 @@ msgstr "Luetut kirjat"
 msgid "Show read and unread"
 msgstr "Näytä luetut ja lukemattomat"
 
-#: cps/templates/index.xml:53 cps/templates/index.xml:57 cps/ub.py:70
-#: cps/web.py:1009
+#: cps/ub.py:70 cps/web.py:1009
 msgid "Unread Books"
 msgstr "Lukemattomat kirjat"
 
@@ -664,7 +684,7 @@ msgstr "Löydä"
 msgid "Show random books"
 msgstr "Näytä satunnaisia kirjoja"
 
-#: cps/templates/index.xml:75 cps/ub.py:76 cps/web.py:787
+#: cps/ub.py:76 cps/web.py:787
 msgid "Categories"
 msgstr "Kategoriat"
 
@@ -672,8 +692,8 @@ msgstr "Kategoriat"
 msgid "Show category selection"
 msgstr "Näytä kategoriavalinta"
 
-#: cps/templates/book_edit.html:69 cps/templates/index.xml:82
-#: cps/templates/search_form.html:53 cps/ub.py:79 cps/web.py:715
+#: cps/templates/book_edit.html:69 cps/templates/search_form.html:53
+#: cps/ub.py:79 cps/web.py:715
 msgid "Series"
 msgstr "Sarjat"
 
@@ -681,7 +701,7 @@ msgstr "Sarjat"
 msgid "Show series selection"
 msgstr "Näytä sarjavalinta"
 
-#: cps/templates/index.xml:61 cps/ub.py:82
+#: cps/ub.py:82
 msgid "Authors"
 msgstr "Kirjailijat"
 
@@ -689,7 +709,7 @@ msgstr "Kirjailijat"
 msgid "Show author selection"
 msgstr "Näytä kirjailijavalinta"
 
-#: cps/templates/index.xml:68 cps/ub.py:86 cps/web.py:699
+#: cps/ub.py:86 cps/web.py:699
 msgid "Publishers"
 msgstr "Julkaisijat"
 
@@ -697,8 +717,7 @@ msgstr "Julkaisijat"
 msgid "Show publisher selection"
 msgstr "Näytä julkaisijavalinta"
 
-#: cps/templates/index.xml:89 cps/templates/search_form.html:74 cps/ub.py:89
-#: cps/web.py:770
+#: cps/templates/search_form.html:74 cps/ub.py:89 cps/web.py:770
 msgid "Languages"
 msgstr "Kielet"
 
@@ -706,7 +725,7 @@ msgstr "Kielet"
 msgid "Show language selection"
 msgstr "Näytä keilivalinta"
 
-#: cps/templates/index.xml:96 cps/ub.py:93
+#: cps/ub.py:93
 msgid "Ratings"
 msgstr "Arvostelut"
 
@@ -714,7 +733,7 @@ msgstr "Arvostelut"
 msgid "Show ratings selection"
 msgstr "Näytä arvosteluvalinta"
 
-#: cps/templates/index.xml:104 cps/ub.py:96
+#: cps/ub.py:96
 msgid "File formats"
 msgstr "Tiedotomuodot"
 
@@ -731,8 +750,12 @@ msgid "No update available. You already have the latest version installed"
 msgstr "Ei päivitystä saatavilla. Sinulla on jo uusin versio"
 
 #: cps/updater.py:333
-msgid "A new update is available. Click on the button below to update to the latest version."
-msgstr "Uusi päivitys saatavilla. Paina alla olevaa nappia päivittääksesi uusimpaan versioon."
+msgid ""
+"A new update is available. Click on the button below to update to the "
+"latest version."
+msgstr ""
+"Uusi päivitys saatavilla. Paina alla olevaa nappia päivittääksesi "
+"uusimpaan versioon."
 
 #: cps/updater.py:385
 msgid "Could not fetch update information"
@@ -744,8 +767,12 @@ msgstr "Ei päivitystietoa saatavilla"
 
 #: cps/updater.py:456 cps/updater.py:467 cps/updater.py:486
 #, python-format
-msgid "A new update is available. Click on the button below to update to version: %(version)s"
-msgstr "Uusi päivitys saatavilla. Paina alla olevaa nappia päivittääksesi versioon: %(version)s"
+msgid ""
+"A new update is available. Click on the button below to update to "
+"version: %(version)s"
+msgstr ""
+"Uusi päivitys saatavilla. Paina alla olevaa nappia päivittääksesi "
+"versioon: %(version)s"
 
 #: cps/updater.py:477
 msgid "Click on the button below to update to the latest stable version."
@@ -768,7 +795,9 @@ msgid "Hot Books (Most Downloaded)"
 msgstr "Kuumat kirjat (ladatuimmat)"
 
 #: cps/web.py:580
-msgid "Oops! Selected book title is unavailable. File does not exist or is not accessible"
+msgid ""
+"Oops! Selected book title is unavailable. File does not exist or is not "
+"accessible"
 msgstr "Virhe eKirjan avaamisessa. Tiedostoa ei ole tai se ei ole saatavilla:"
 
 #: cps/web.py:593
@@ -818,9 +847,9 @@ msgstr "Tiedostomuotolistaus"
 msgid "Tasks"
 msgstr "Tehtävät"
 
-#: cps/templates/book_edit.html:212 cps/templates/feed.xml:33
-#: cps/templates/layout.html:44 cps/templates/layout.html:47
-#: cps/templates/search_form.html:170 cps/web.py:821 cps/web.py:823
+#: cps/templates/book_edit.html:212 cps/templates/layout.html:44
+#: cps/templates/layout.html:47 cps/templates/search_form.html:170
+#: cps/web.py:821 cps/web.py:823
 msgid "Search"
 msgstr "Hae"
 
@@ -959,189 +988,189 @@ msgstr "E-kirjan muunnos epäonnistui: %(error)s"
 msgid "Kindlegen failed with Error %(error)s. Message: %(message)s"
 msgstr "Kindlegen epäonnistui virheeseen %(error)s. Viesti: %(message)s"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html:8
 msgid "Users"
 msgstr "Käyttäjälista"
 
-#: cps/templates/admin.html:12 cps/templates/login.html:8
+#: cps/templates/admin.html:11 cps/templates/login.html:8
 #: cps/templates/login.html:9 cps/templates/register.html:7
 #: cps/templates/user_edit.html:8
 msgid "Username"
 msgstr "Lempinimi"
 
-#: cps/templates/admin.html:13 cps/templates/register.html:11
+#: cps/templates/admin.html:12 cps/templates/register.html:11
 #: cps/templates/user_edit.html:13
 msgid "E-mail Address"
 msgstr "Sähköposti"
 
-#: cps/templates/admin.html:14 cps/templates/user_edit.html:26
+#: cps/templates/admin.html:13 cps/templates/user_edit.html:26
 msgid "Send to Kindle E-mail Address"
 msgstr "Kindle"
 
-#: cps/templates/admin.html:15
+#: cps/templates/admin.html:14
 msgid "Downloads"
 msgstr "DLS"
 
-#: cps/templates/admin.html:16 cps/templates/layout.html:76
+#: cps/templates/admin.html:15 cps/templates/layout.html:76
 msgid "Admin"
 msgstr "Ylläpito"
 
-#: cps/templates/admin.html:17 cps/templates/detail.html:18
+#: cps/templates/admin.html:16 cps/templates/detail.html:18
 #: cps/templates/detail.html:27 cps/templates/shelf.html:6
 #: cps/templates/shelfdown.html:62
 msgid "Download"
 msgstr "Lataa"
 
-#: cps/templates/admin.html:18
+#: cps/templates/admin.html:17
 msgid "View Books"
 msgstr "Näytä ekirjat"
 
-#: cps/templates/admin.html:19 cps/templates/layout.html:65
+#: cps/templates/admin.html:18 cps/templates/layout.html:65
 msgid "Upload"
 msgstr "Lähetä"
 
-#: cps/templates/admin.html:20
+#: cps/templates/admin.html:19
 msgid "Edit"
 msgstr "Muokkaa"
 
-#: cps/templates/admin.html:38
+#: cps/templates/admin.html:37
 msgid "Add New User"
 msgstr ""
 
-#: cps/templates/admin.html:44
+#: cps/templates/admin.html:43
 msgid "E-mail Server Settings"
 msgstr "SMTP sähköpostipalvelimen asetukset"
 
-#: cps/templates/admin.html:47 cps/templates/email_edit.html:11
+#: cps/templates/admin.html:46 cps/templates/email_edit.html:11
 msgid "SMTP Hostname"
 msgstr "SMTP palvein"
 
-#: cps/templates/admin.html:48 cps/templates/email_edit.html:15
+#: cps/templates/admin.html:47 cps/templates/email_edit.html:15
 msgid "SMTP Port"
 msgstr "SMTP portti"
 
-#: cps/templates/admin.html:49 cps/templates/email_edit.html:19
+#: cps/templates/admin.html:48 cps/templates/email_edit.html:19
 msgid "Encryption"
 msgstr "SSL"
 
-#: cps/templates/admin.html:50 cps/templates/email_edit.html:27
+#: cps/templates/admin.html:49 cps/templates/email_edit.html:27
 msgid "SMTP Login"
 msgstr "SMTP tunnus"
 
-#: cps/templates/admin.html:51 cps/templates/email_edit.html:35
+#: cps/templates/admin.html:50 cps/templates/email_edit.html:35
 msgid "From E-mail"
 msgstr "Lähettäjän sähköposti"
 
-#: cps/templates/admin.html:61
+#: cps/templates/admin.html:60
 msgid "Edit E-mail Server Settings"
 msgstr "Muuta SMTP asetuksia"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html:66
 msgid "Configuration"
 msgstr "Asetukset"
 
-#: cps/templates/admin.html:70
+#: cps/templates/admin.html:69
 msgid "Calibre Database Directory"
 msgstr "Calibre DB hakemisto"
 
-#: cps/templates/admin.html:74 cps/templates/config_edit.html:122
+#: cps/templates/admin.html:73 cps/templates/config_edit.html:122
 msgid "Log Level"
 msgstr "Lokitaso"
 
-#: cps/templates/admin.html:78
+#: cps/templates/admin.html:77
 msgid "Port"
 msgstr "Portti"
 
-#: cps/templates/admin.html:84 cps/templates/config_view_edit.html:27
+#: cps/templates/admin.html:83 cps/templates/config_view_edit.html:27
 msgid "Books per Page"
 msgstr "Kirjaa sivulla"
 
-#: cps/templates/admin.html:88
+#: cps/templates/admin.html:87
 msgid "Uploads"
 msgstr "Lähetetään"
 
-#: cps/templates/admin.html:92
+#: cps/templates/admin.html:91
 msgid "Anonymous Browsing"
 msgstr "Nimetön selaus"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html:95
 msgid "Public Registration"
 msgstr "Julkinen rekisteröinti"
 
-#: cps/templates/admin.html:100
+#: cps/templates/admin.html:99
 msgid "Magic Link Remote Login"
 msgstr "Etäkirjautuminen"
 
-#: cps/templates/admin.html:104
+#: cps/templates/admin.html:103
 msgid "Reverse Proxy Login"
 msgstr ""
 
-#: cps/templates/admin.html:109
+#: cps/templates/admin.html:108
 msgid "Reverse proxy header name"
 msgstr ""
 
-#: cps/templates/admin.html:114
+#: cps/templates/admin.html:113
 msgid "Edit Basic Configuration"
 msgstr ""
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html:114
 msgid "Edit UI Configuration"
 msgstr ""
 
-#: cps/templates/admin.html:121
+#: cps/templates/admin.html:120
 msgid "Administration"
 msgstr "Ylläpito"
 
-#: cps/templates/admin.html:122
+#: cps/templates/admin.html:121
 msgid "View Logs"
 msgstr "Katsele lokitiedostoja"
 
-#: cps/templates/admin.html:123
+#: cps/templates/admin.html:122
 msgid "Reconnect Calibre Database"
 msgstr "Uudelleenyhdistä Calibre DB"
 
-#: cps/templates/admin.html:124
+#: cps/templates/admin.html:123
 msgid "Restart"
 msgstr "Uudellenkäynnistä Calibre-Web"
 
-#: cps/templates/admin.html:125
+#: cps/templates/admin.html:124
 msgid "Shutdown"
 msgstr "Sammuta Calibre-Web"
 
-#: cps/templates/admin.html:131
+#: cps/templates/admin.html:130
 msgid "Update"
 msgstr "Päivitä"
 
-#: cps/templates/admin.html:135
+#: cps/templates/admin.html:134
 msgid "Version"
 msgstr "Versio"
 
-#: cps/templates/admin.html:136
+#: cps/templates/admin.html:135
 msgid "Details"
 msgstr "Yksityiskohdat"
 
-#: cps/templates/admin.html:142
+#: cps/templates/admin.html:141
 msgid "Current version"
 msgstr "Nykyinen versio"
 
-#: cps/templates/admin.html:148
+#: cps/templates/admin.html:147
 msgid "Check for Update"
 msgstr "Tarkista päivitykset"
 
-#: cps/templates/admin.html:149
+#: cps/templates/admin.html:148
 msgid "Perform Update"
 msgstr "Päivitä"
 
-#: cps/templates/admin.html:161
+#: cps/templates/admin.html:160
 msgid "Are you sure you want to restart?"
 msgstr "Haluatko varmasti uudelleenkäynnistää Calibre-Webin?"
 
-#: cps/templates/admin.html:166 cps/templates/admin.html:180
-#: cps/templates/admin.html:200 cps/templates/shelf.html:72
+#: cps/templates/admin.html:165 cps/templates/admin.html:179
+#: cps/templates/admin.html:199 cps/templates/shelf.html:72
 msgid "OK"
 msgstr "Ok"
 
-#: cps/templates/admin.html:167 cps/templates/admin.html:181
+#: cps/templates/admin.html:166 cps/templates/admin.html:180
 #: cps/templates/book_edit.html:172 cps/templates/book_edit.html:194
 #: cps/templates/config_edit.html:346 cps/templates/config_view_edit.html:151
 #: cps/templates/email_edit.html:40 cps/templates/email_edit.html:92
@@ -1150,11 +1179,11 @@ msgstr "Ok"
 msgid "Cancel"
 msgstr ""
 
-#: cps/templates/admin.html:179
+#: cps/templates/admin.html:178
 msgid "Are you sure you want to shutdown?"
 msgstr "Haluatko varmasti pysäyttää Calibre-Webin?"
 
-#: cps/templates/admin.html:191
+#: cps/templates/admin.html:190
 msgid "Updating, please do not reload this page"
 msgstr "Päivitetään, älä päivitä sivua"
 
@@ -1243,8 +1272,12 @@ msgid "Rating"
 msgstr "Arvostelu"
 
 #: cps/templates/book_edit.html:81
-msgid "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
-msgstr "Kannen osoite (jpg, kuva ladataan ja tallennetaan tietokantaan, kenttä jää uudelleen tyhjäksi)"
+msgid ""
+"Fetch Cover from URL (JPEG - Image will be downloaded and stored in "
+"database)"
+msgstr ""
+"Kannen osoite (jpg, kuva ladataan ja tallennetaan tietokantaan, kenttä "
+"jää uudelleen tyhjäksi)"
 
 #: cps/templates/book_edit.html:85
 msgid "Upload Cover from Local Disk"
@@ -1777,15 +1810,6 @@ msgstr ""
 msgid "Are you sure you want to delete this domain?"
 msgstr "Haluatko todellakin poistaa tämän domainin säännön?"
 
-#: cps/templates/feed.xml:21 cps/templates/layout.html:173
-msgid "Next"
-msgstr "Seuraava"
-
-#: cps/templates/feed.xml:79 cps/templates/layout.html:136
-#: cps/templates/layout.html:140
-msgid "(Public)"
-msgstr ""
-
 #: cps/templates/generate_kobo_auth_url.html:5
 msgid "Open the .kobo/Kobo eReader.conf file in a text editor and add (or edit):"
 msgstr ""
@@ -1801,70 +1825,6 @@ msgstr "Palaa kotiin"
 #: cps/templates/index.html:64
 msgid "Group by series"
 msgstr "Ryhmitä sarjoittain"
-
-#: cps/templates/index.xml:6
-msgid "Start"
-msgstr "Aloita"
-
-#: cps/templates/index.xml:21
-msgid "Popular publications from this catalog based on Downloads."
-msgstr "Suositut julkaisut tästä kokoelmasta perustuen latauksiin."
-
-#: cps/templates/index.xml:28
-msgid "Popular publications from this catalog based on Rating."
-msgstr "Suositut julkaisut tästä kokoelmasta perustuen arvioihin."
-
-#: cps/templates/index.xml:31
-msgid "Recently added Books"
-msgstr ""
-
-#: cps/templates/index.xml:35
-msgid "The latest Books"
-msgstr "Viimeisimmät kirjat"
-
-#: cps/templates/index.xml:38
-msgid "Random Books"
-msgstr "Satunnaisia kirjoja"
-
-#: cps/templates/index.xml:42 cps/templates/user_edit.html:80
-msgid "Show Random Books"
-msgstr "Näytä satunnausia kirjoja"
-
-#: cps/templates/index.xml:65
-msgid "Books ordered by Author"
-msgstr "Kirjat kirjailijoittain"
-
-#: cps/templates/index.xml:72
-msgid "Books ordered by publisher"
-msgstr "Kirjat julkaisijoittain"
-
-#: cps/templates/index.xml:79
-msgid "Books ordered by category"
-msgstr "Kirjat kategorioittain"
-
-#: cps/templates/index.xml:86
-msgid "Books ordered by series"
-msgstr "Kirjat sarjoittain"
-
-#: cps/templates/index.xml:93
-msgid "Books ordered by Languages"
-msgstr ""
-
-#: cps/templates/index.xml:100
-msgid "Books ordered by Rating"
-msgstr ""
-
-#: cps/templates/index.xml:108
-msgid "Books ordered by file formats"
-msgstr ""
-
-#: cps/templates/index.xml:111 cps/templates/layout.html:134
-msgid "Shelves"
-msgstr ""
-
-#: cps/templates/index.xml:115
-msgid "Books organized in shelves"
-msgstr ""
 
 #: cps/templates/layout.html:28
 msgid "Home"
@@ -1916,6 +1876,14 @@ msgstr ""
 msgid "Browse"
 msgstr "Selaa"
 
+#: cps/templates/layout.html:134
+msgid "Shelves"
+msgstr ""
+
+#: cps/templates/layout.html:136 cps/templates/layout.html:140
+msgid "(Public)"
+msgstr ""
+
 #: cps/templates/layout.html:138
 msgid "Your Shelves"
 msgstr "Omat hyllysi"
@@ -1927,6 +1895,10 @@ msgstr "Tietoja"
 #: cps/templates/layout.html:158
 msgid "Previous"
 msgstr "Edellinen"
+
+#: cps/templates/layout.html:173
+msgid "Next"
+msgstr "Seuraava"
 
 #: cps/templates/layout.html:185
 msgid "Book Details"
@@ -2309,6 +2281,10 @@ msgstr ""
 msgid "Create/View"
 msgstr ""
 
+#: cps/templates/user_edit.html:80
+msgid "Show Random Books"
+msgstr "Näytä satunnausia kirjoja"
+
 #: cps/templates/user_edit.html:84
 msgid "Add allowed/Denied Custom Column Values"
 msgstr ""
@@ -2328,4 +2304,208 @@ msgstr ""
 #: cps/templates/user_edit.html:176
 msgid "Do you really want to delete the Kobo Token?"
 msgstr ""
+
+#: vendor/tornado/locale.py:285
+msgid "January"
+msgstr ""
+
+#: vendor/tornado/locale.py:286
+msgid "February"
+msgstr ""
+
+#: vendor/tornado/locale.py:287
+msgid "March"
+msgstr ""
+
+#: vendor/tornado/locale.py:288
+msgid "April"
+msgstr ""
+
+#: vendor/tornado/locale.py:289
+msgid "May"
+msgstr ""
+
+#: vendor/tornado/locale.py:290
+msgid "June"
+msgstr ""
+
+#: vendor/tornado/locale.py:291
+msgid "July"
+msgstr ""
+
+#: vendor/tornado/locale.py:292
+msgid "August"
+msgstr ""
+
+#: vendor/tornado/locale.py:293
+msgid "September"
+msgstr ""
+
+#: vendor/tornado/locale.py:294
+msgid "October"
+msgstr ""
+
+#: vendor/tornado/locale.py:295
+msgid "November"
+msgstr ""
+
+#: vendor/tornado/locale.py:296
+msgid "December"
+msgstr ""
+
+#: vendor/tornado/locale.py:299
+msgid "Monday"
+msgstr ""
+
+#: vendor/tornado/locale.py:300
+msgid "Tuesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:301
+msgid "Wednesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:302
+msgid "Thursday"
+msgstr ""
+
+#: vendor/tornado/locale.py:303
+msgid "Friday"
+msgstr ""
+
+#: vendor/tornado/locale.py:304
+msgid "Saturday"
+msgstr ""
+
+#: vendor/tornado/locale.py:305
+msgid "Sunday"
+msgstr ""
+
+#: vendor/tornado/locale.py:368
+msgid "1 second ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:374
+msgid "1 minute ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:379
+msgid "1 hour ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:382
+#, python-format
+msgid "%(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+msgid "yesterday"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+#, python-format
+msgid "yesterday at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:389 vendor/tornado/locale.py:442
+#, python-format
+msgid "%(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:391
+#, python-format
+msgid "%(month_name)s %(day)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:396
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:398
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:436
+#, python-format
+msgid "%(weekday)s, %(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:459
+#, python-format
+msgid "%(commas)s and %(last)s"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:68
+msgctxt "law"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:69
+msgctxt "good"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:71 vendor/tornado/test/locale_test.py:74
+msgctxt "organization"
+msgid "club"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:76 vendor/tornado/test/locale_test.py:77
+msgctxt "stick"
+msgid "club"
+msgstr ""
+
+#~ msgid "Start"
+#~ msgstr "Aloita"
+
+#~ msgid "Popular publications from this catalog based on Downloads."
+#~ msgstr "Suositut julkaisut tästä kokoelmasta perustuen latauksiin."
+
+#~ msgid "Popular publications from this catalog based on Rating."
+#~ msgstr "Suositut julkaisut tästä kokoelmasta perustuen arvioihin."
+
+#~ msgid "Recently added Books"
+#~ msgstr ""
+
+#~ msgid "The latest Books"
+#~ msgstr "Viimeisimmät kirjat"
+
+#~ msgid "Random Books"
+#~ msgstr "Satunnaisia kirjoja"
+
+#~ msgid "Books ordered by Author"
+#~ msgstr "Kirjat kirjailijoittain"
+
+#~ msgid "Books ordered by publisher"
+#~ msgstr "Kirjat julkaisijoittain"
+
+#~ msgid "Books ordered by category"
+#~ msgstr "Kirjat kategorioittain"
+
+#~ msgid "Books ordered by series"
+#~ msgstr "Kirjat sarjoittain"
+
+#~ msgid "Books ordered by Languages"
+#~ msgstr ""
+
+#~ msgid "Books ordered by Rating"
+#~ msgstr ""
+
+#~ msgid "Books ordered by file formats"
+#~ msgstr ""
+
+#~ msgid "Books organized in shelves"
+#~ msgstr ""
 

--- a/cps/translations/fr/LC_MESSAGES/messages.po
+++ b/cps/translations/fr/LC_MESSAGES/messages.po
@@ -20,7 +20,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Calibre-Web\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-03 19:49+0200\n"
+"POT-Creation-Date: 2020-04-08 23:10+0800\n"
 "PO-Revision-Date: 2019-08-21 15:20+0100\n"
 "Last-Translator: Nicolas Roudninski <nicoroud@gmail.com>\n"
 "Language: fr\n"
@@ -97,7 +97,9 @@ msgstr "Cette adresse de courriel n’appartient pas à un domaine valide"
 
 #: cps/admin.py:710 cps/admin.py:725
 msgid "Found an existing account for this e-mail address or nickname."
-msgstr "Un compte existant a été trouvé pour cette adresse de courriel ou pour ce surnom."
+msgstr ""
+"Un compte existant a été trouvé pour cette adresse de courriel ou pour ce"
+" surnom."
 
 #: cps/admin.py:721
 #, python-format
@@ -233,7 +235,9 @@ msgstr ""
 
 #: cps/editbooks.py:214 cps/editbooks.py:396
 msgid "Error opening eBook. File does not exist or file is not accessible"
-msgstr "Erreur à l’ouverture du livre. Le fichier n’existe pas ou n’est pas accessible"
+msgstr ""
+"Erreur à l’ouverture du livre. Le fichier n’existe pas ou n’est pas "
+"accessible"
 
 #: cps/editbooks.py:242
 msgid "edit metadata"
@@ -242,7 +246,9 @@ msgstr "modifier les métadonnées"
 #: cps/editbooks.py:321 cps/editbooks.py:569
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
-msgstr "L’extension de fichier '%(ext)s' n’est pas autorisée pour être déposée sur ce serveur"
+msgstr ""
+"L’extension de fichier '%(ext)s' n’est pas autorisée pour être déposée "
+"sur ce serveur"
 
 #: cps/editbooks.py:325 cps/editbooks.py:573
 msgid "File to be uploaded must have an extension"
@@ -278,7 +284,9 @@ msgstr "Les métadonnées ont bien été mise à jour"
 
 #: cps/editbooks.py:534
 msgid "Error editing book, please check logfile for details"
-msgstr "Erreur d’édition du livre, veuillez consulter le journal (log) pour plus de détails"
+msgstr ""
+"Erreur d’édition du livre, veuillez consulter le journal (log) pour plus "
+"de détails"
 
 #: cps/editbooks.py:581
 #, python-format
@@ -286,7 +294,9 @@ msgid "File %(filename)s could not saved to temp dir"
 msgstr ""
 
 #: cps/editbooks.py:598
-msgid "Uploaded book probably exists in the library, consider to change before upload new: "
+msgid ""
+"Uploaded book probably exists in the library, consider to change before "
+"upload new: "
 msgstr ""
 
 #: cps/editbooks.py:613
@@ -311,7 +321,9 @@ msgstr "Le format de conversion de la source ou de la destination est manquant"
 #: cps/editbooks.py:746
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
-msgstr "Le livre a été mis avec succès en file de traitement pour conversion vers %(book_format)s"
+msgstr ""
+"Le livre a été mis avec succès en file de traitement pour conversion vers"
+" %(book_format)s"
 
 #: cps/editbooks.py:750
 #, python-format
@@ -319,12 +331,21 @@ msgid "There was an error converting this book: %(res)s"
 msgstr "Une erreur est survenue au cours de la conversion du livre : %(res)s"
 
 #: cps/gdrive.py:61
-msgid "Google Drive setup not completed, try to deactivate and activate Google Drive again"
-msgstr "La configuration de Google Drive n’est pas terminée, essayez de désactiver et d’activer à nouveau Google Drive."
+msgid ""
+"Google Drive setup not completed, try to deactivate and activate Google "
+"Drive again"
+msgstr ""
+"La configuration de Google Drive n’est pas terminée, essayez de "
+"désactiver et d’activer à nouveau Google Drive."
 
 #: cps/gdrive.py:103
-msgid "Callback domain is not verified, please follow steps to verify domain in google developer console"
-msgstr "Le domaine de retour d’appel (Callback domain) est non vérifié, Veuillez suivre les étapes nécessaires pour vérifier le domaine dans la console de développement de Google"
+msgid ""
+"Callback domain is not verified, please follow steps to verify domain in "
+"google developer console"
+msgstr ""
+"Le domaine de retour d’appel (Callback domain) est non vérifié, Veuillez "
+"suivre les étapes nécessaires pour vérifier le domaine dans la console de"
+" développement de Google"
 
 #: cps/helper.py:80
 #, python-format
@@ -390,17 +411,23 @@ msgstr "Le fichier demandé n’a pu être lu. Problème de permission d’accè
 #: cps/helper.py:322
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
-msgstr "Renommer le titre de : '%(src)s' à '%(dest)s' a échoué avec l’erreur : %(error)s"
+msgstr ""
+"Renommer le titre de : '%(src)s' à '%(dest)s' a échoué avec l’erreur : "
+"%(error)s"
 
 #: cps/helper.py:332
 #, python-format
 msgid "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
-msgstr "Renommer l’auteur de : '%(src)s' à '%(dest)s' a échoué avec l’erreur : %(error)s"
+msgstr ""
+"Renommer l’auteur de : '%(src)s' à '%(dest)s' a échoué avec l’erreur : "
+"%(error)s"
 
 #: cps/helper.py:346
 #, python-format
 msgid "Rename file in path '%(src)s' to '%(dest)s' failed with error: %(error)s"
-msgstr "La modification du nom de fichier du chemin : '%(src)s' vers '%(dest)s' a échoué avec l’erreur : %(error)s"
+msgstr ""
+"La modification du nom de fichier du chemin : '%(src)s' vers '%(dest)s' a"
+" échoué avec l’erreur : %(error)s"
 
 #: cps/helper.py:372 cps/helper.py:382 cps/helper.py:390
 #, python-format
@@ -469,7 +496,9 @@ msgid "Unknown Task: "
 msgstr "Tâche inconnue : "
 
 #: cps/kobo_auth.py:127
-msgid "PLease access calibre-web from non localhost to get valid api_endpoint for kobo device"
+msgid ""
+"PLease access calibre-web from non localhost to get valid api_endpoint "
+"for kobo device"
 msgstr ""
 
 #: cps/kobo_auth.py:130 cps/kobo_auth.py:150
@@ -527,7 +556,9 @@ msgstr "L’étagère indiquée est invalide"
 #: cps/shelf.py:54
 #, python-format
 msgid "Sorry you are not allowed to add a book to the the shelf: %(shelfname)s"
-msgstr "Désolé, vous n’êtes pas autorisé à ajouter un livre dans l’étagère %(shelfname)s"
+msgstr ""
+"Désolé, vous n’êtes pas autorisé à ajouter un livre dans l’étagère "
+"%(shelfname)s"
 
 #: cps/shelf.py:62
 msgid "You are not allowed to edit public shelves"
@@ -575,7 +606,9 @@ msgstr "Le livre a été supprimé de l'étagère %(sname)s"
 #: cps/shelf.py:190
 #, python-format
 msgid "Sorry you are not allowed to remove a book from this shelf: %(sname)s"
-msgstr "Désolé, vous n’êtes pas autorisé à enlever un livre de cette étagère : %(sname)s"
+msgstr ""
+"Désolé, vous n’êtes pas autorisé à enlever un livre de cette étagère : "
+"%(sname)s"
 
 #: cps/shelf.py:215 cps/shelf.py:252
 #, python-format
@@ -616,7 +649,9 @@ msgstr "Étagère : '%(name)s'"
 
 #: cps/shelf.py:330
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
-msgstr "Erreur à l’ouverture de l’étagère. Elle n’existe plus ou n’est plus accessible"
+msgstr ""
+"Erreur à l’ouverture de l’étagère. Elle n’existe plus ou n’est plus "
+"accessible"
 
 #: cps/shelf.py:368
 msgid "Hidden Book"
@@ -635,7 +670,7 @@ msgstr "Ajouts récents"
 msgid "Show recent books"
 msgstr "Afficher les livres récents"
 
-#: cps/templates/index.xml:17 cps/ub.py:59
+#: cps/ub.py:59
 msgid "Hot Books"
 msgstr "Livres populaires"
 
@@ -643,7 +678,7 @@ msgstr "Livres populaires"
 msgid "Show Hot Books"
 msgstr "Montrer les livres populaires"
 
-#: cps/templates/index.xml:24 cps/ub.py:63 cps/web.py:508
+#: cps/ub.py:63 cps/web.py:508
 msgid "Top Rated Books"
 msgstr "Livres les mieux notés"
 
@@ -651,8 +686,7 @@ msgstr "Livres les mieux notés"
 msgid "Show Top Rated Books"
 msgstr "Montrer les livres les mieux notés"
 
-#: cps/templates/index.xml:46 cps/templates/index.xml:50 cps/ub.py:66
-#: cps/web.py:1005
+#: cps/ub.py:66 cps/web.py:1005
 msgid "Read Books"
 msgstr "Livres lus"
 
@@ -660,8 +694,7 @@ msgstr "Livres lus"
 msgid "Show read and unread"
 msgstr "Montrer lu et non-lu"
 
-#: cps/templates/index.xml:53 cps/templates/index.xml:57 cps/ub.py:70
-#: cps/web.py:1009
+#: cps/ub.py:70 cps/web.py:1009
 msgid "Unread Books"
 msgstr "Livres non-lus"
 
@@ -677,7 +710,7 @@ msgstr "Découvrir"
 msgid "Show random books"
 msgstr "Montrer des livres au hasard"
 
-#: cps/templates/index.xml:75 cps/ub.py:76 cps/web.py:787
+#: cps/ub.py:76 cps/web.py:787
 msgid "Categories"
 msgstr "Catégories"
 
@@ -685,8 +718,8 @@ msgstr "Catégories"
 msgid "Show category selection"
 msgstr "Montrer la sélection par catégories"
 
-#: cps/templates/book_edit.html:69 cps/templates/index.xml:82
-#: cps/templates/search_form.html:53 cps/ub.py:79 cps/web.py:715
+#: cps/templates/book_edit.html:69 cps/templates/search_form.html:53
+#: cps/ub.py:79 cps/web.py:715
 msgid "Series"
 msgstr "Séries"
 
@@ -694,7 +727,7 @@ msgstr "Séries"
 msgid "Show series selection"
 msgstr "Montrer la sélection par séries"
 
-#: cps/templates/index.xml:61 cps/ub.py:82
+#: cps/ub.py:82
 msgid "Authors"
 msgstr "Auteurs"
 
@@ -702,7 +735,7 @@ msgstr "Auteurs"
 msgid "Show author selection"
 msgstr "Montrer la sélection par auteur"
 
-#: cps/templates/index.xml:68 cps/ub.py:86 cps/web.py:699
+#: cps/ub.py:86 cps/web.py:699
 msgid "Publishers"
 msgstr "Editeurs"
 
@@ -710,8 +743,7 @@ msgstr "Editeurs"
 msgid "Show publisher selection"
 msgstr "Montrer la sélection par éditeur"
 
-#: cps/templates/index.xml:89 cps/templates/search_form.html:74 cps/ub.py:89
-#: cps/web.py:770
+#: cps/templates/search_form.html:74 cps/ub.py:89 cps/web.py:770
 msgid "Languages"
 msgstr "Langues"
 
@@ -719,7 +751,7 @@ msgstr "Langues"
 msgid "Show language selection"
 msgstr "Montrer la sélection par langue"
 
-#: cps/templates/index.xml:96 cps/ub.py:93
+#: cps/ub.py:93
 msgid "Ratings"
 msgstr "Notes"
 
@@ -727,7 +759,7 @@ msgstr "Notes"
 msgid "Show ratings selection"
 msgstr "Afficher la sélection des notes"
 
-#: cps/templates/index.xml:104 cps/ub.py:96
+#: cps/ub.py:96
 msgid "File formats"
 msgstr "Format de fichier"
 
@@ -741,11 +773,17 @@ msgstr "Données inattendues lors de la lecture des informations de mise à jour
 
 #: cps/updater.py:301 cps/updater.py:412
 msgid "No update available. You already have the latest version installed"
-msgstr "Aucune mise à jour disponible. Vous avez déjà la dernière version installée"
+msgstr ""
+"Aucune mise à jour disponible. Vous avez déjà la dernière version "
+"installée"
 
 #: cps/updater.py:333
-msgid "A new update is available. Click on the button below to update to the latest version."
-msgstr "Une nouvelle mise à jour est disponible. Cliquez sur le bouton ci-dessous pour charger la dernière version."
+msgid ""
+"A new update is available. Click on the button below to update to the "
+"latest version."
+msgstr ""
+"Une nouvelle mise à jour est disponible. Cliquez sur le bouton ci-dessous"
+" pour charger la dernière version."
 
 #: cps/updater.py:385
 msgid "Could not fetch update information"
@@ -757,8 +795,12 @@ msgstr "Aucune information concernant cette version n’est disponible"
 
 #: cps/updater.py:456 cps/updater.py:467 cps/updater.py:486
 #, python-format
-msgid "A new update is available. Click on the button below to update to version: %(version)s"
-msgstr "Une nouvelle mise à jour est disponible. Cliquez sur le bouton ci-dessous pour charger la version %(version)s"
+msgid ""
+"A new update is available. Click on the button below to update to "
+"version: %(version)s"
+msgstr ""
+"Une nouvelle mise à jour est disponible. Cliquez sur le bouton ci-dessous"
+" pour charger la version %(version)s"
 
 #: cps/updater.py:477
 msgid "Click on the button below to update to the latest stable version."
@@ -781,8 +823,12 @@ msgid "Hot Books (Most Downloaded)"
 msgstr "Livres populaires (les plus téléchargés)"
 
 #: cps/web.py:580
-msgid "Oops! Selected book title is unavailable. File does not exist or is not accessible"
-msgstr "Erreur d'ouverture du livre numérique. Le fichier n'existe pas ou n'est pas accessible :"
+msgid ""
+"Oops! Selected book title is unavailable. File does not exist or is not "
+"accessible"
+msgstr ""
+"Erreur d'ouverture du livre numérique. Le fichier n'existe pas ou n'est "
+"pas accessible :"
 
 #: cps/web.py:593
 #, python-format
@@ -831,9 +877,9 @@ msgstr ""
 msgid "Tasks"
 msgstr "Tâches"
 
-#: cps/templates/book_edit.html:212 cps/templates/feed.xml:33
-#: cps/templates/layout.html:44 cps/templates/layout.html:47
-#: cps/templates/search_form.html:170 cps/web.py:821 cps/web.py:823
+#: cps/templates/book_edit.html:212 cps/templates/layout.html:44
+#: cps/templates/layout.html:47 cps/templates/search_form.html:170
+#: cps/web.py:821 cps/web.py:823
 msgid "Search"
 msgstr "Chercher"
 
@@ -862,7 +908,9 @@ msgstr "recherche"
 #: cps/web.py:1060
 #, python-format
 msgid "Book successfully queued for sending to %(kindlemail)s"
-msgstr "Le livre a été mis en file de traitement avec succès pour un envois vers %(kindlemail)s"
+msgstr ""
+"Le livre a été mis en file de traitement avec succès pour un envois vers "
+"%(kindlemail)s"
 
 #: cps/web.py:1064
 #, python-format
@@ -905,7 +953,9 @@ msgstr "vous êtes maintenant connecté sous : '%(nickname)s'"
 
 #: cps/web.py:1155
 msgid "Could not login. LDAP server down, please contact your administrator"
-msgstr "Impossible de se connecter. Serveur LDAP hors service, veuillez contacter votre administrateur"
+msgstr ""
+"Impossible de se connecter. Serveur LDAP hors service, veuillez contacter"
+" votre administrateur"
 
 #: cps/web.py:1159 cps/web.py:1182
 msgid "Wrong Username or Password"
@@ -960,7 +1010,9 @@ msgstr "Lire un livre"
 
 #: cps/web.py:1425
 msgid "Error opening eBook. File does not exist or file is not accessible."
-msgstr "Erreur lors de l’ouverture d’un eBook. Le fichier n’existe pas ou le fichier n’est pas accessible."
+msgstr ""
+"Erreur lors de l’ouverture d’un eBook. Le fichier n’existe pas ou le "
+"fichier n’est pas accessible."
 
 #: cps/worker.py:335
 #, python-format
@@ -970,191 +1022,193 @@ msgstr "La commande ebook-convert a échouée : %(error)s"
 #: cps/worker.py:346
 #, python-format
 msgid "Kindlegen failed with Error %(error)s. Message: %(message)s"
-msgstr "La commande Kindlegen a échouée avec le code d’erreur : %(error)s et le message : %(message)s"
+msgstr ""
+"La commande Kindlegen a échouée avec le code d’erreur : %(error)s et le "
+"message : %(message)s"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html:8
 msgid "Users"
 msgstr "Liste des utilisateurs"
 
-#: cps/templates/admin.html:12 cps/templates/login.html:8
+#: cps/templates/admin.html:11 cps/templates/login.html:8
 #: cps/templates/login.html:9 cps/templates/register.html:7
 #: cps/templates/user_edit.html:8
 msgid "Username"
 msgstr "Surnom"
 
-#: cps/templates/admin.html:13 cps/templates/register.html:11
+#: cps/templates/admin.html:12 cps/templates/register.html:11
 #: cps/templates/user_edit.html:13
 msgid "E-mail Address"
 msgstr "Courriel"
 
-#: cps/templates/admin.html:14 cps/templates/user_edit.html:26
+#: cps/templates/admin.html:13 cps/templates/user_edit.html:26
 msgid "Send to Kindle E-mail Address"
 msgstr "Kindle"
 
-#: cps/templates/admin.html:15
+#: cps/templates/admin.html:14
 msgid "Downloads"
 msgstr "DLS"
 
-#: cps/templates/admin.html:16 cps/templates/layout.html:76
+#: cps/templates/admin.html:15 cps/templates/layout.html:76
 msgid "Admin"
 msgstr "Administration"
 
-#: cps/templates/admin.html:17 cps/templates/detail.html:18
+#: cps/templates/admin.html:16 cps/templates/detail.html:18
 #: cps/templates/detail.html:27 cps/templates/shelf.html:6
 #: cps/templates/shelfdown.html:62
 msgid "Download"
 msgstr "Télécharger"
 
-#: cps/templates/admin.html:18
+#: cps/templates/admin.html:17
 msgid "View Books"
 msgstr "Afficher les Ebooks"
 
-#: cps/templates/admin.html:19 cps/templates/layout.html:65
+#: cps/templates/admin.html:18 cps/templates/layout.html:65
 msgid "Upload"
 msgstr "Téléverser"
 
-#: cps/templates/admin.html:20
+#: cps/templates/admin.html:19
 msgid "Edit"
 msgstr "Éditer"
 
-#: cps/templates/admin.html:38
+#: cps/templates/admin.html:37
 msgid "Add New User"
 msgstr ""
 
-#: cps/templates/admin.html:44
+#: cps/templates/admin.html:43
 msgid "E-mail Server Settings"
 msgstr "Paramètres du serveur SMTP"
 
-#: cps/templates/admin.html:47 cps/templates/email_edit.html:11
+#: cps/templates/admin.html:46 cps/templates/email_edit.html:11
 msgid "SMTP Hostname"
 msgstr "Adresse du serveur SMTP"
 
-#: cps/templates/admin.html:48 cps/templates/email_edit.html:15
+#: cps/templates/admin.html:47 cps/templates/email_edit.html:15
 msgid "SMTP Port"
 msgstr "Port du serveur SMTP"
 
-#: cps/templates/admin.html:49 cps/templates/email_edit.html:19
+#: cps/templates/admin.html:48 cps/templates/email_edit.html:19
 msgid "Encryption"
 msgstr "SSL"
 
-#: cps/templates/admin.html:50 cps/templates/email_edit.html:27
+#: cps/templates/admin.html:49 cps/templates/email_edit.html:27
 msgid "SMTP Login"
 msgstr "Compte utilisateur SMTP"
 
-#: cps/templates/admin.html:51 cps/templates/email_edit.html:35
+#: cps/templates/admin.html:50 cps/templates/email_edit.html:35
 msgid "From E-mail"
 msgstr "Expéditeur des courriels"
 
-#: cps/templates/admin.html:61
+#: cps/templates/admin.html:60
 msgid "Edit E-mail Server Settings"
 msgstr "Modifier les paramètres SMTP"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html:66
 msgid "Configuration"
 msgstr "Configuration"
 
-#: cps/templates/admin.html:70
+#: cps/templates/admin.html:69
 msgid "Calibre Database Directory"
 msgstr "Répertoire de la base de donnée Calibre"
 
-#: cps/templates/admin.html:74 cps/templates/config_edit.html:122
+#: cps/templates/admin.html:73 cps/templates/config_edit.html:122
 msgid "Log Level"
 msgstr "Niveau de journalisation"
 
-#: cps/templates/admin.html:78
+#: cps/templates/admin.html:77
 msgid "Port"
 msgstr "Port"
 
-#: cps/templates/admin.html:84 cps/templates/config_view_edit.html:27
+#: cps/templates/admin.html:83 cps/templates/config_view_edit.html:27
 msgid "Books per Page"
 msgstr "Livres par page"
 
-#: cps/templates/admin.html:88
+#: cps/templates/admin.html:87
 msgid "Uploads"
 msgstr "Téléversement de fichier"
 
-#: cps/templates/admin.html:92
+#: cps/templates/admin.html:91
 msgid "Anonymous Browsing"
 msgstr "Navigation anonyme"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html:95
 msgid "Public Registration"
 msgstr "Inscription public"
 
-#: cps/templates/admin.html:100
+#: cps/templates/admin.html:99
 msgid "Magic Link Remote Login"
 msgstr "Connexion (\"magic link\")"
 
-#: cps/templates/admin.html:104
+#: cps/templates/admin.html:103
 msgid "Reverse Proxy Login"
 msgstr ""
 
-#: cps/templates/admin.html:109
+#: cps/templates/admin.html:108
 msgid "Reverse proxy header name"
 msgstr ""
 
-#: cps/templates/admin.html:114
+#: cps/templates/admin.html:113
 msgid "Edit Basic Configuration"
 msgstr ""
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html:114
 msgid "Edit UI Configuration"
 msgstr ""
 
-#: cps/templates/admin.html:121
+#: cps/templates/admin.html:120
 msgid "Administration"
 msgstr "Administration"
 
-#: cps/templates/admin.html:122
+#: cps/templates/admin.html:121
 msgid "View Logs"
 msgstr "Afficher les fichiers journaux"
 
-#: cps/templates/admin.html:123
+#: cps/templates/admin.html:122
 msgid "Reconnect Calibre Database"
 msgstr "Se reconnecter à Calibre-Web"
 
-#: cps/templates/admin.html:124
+#: cps/templates/admin.html:123
 msgid "Restart"
 msgstr "Redémarrer Calibre-Web"
 
-#: cps/templates/admin.html:125
+#: cps/templates/admin.html:124
 msgid "Shutdown"
 msgstr "Arrêter Calibre-Web"
 
-#: cps/templates/admin.html:131
+#: cps/templates/admin.html:130
 msgid "Update"
 msgstr "Mise à jour de Calibre-Web"
 
-#: cps/templates/admin.html:135
+#: cps/templates/admin.html:134
 msgid "Version"
 msgstr "Version"
 
-#: cps/templates/admin.html:136
+#: cps/templates/admin.html:135
 msgid "Details"
 msgstr "Détails"
 
-#: cps/templates/admin.html:142
+#: cps/templates/admin.html:141
 msgid "Current version"
 msgstr "Version actuellement installée"
 
-#: cps/templates/admin.html:148
+#: cps/templates/admin.html:147
 msgid "Check for Update"
 msgstr "Rechercher les mise à jour"
 
-#: cps/templates/admin.html:149
+#: cps/templates/admin.html:148
 msgid "Perform Update"
 msgstr "Effectuer la mise à jour"
 
-#: cps/templates/admin.html:161
+#: cps/templates/admin.html:160
 msgid "Are you sure you want to restart?"
 msgstr "Voulez-vous vraiment redémarrer Calibre-Web?"
 
-#: cps/templates/admin.html:166 cps/templates/admin.html:180
-#: cps/templates/admin.html:200 cps/templates/shelf.html:72
+#: cps/templates/admin.html:165 cps/templates/admin.html:179
+#: cps/templates/admin.html:199 cps/templates/shelf.html:72
 msgid "OK"
 msgstr "Oui"
 
-#: cps/templates/admin.html:167 cps/templates/admin.html:181
+#: cps/templates/admin.html:166 cps/templates/admin.html:180
 #: cps/templates/book_edit.html:172 cps/templates/book_edit.html:194
 #: cps/templates/config_edit.html:346 cps/templates/config_view_edit.html:151
 #: cps/templates/email_edit.html:40 cps/templates/email_edit.html:92
@@ -1163,11 +1217,11 @@ msgstr "Oui"
 msgid "Cancel"
 msgstr ""
 
-#: cps/templates/admin.html:179
+#: cps/templates/admin.html:178
 msgid "Are you sure you want to shutdown?"
 msgstr "Voulez-Vous vraiment arrêter Calibre-Web?"
 
-#: cps/templates/admin.html:191
+#: cps/templates/admin.html:190
 msgid "Updating, please do not reload this page"
 msgstr "Mise à jour en cours, ne pas rafraîchir la page"
 
@@ -1256,8 +1310,12 @@ msgid "Rating"
 msgstr "Évaluation"
 
 #: cps/templates/book_edit.html:81
-msgid "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
-msgstr "URL de la couverture (jpg, la couverture est déposée sur le serveur et sauvegardée en base, ce champ est ensuite remis à vide)"
+msgid ""
+"Fetch Cover from URL (JPEG - Image will be downloaded and stored in "
+"database)"
+msgstr ""
+"URL de la couverture (jpg, la couverture est déposée sur le serveur et "
+"sauvegardée en base, ce champ est ensuite remis à vide)"
 
 #: cps/templates/book_edit.html:85
 msgid "Upload Cover from Local Disk"
@@ -1404,7 +1462,9 @@ msgstr "Emplacement du certificat SSL (laisser vide pour les serveurs non SSL)"
 
 #: cps/templates/config_edit.html:95
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
-msgstr "Emplacement de la clé de chiffrement SSL (laisser vide pour les serveurs non SSL)"
+msgstr ""
+"Emplacement de la clé de chiffrement SSL (laisser vide pour les serveurs "
+"non SSL)"
 
 #: cps/templates/config_edit.html:99
 msgid "Update Channel"
@@ -1440,7 +1500,9 @@ msgstr "Activer le journal des accès"
 
 #: cps/templates/config_edit.html:139
 msgid "Location and name of access logfile (access.log for no entry)"
-msgstr "Emplacement et nom du fichier journal d’accès (access.log pour aucune entrée)"
+msgstr ""
+"Emplacement et nom du fichier journal d’accès (access.log pour aucune "
+"entrée)"
 
 #: cps/templates/config_edit.html:150
 msgid "Feature Configuration"
@@ -1790,15 +1852,6 @@ msgstr ""
 msgid "Are you sure you want to delete this domain?"
 msgstr "Souhaitez-vous vraiment supprimer cette règle de domaine ?"
 
-#: cps/templates/feed.xml:21 cps/templates/layout.html:173
-msgid "Next"
-msgstr "Suivant"
-
-#: cps/templates/feed.xml:79 cps/templates/layout.html:136
-#: cps/templates/layout.html:140
-msgid "(Public)"
-msgstr ""
-
 #: cps/templates/generate_kobo_auth_url.html:5
 msgid "Open the .kobo/Kobo eReader.conf file in a text editor and add (or edit):"
 msgstr ""
@@ -1814,70 +1867,6 @@ msgstr "Retour à l’accueil"
 #: cps/templates/index.html:64
 msgid "Group by series"
 msgstr "Grouper par série"
-
-#: cps/templates/index.xml:6
-msgid "Start"
-msgstr "Démarrer"
-
-#: cps/templates/index.xml:21
-msgid "Popular publications from this catalog based on Downloads."
-msgstr "Publications populaires depuis le catalogue basées sur les téléchargements."
-
-#: cps/templates/index.xml:28
-msgid "Popular publications from this catalog based on Rating."
-msgstr "Publications populaires de ce catalogue sur la base de notes."
-
-#: cps/templates/index.xml:31
-msgid "Recently added Books"
-msgstr ""
-
-#: cps/templates/index.xml:35
-msgid "The latest Books"
-msgstr "Les derniers livres"
-
-#: cps/templates/index.xml:38
-msgid "Random Books"
-msgstr "Livres au hasard"
-
-#: cps/templates/index.xml:42 cps/templates/user_edit.html:80
-msgid "Show Random Books"
-msgstr "Montrer des livres au hasard"
-
-#: cps/templates/index.xml:65
-msgid "Books ordered by Author"
-msgstr "Livres classés par auteur"
-
-#: cps/templates/index.xml:72
-msgid "Books ordered by publisher"
-msgstr "Livres classés par éditeur"
-
-#: cps/templates/index.xml:79
-msgid "Books ordered by category"
-msgstr "Livres classés par catégorie"
-
-#: cps/templates/index.xml:86
-msgid "Books ordered by series"
-msgstr "Livres classés par série"
-
-#: cps/templates/index.xml:93
-msgid "Books ordered by Languages"
-msgstr ""
-
-#: cps/templates/index.xml:100
-msgid "Books ordered by Rating"
-msgstr ""
-
-#: cps/templates/index.xml:108
-msgid "Books ordered by file formats"
-msgstr ""
-
-#: cps/templates/index.xml:111 cps/templates/layout.html:134
-msgid "Shelves"
-msgstr ""
-
-#: cps/templates/index.xml:115
-msgid "Books organized in shelves"
-msgstr ""
 
 #: cps/templates/layout.html:28
 msgid "Home"
@@ -1929,6 +1918,14 @@ msgstr ""
 msgid "Browse"
 msgstr "Explorer"
 
+#: cps/templates/layout.html:134
+msgid "Shelves"
+msgstr ""
+
+#: cps/templates/layout.html:136 cps/templates/layout.html:140
+msgid "(Public)"
+msgstr ""
+
 #: cps/templates/layout.html:138
 msgid "Your Shelves"
 msgstr "Vos étagères"
@@ -1940,6 +1937,10 @@ msgstr "À propos"
 #: cps/templates/layout.html:158
 msgid "Previous"
 msgstr "Précédent"
+
+#: cps/templates/layout.html:173
+msgid "Next"
+msgstr "Suivant"
 
 #: cps/templates/layout.html:185
 msgid "Book Details"
@@ -2016,7 +2017,9 @@ msgstr "Catalogue de livres électroniques Calibre-Web"
 
 #: cps/templates/read.html:74
 msgid "Reflow text when sidebars are open."
-msgstr "Mettre à jour la mise en page du texte quand les bandeaux latéraux sont ouverts."
+msgstr ""
+"Mettre à jour la mise en page du texte quand les bandeaux latéraux sont "
+"ouverts."
 
 #: cps/templates/readcbr.html:88
 msgid "Keyboard Shortcuts"
@@ -2322,6 +2325,10 @@ msgstr ""
 msgid "Create/View"
 msgstr ""
 
+#: cps/templates/user_edit.html:80
+msgid "Show Random Books"
+msgstr "Montrer des livres au hasard"
+
 #: cps/templates/user_edit.html:84
 msgid "Add allowed/Denied Custom Column Values"
 msgstr ""
@@ -2341,4 +2348,210 @@ msgstr ""
 #: cps/templates/user_edit.html:176
 msgid "Do you really want to delete the Kobo Token?"
 msgstr ""
+
+#: vendor/tornado/locale.py:285
+msgid "January"
+msgstr ""
+
+#: vendor/tornado/locale.py:286
+msgid "February"
+msgstr ""
+
+#: vendor/tornado/locale.py:287
+msgid "March"
+msgstr ""
+
+#: vendor/tornado/locale.py:288
+msgid "April"
+msgstr ""
+
+#: vendor/tornado/locale.py:289
+msgid "May"
+msgstr ""
+
+#: vendor/tornado/locale.py:290
+msgid "June"
+msgstr ""
+
+#: vendor/tornado/locale.py:291
+msgid "July"
+msgstr ""
+
+#: vendor/tornado/locale.py:292
+msgid "August"
+msgstr ""
+
+#: vendor/tornado/locale.py:293
+msgid "September"
+msgstr ""
+
+#: vendor/tornado/locale.py:294
+msgid "October"
+msgstr ""
+
+#: vendor/tornado/locale.py:295
+msgid "November"
+msgstr ""
+
+#: vendor/tornado/locale.py:296
+msgid "December"
+msgstr ""
+
+#: vendor/tornado/locale.py:299
+msgid "Monday"
+msgstr ""
+
+#: vendor/tornado/locale.py:300
+msgid "Tuesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:301
+msgid "Wednesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:302
+msgid "Thursday"
+msgstr ""
+
+#: vendor/tornado/locale.py:303
+msgid "Friday"
+msgstr ""
+
+#: vendor/tornado/locale.py:304
+msgid "Saturday"
+msgstr ""
+
+#: vendor/tornado/locale.py:305
+msgid "Sunday"
+msgstr ""
+
+#: vendor/tornado/locale.py:368
+msgid "1 second ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:374
+msgid "1 minute ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:379
+msgid "1 hour ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:382
+#, python-format
+msgid "%(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+msgid "yesterday"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+#, python-format
+msgid "yesterday at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:389 vendor/tornado/locale.py:442
+#, python-format
+msgid "%(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:391
+#, python-format
+msgid "%(month_name)s %(day)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:396
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:398
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:436
+#, python-format
+msgid "%(weekday)s, %(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:459
+#, python-format
+msgid "%(commas)s and %(last)s"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:68
+msgctxt "law"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:69
+msgctxt "good"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:71 vendor/tornado/test/locale_test.py:74
+msgctxt "organization"
+msgid "club"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:76 vendor/tornado/test/locale_test.py:77
+msgctxt "stick"
+msgid "club"
+msgstr ""
+
+#~ msgid "Start"
+#~ msgstr "Démarrer"
+
+#~ msgid "Popular publications from this catalog based on Downloads."
+#~ msgstr ""
+#~ "Publications populaires depuis le catalogue"
+#~ " basées sur les téléchargements."
+
+#~ msgid "Popular publications from this catalog based on Rating."
+#~ msgstr "Publications populaires de ce catalogue sur la base de notes."
+
+#~ msgid "Recently added Books"
+#~ msgstr ""
+
+#~ msgid "The latest Books"
+#~ msgstr "Les derniers livres"
+
+#~ msgid "Random Books"
+#~ msgstr "Livres au hasard"
+
+#~ msgid "Books ordered by Author"
+#~ msgstr "Livres classés par auteur"
+
+#~ msgid "Books ordered by publisher"
+#~ msgstr "Livres classés par éditeur"
+
+#~ msgid "Books ordered by category"
+#~ msgstr "Livres classés par catégorie"
+
+#~ msgid "Books ordered by series"
+#~ msgstr "Livres classés par série"
+
+#~ msgid "Books ordered by Languages"
+#~ msgstr ""
+
+#~ msgid "Books ordered by Rating"
+#~ msgstr ""
+
+#~ msgid "Books ordered by file formats"
+#~ msgstr ""
+
+#~ msgid "Books organized in shelves"
+#~ msgstr ""
 

--- a/cps/translations/hu/LC_MESSAGES/messages.po
+++ b/cps/translations/hu/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-03 19:49+0200\n"
+"POT-Creation-Date: 2020-04-08 23:10+0800\n"
 "PO-Revision-Date: 2019-04-06 23:36+0200\n"
 "Last-Translator: \n"
 "Language: hu\n"
@@ -229,7 +229,9 @@ msgstr "Metaadatok szerkesztése"
 #: cps/editbooks.py:321 cps/editbooks.py:569
 #, python-format
 msgid "File extension '%(ext)s' is not allowed to be uploaded to this server"
-msgstr "A(z) \"%(ext)s\" kiterjesztésű fájlok feltöltése nincs engedélyezve ezen a szerveren."
+msgstr ""
+"A(z) \"%(ext)s\" kiterjesztésű fájlok feltöltése nincs engedélyezve ezen "
+"a szerveren."
 
 #: cps/editbooks.py:325 cps/editbooks.py:573
 msgid "File to be uploaded must have an extension"
@@ -273,7 +275,9 @@ msgid "File %(filename)s could not saved to temp dir"
 msgstr ""
 
 #: cps/editbooks.py:598
-msgid "Uploaded book probably exists in the library, consider to change before upload new: "
+msgid ""
+"Uploaded book probably exists in the library, consider to change before "
+"upload new: "
 msgstr ""
 
 #: cps/editbooks.py:613
@@ -298,7 +302,9 @@ msgstr "Az átalakításhoz hiányzik a forrás- vagy a célformátum!"
 #: cps/editbooks.py:746
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
-msgstr "A könyv sikeresen átalakításra lett jelölve a következő formátumra: %(book_format)s"
+msgstr ""
+"A könyv sikeresen átalakításra lett jelölve a következő formátumra: "
+"%(book_format)s"
 
 #: cps/editbooks.py:750
 #, python-format
@@ -306,12 +312,20 @@ msgid "There was an error converting this book: %(res)s"
 msgstr "Hiba történt a könyv átalakításakor: %(res)s"
 
 #: cps/gdrive.py:61
-msgid "Google Drive setup not completed, try to deactivate and activate Google Drive again"
-msgstr "A Google Drive beállítása nem fejeződött be, próbáld kikapcsolni és újra aktíválni a Google Drive-ot."
+msgid ""
+"Google Drive setup not completed, try to deactivate and activate Google "
+"Drive again"
+msgstr ""
+"A Google Drive beállítása nem fejeződött be, próbáld kikapcsolni és újra "
+"aktíválni a Google Drive-ot."
 
 #: cps/gdrive.py:103
-msgid "Callback domain is not verified, please follow steps to verify domain in google developer console"
-msgstr "A visszahívási tartomány nem ellenőrzött, kövesd az alábbi lépéseket a tartomány ellenőrzéséhez a Google Developer Console-ban:"
+msgid ""
+"Callback domain is not verified, please follow steps to verify domain in "
+"google developer console"
+msgstr ""
+"A visszahívási tartomány nem ellenőrzött, kövesd az alábbi lépéseket a "
+"tartomány ellenőrzéséhez a Google Developer Console-ban:"
 
 #: cps/helper.py:80
 #, python-format
@@ -377,17 +391,23 @@ msgstr "A kért fájl nem olvasható. Esetleg jogosultsági probléma lenne?"
 #: cps/helper.py:322
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
-msgstr "A cím átnevezése \"%(src)s\"-ról \"%(dest)s\"-ra nem sikerült a következő hiba miatt: %(error)s"
+msgstr ""
+"A cím átnevezése \"%(src)s\"-ról \"%(dest)s\"-ra nem sikerült a következő"
+" hiba miatt: %(error)s"
 
 #: cps/helper.py:332
 #, python-format
 msgid "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
-msgstr "A szerző átnevezése \"%(src)s\"-ról \"%(dest)s\"-ra nem sikerült a következő hiba miatt: %(error)s"
+msgstr ""
+"A szerző átnevezése \"%(src)s\"-ról \"%(dest)s\"-ra nem sikerült a "
+"következő hiba miatt: %(error)s"
 
 #: cps/helper.py:346
 #, python-format
 msgid "Rename file in path '%(src)s' to '%(dest)s' failed with error: %(error)s"
-msgstr "\"%(src)s\" fájl átnevezése \"%(dest)s\"-re nem sikerült a következő hiba miatt: %(error)s"
+msgstr ""
+"\"%(src)s\" fájl átnevezése \"%(dest)s\"-re nem sikerült a következő hiba"
+" miatt: %(error)s"
 
 #: cps/helper.py:372 cps/helper.py:382 cps/helper.py:390
 #, python-format
@@ -456,7 +476,9 @@ msgid "Unknown Task: "
 msgstr "Ismeretlen feladat:"
 
 #: cps/kobo_auth.py:127
-msgid "PLease access calibre-web from non localhost to get valid api_endpoint for kobo device"
+msgid ""
+"PLease access calibre-web from non localhost to get valid api_endpoint "
+"for kobo device"
 msgstr ""
 
 #: cps/kobo_auth.py:130 cps/kobo_auth.py:150
@@ -514,7 +536,9 @@ msgstr "A megadott polc érvénytelen!"
 #: cps/shelf.py:54
 #, python-format
 msgid "Sorry you are not allowed to add a book to the the shelf: %(shelfname)s"
-msgstr "Elnézést, nem vagy jogosult hozzáadni a könyvet a következő polcra: %(shelfname)s"
+msgstr ""
+"Elnézést, nem vagy jogosult hozzáadni a könyvet a következő polcra: "
+"%(shelfname)s"
 
 #: cps/shelf.py:62
 msgid "You are not allowed to edit public shelves"
@@ -562,7 +586,9 @@ msgstr "A könyv el lett távolítva a polcról: %(sname)s"
 #: cps/shelf.py:190
 #, python-format
 msgid "Sorry you are not allowed to remove a book from this shelf: %(sname)s"
-msgstr "Sajnálom, nincs jogosultságot eltávolítani könyvet erről a polcról: %(sname)s"
+msgstr ""
+"Sajnálom, nincs jogosultságot eltávolítani könyvet erről a polcról: "
+"%(sname)s"
 
 #: cps/shelf.py:215 cps/shelf.py:252
 #, python-format
@@ -622,7 +648,7 @@ msgstr "Legutóbb hozzáadott"
 msgid "Show recent books"
 msgstr "Legutóbbi könyvek mutatása"
 
-#: cps/templates/index.xml:17 cps/ub.py:59
+#: cps/ub.py:59
 msgid "Hot Books"
 msgstr "Kelendő könyvek"
 
@@ -630,7 +656,7 @@ msgstr "Kelendő könyvek"
 msgid "Show Hot Books"
 msgstr "Kelendő könyvek mutatása"
 
-#: cps/templates/index.xml:24 cps/ub.py:63 cps/web.py:508
+#: cps/ub.py:63 cps/web.py:508
 msgid "Top Rated Books"
 msgstr "Legjobb könyvek"
 
@@ -638,8 +664,7 @@ msgstr "Legjobb könyvek"
 msgid "Show Top Rated Books"
 msgstr "Legjobbra értékelt könyvek mutatása"
 
-#: cps/templates/index.xml:46 cps/templates/index.xml:50 cps/ub.py:66
-#: cps/web.py:1005
+#: cps/ub.py:66 cps/web.py:1005
 msgid "Read Books"
 msgstr "Olvasott könyvek"
 
@@ -647,8 +672,7 @@ msgstr "Olvasott könyvek"
 msgid "Show read and unread"
 msgstr "Mutassa az olvasva/olvasatlan állapotot"
 
-#: cps/templates/index.xml:53 cps/templates/index.xml:57 cps/ub.py:70
-#: cps/web.py:1009
+#: cps/ub.py:70 cps/web.py:1009
 msgid "Unread Books"
 msgstr "Olvasatlan könyvek"
 
@@ -664,7 +688,7 @@ msgstr "Felfedezés"
 msgid "Show random books"
 msgstr "Könyvek találomra mutatása"
 
-#: cps/templates/index.xml:75 cps/ub.py:76 cps/web.py:787
+#: cps/ub.py:76 cps/web.py:787
 msgid "Categories"
 msgstr "Címkék"
 
@@ -672,8 +696,8 @@ msgstr "Címkék"
 msgid "Show category selection"
 msgstr "Címke választó mutatása"
 
-#: cps/templates/book_edit.html:69 cps/templates/index.xml:82
-#: cps/templates/search_form.html:53 cps/ub.py:79 cps/web.py:715
+#: cps/templates/book_edit.html:69 cps/templates/search_form.html:53
+#: cps/ub.py:79 cps/web.py:715
 msgid "Series"
 msgstr "Sorozatok"
 
@@ -681,7 +705,7 @@ msgstr "Sorozatok"
 msgid "Show series selection"
 msgstr "Sorozat választó mutatása"
 
-#: cps/templates/index.xml:61 cps/ub.py:82
+#: cps/ub.py:82
 msgid "Authors"
 msgstr "Szerzők"
 
@@ -689,7 +713,7 @@ msgstr "Szerzők"
 msgid "Show author selection"
 msgstr "Szerző választó mutatása"
 
-#: cps/templates/index.xml:68 cps/ub.py:86 cps/web.py:699
+#: cps/ub.py:86 cps/web.py:699
 msgid "Publishers"
 msgstr "Kiadók"
 
@@ -697,8 +721,7 @@ msgstr "Kiadók"
 msgid "Show publisher selection"
 msgstr "Kiadó választó mutatása"
 
-#: cps/templates/index.xml:89 cps/templates/search_form.html:74 cps/ub.py:89
-#: cps/web.py:770
+#: cps/templates/search_form.html:74 cps/ub.py:89 cps/web.py:770
 msgid "Languages"
 msgstr "Nyelvek"
 
@@ -706,7 +729,7 @@ msgstr "Nyelvek"
 msgid "Show language selection"
 msgstr "Nyelv választó mutatása"
 
-#: cps/templates/index.xml:96 cps/ub.py:93
+#: cps/ub.py:93
 msgid "Ratings"
 msgstr ""
 
@@ -714,7 +737,7 @@ msgstr ""
 msgid "Show ratings selection"
 msgstr ""
 
-#: cps/templates/index.xml:104 cps/ub.py:96
+#: cps/ub.py:96
 msgid "File formats"
 msgstr ""
 
@@ -731,8 +754,12 @@ msgid "No update available. You already have the latest version installed"
 msgstr "Nem érhető el újabb frissítés. Már a legújabb verzió van telepítve."
 
 #: cps/updater.py:333
-msgid "A new update is available. Click on the button below to update to the latest version."
-msgstr "Egy új frissítés érhető el. Kattints a lenti gombra a legújabb verzió frissítésére"
+msgid ""
+"A new update is available. Click on the button below to update to the "
+"latest version."
+msgstr ""
+"Egy új frissítés érhető el. Kattints a lenti gombra a legújabb verzió "
+"frissítésére"
 
 #: cps/updater.py:385
 msgid "Could not fetch update information"
@@ -744,8 +771,12 @@ msgstr "Nincs információ a kiadásról."
 
 #: cps/updater.py:456 cps/updater.py:467 cps/updater.py:486
 #, python-format
-msgid "A new update is available. Click on the button below to update to version: %(version)s"
-msgstr "Új frissítés érhető el. Kattints az alábbi gombra a frissítéshez a következő verzióra: %(version)s"
+msgid ""
+"A new update is available. Click on the button below to update to "
+"version: %(version)s"
+msgstr ""
+"Új frissítés érhető el. Kattints az alábbi gombra a frissítéshez a "
+"következő verzióra: %(version)s"
 
 #: cps/updater.py:477
 msgid "Click on the button below to update to the latest stable version."
@@ -768,8 +799,12 @@ msgid "Hot Books (Most Downloaded)"
 msgstr "Kelendő könyvek (legtöbbet letöltöttek)"
 
 #: cps/web.py:580
-msgid "Oops! Selected book title is unavailable. File does not exist or is not accessible"
-msgstr "Hiba történt az e-könyv megnyitásakor. A fájl nem létezik vagy nem érhető el:"
+msgid ""
+"Oops! Selected book title is unavailable. File does not exist or is not "
+"accessible"
+msgstr ""
+"Hiba történt az e-könyv megnyitásakor. A fájl nem létezik vagy nem érhető"
+" el:"
 
 #: cps/web.py:593
 #, python-format
@@ -818,9 +853,9 @@ msgstr ""
 msgid "Tasks"
 msgstr "Feladatok"
 
-#: cps/templates/book_edit.html:212 cps/templates/feed.xml:33
-#: cps/templates/layout.html:44 cps/templates/layout.html:47
-#: cps/templates/search_form.html:170 cps/web.py:821 cps/web.py:823
+#: cps/templates/book_edit.html:212 cps/templates/layout.html:44
+#: cps/templates/layout.html:47 cps/templates/search_form.html:170
+#: cps/web.py:821 cps/web.py:823
 msgid "Search"
 msgstr "Keresés"
 
@@ -957,191 +992,193 @@ msgstr "Az e-könyv átalakítás nem sikerült: %(error)s"
 #: cps/worker.py:346
 #, python-format
 msgid "Kindlegen failed with Error %(error)s. Message: %(message)s"
-msgstr "A Kindlegen futtatása nem sikerült a(z) %(error)s hiba miatt. Üzenet: %(message)s"
+msgstr ""
+"A Kindlegen futtatása nem sikerült a(z) %(error)s hiba miatt. Üzenet: "
+"%(message)s"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html:8
 msgid "Users"
 msgstr "Felhasználók listája"
 
-#: cps/templates/admin.html:12 cps/templates/login.html:8
+#: cps/templates/admin.html:11 cps/templates/login.html:8
 #: cps/templates/login.html:9 cps/templates/register.html:7
 #: cps/templates/user_edit.html:8
 msgid "Username"
 msgstr "Felhasználói név"
 
-#: cps/templates/admin.html:13 cps/templates/register.html:11
+#: cps/templates/admin.html:12 cps/templates/register.html:11
 #: cps/templates/user_edit.html:13
 msgid "E-mail Address"
 msgstr "E-mail"
 
-#: cps/templates/admin.html:14 cps/templates/user_edit.html:26
+#: cps/templates/admin.html:13 cps/templates/user_edit.html:26
 msgid "Send to Kindle E-mail Address"
 msgstr "Kindle"
 
-#: cps/templates/admin.html:15
+#: cps/templates/admin.html:14
 msgid "Downloads"
 msgstr "Letöltések"
 
-#: cps/templates/admin.html:16 cps/templates/layout.html:76
+#: cps/templates/admin.html:15 cps/templates/layout.html:76
 msgid "Admin"
 msgstr "Rendszergazda"
 
-#: cps/templates/admin.html:17 cps/templates/detail.html:18
+#: cps/templates/admin.html:16 cps/templates/detail.html:18
 #: cps/templates/detail.html:27 cps/templates/shelf.html:6
 #: cps/templates/shelfdown.html:62
 msgid "Download"
 msgstr "Letöltés"
 
-#: cps/templates/admin.html:18
+#: cps/templates/admin.html:17
 msgid "View Books"
 msgstr ""
 
-#: cps/templates/admin.html:19 cps/templates/layout.html:65
+#: cps/templates/admin.html:18 cps/templates/layout.html:65
 msgid "Upload"
 msgstr "Feltöltés"
 
-#: cps/templates/admin.html:20
+#: cps/templates/admin.html:19
 msgid "Edit"
 msgstr "Szerkesztés"
 
-#: cps/templates/admin.html:38
+#: cps/templates/admin.html:37
 msgid "Add New User"
 msgstr ""
 
-#: cps/templates/admin.html:44
+#: cps/templates/admin.html:43
 msgid "E-mail Server Settings"
 msgstr "SMTP e-mail kiszolgáló beállítások"
 
-#: cps/templates/admin.html:47 cps/templates/email_edit.html:11
+#: cps/templates/admin.html:46 cps/templates/email_edit.html:11
 msgid "SMTP Hostname"
 msgstr "SMTP szervernév"
 
-#: cps/templates/admin.html:48 cps/templates/email_edit.html:15
+#: cps/templates/admin.html:47 cps/templates/email_edit.html:15
 msgid "SMTP Port"
 msgstr "SMTP port"
 
-#: cps/templates/admin.html:49 cps/templates/email_edit.html:19
+#: cps/templates/admin.html:48 cps/templates/email_edit.html:19
 msgid "Encryption"
 msgstr "SSL"
 
-#: cps/templates/admin.html:50 cps/templates/email_edit.html:27
+#: cps/templates/admin.html:49 cps/templates/email_edit.html:27
 msgid "SMTP Login"
 msgstr "SMTP felhasználó"
 
-#: cps/templates/admin.html:51 cps/templates/email_edit.html:35
+#: cps/templates/admin.html:50 cps/templates/email_edit.html:35
 msgid "From E-mail"
 msgstr "Küldő e-mail cím"
 
-#: cps/templates/admin.html:61
+#: cps/templates/admin.html:60
 msgid "Edit E-mail Server Settings"
 msgstr "SMTP beállítások változtatása"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html:66
 msgid "Configuration"
 msgstr "Konfiguráció"
 
-#: cps/templates/admin.html:70
+#: cps/templates/admin.html:69
 msgid "Calibre Database Directory"
 msgstr "Calibre adatbázis mappája:"
 
-#: cps/templates/admin.html:74 cps/templates/config_edit.html:122
+#: cps/templates/admin.html:73 cps/templates/config_edit.html:122
 msgid "Log Level"
 msgstr "Naplózás szintje:"
 
-#: cps/templates/admin.html:78
+#: cps/templates/admin.html:77
 msgid "Port"
 msgstr "Port:"
 
-#: cps/templates/admin.html:84 cps/templates/config_view_edit.html:27
+#: cps/templates/admin.html:83 cps/templates/config_view_edit.html:27
 msgid "Books per Page"
 msgstr "Könyvek oldalanként:"
 
-#: cps/templates/admin.html:88
+#: cps/templates/admin.html:87
 msgid "Uploads"
 msgstr "Feltöltés:"
 
-#: cps/templates/admin.html:92
+#: cps/templates/admin.html:91
 msgid "Anonymous Browsing"
 msgstr "Böngészés bejelentkezés nélkül:"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html:95
 msgid "Public Registration"
 msgstr "Nyílvános regisztráció:"
 
-#: cps/templates/admin.html:100
+#: cps/templates/admin.html:99
 msgid "Magic Link Remote Login"
 msgstr "Távoli belépés:"
 
-#: cps/templates/admin.html:104
+#: cps/templates/admin.html:103
 msgid "Reverse Proxy Login"
 msgstr ""
 
-#: cps/templates/admin.html:109
+#: cps/templates/admin.html:108
 msgid "Reverse proxy header name"
 msgstr ""
 
-#: cps/templates/admin.html:114
+#: cps/templates/admin.html:113
 msgid "Edit Basic Configuration"
 msgstr ""
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html:114
 msgid "Edit UI Configuration"
 msgstr ""
 
-#: cps/templates/admin.html:121
+#: cps/templates/admin.html:120
 msgid "Administration"
 msgstr "Adminisztráció"
 
-#: cps/templates/admin.html:122
+#: cps/templates/admin.html:121
 msgid "View Logs"
 msgstr ""
 
-#: cps/templates/admin.html:123
+#: cps/templates/admin.html:122
 msgid "Reconnect Calibre Database"
 msgstr "Újracsatlakozás a Calibre adatbázishoz"
 
-#: cps/templates/admin.html:124
+#: cps/templates/admin.html:123
 msgid "Restart"
 msgstr "A Calibre adatbázis újraindítása"
 
-#: cps/templates/admin.html:125
+#: cps/templates/admin.html:124
 msgid "Shutdown"
 msgstr "A Calibre adatbázis leállítása"
 
-#: cps/templates/admin.html:131
+#: cps/templates/admin.html:130
 msgid "Update"
 msgstr "Frissítés"
 
-#: cps/templates/admin.html:135
+#: cps/templates/admin.html:134
 msgid "Version"
 msgstr "Verzió"
 
-#: cps/templates/admin.html:136
+#: cps/templates/admin.html:135
 msgid "Details"
 msgstr "Részletek"
 
-#: cps/templates/admin.html:142
+#: cps/templates/admin.html:141
 msgid "Current version"
 msgstr "Jelenlegi verzió"
 
-#: cps/templates/admin.html:148
+#: cps/templates/admin.html:147
 msgid "Check for Update"
 msgstr "Frissítés keresése"
 
-#: cps/templates/admin.html:149
+#: cps/templates/admin.html:148
 msgid "Perform Update"
 msgstr "Frissítés elkezdése"
 
-#: cps/templates/admin.html:161
+#: cps/templates/admin.html:160
 msgid "Are you sure you want to restart?"
 msgstr "Valóban újra akarod indítani a Calibre-Web-et?"
 
-#: cps/templates/admin.html:166 cps/templates/admin.html:180
-#: cps/templates/admin.html:200 cps/templates/shelf.html:72
+#: cps/templates/admin.html:165 cps/templates/admin.html:179
+#: cps/templates/admin.html:199 cps/templates/shelf.html:72
 msgid "OK"
 msgstr "OK"
 
-#: cps/templates/admin.html:167 cps/templates/admin.html:181
+#: cps/templates/admin.html:166 cps/templates/admin.html:180
 #: cps/templates/book_edit.html:172 cps/templates/book_edit.html:194
 #: cps/templates/config_edit.html:346 cps/templates/config_view_edit.html:151
 #: cps/templates/email_edit.html:40 cps/templates/email_edit.html:92
@@ -1150,11 +1187,11 @@ msgstr "OK"
 msgid "Cancel"
 msgstr ""
 
-#: cps/templates/admin.html:179
+#: cps/templates/admin.html:178
 msgid "Are you sure you want to shutdown?"
 msgstr "Valóban le akarod állítani a Calibre-Web-et?"
 
-#: cps/templates/admin.html:191
+#: cps/templates/admin.html:190
 msgid "Updating, please do not reload this page"
 msgstr "Frissítés folyamatban, ne töltsd újra az oldalt"
 
@@ -1243,8 +1280,12 @@ msgid "Rating"
 msgstr "Értékelés"
 
 #: cps/templates/book_edit.html:81
-msgid "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
-msgstr "Borító URL (jpg, borító letöltve és elmentve az adatbázisban, a mező újra üres lesz utána)"
+msgid ""
+"Fetch Cover from URL (JPEG - Image will be downloaded and stored in "
+"database)"
+msgstr ""
+"Borító URL (jpg, borító letöltve és elmentve az adatbázisban, a mező újra"
+" üres lesz utána)"
 
 #: cps/templates/book_edit.html:85
 msgid "Upload Cover from Local Disk"
@@ -1777,15 +1818,6 @@ msgstr ""
 msgid "Are you sure you want to delete this domain?"
 msgstr "Valóban törölni akarod ezt a tartomány-szabályt?"
 
-#: cps/templates/feed.xml:21 cps/templates/layout.html:173
-msgid "Next"
-msgstr "Következő"
-
-#: cps/templates/feed.xml:79 cps/templates/layout.html:136
-#: cps/templates/layout.html:140
-msgid "(Public)"
-msgstr ""
-
 #: cps/templates/generate_kobo_auth_url.html:5
 msgid "Open the .kobo/Kobo eReader.conf file in a text editor and add (or edit):"
 msgstr ""
@@ -1800,70 +1832,6 @@ msgstr "Vissza a kezdőlapra"
 
 #: cps/templates/index.html:64
 msgid "Group by series"
-msgstr ""
-
-#: cps/templates/index.xml:6
-msgid "Start"
-msgstr "Kezdés"
-
-#: cps/templates/index.xml:21
-msgid "Popular publications from this catalog based on Downloads."
-msgstr "Ebből a katalógusból származó népszerű kiadványok letöltések alapján."
-
-#: cps/templates/index.xml:28
-msgid "Popular publications from this catalog based on Rating."
-msgstr "Ebből a katalógusból származó népszerű kiadványok értékelések alapján."
-
-#: cps/templates/index.xml:31
-msgid "Recently added Books"
-msgstr ""
-
-#: cps/templates/index.xml:35
-msgid "The latest Books"
-msgstr "A legfrissebb könyvek"
-
-#: cps/templates/index.xml:38
-msgid "Random Books"
-msgstr "Könyvek találomra"
-
-#: cps/templates/index.xml:42 cps/templates/user_edit.html:80
-msgid "Show Random Books"
-msgstr "Mutass könyveket találomra"
-
-#: cps/templates/index.xml:65
-msgid "Books ordered by Author"
-msgstr "Könyvek szerző szerint rendezve"
-
-#: cps/templates/index.xml:72
-msgid "Books ordered by publisher"
-msgstr "Könyvek kiadók szerint rendezve"
-
-#: cps/templates/index.xml:79
-msgid "Books ordered by category"
-msgstr "Könyvek címke szerint rendezve"
-
-#: cps/templates/index.xml:86
-msgid "Books ordered by series"
-msgstr "Könyvek sorozat szerint rendezve"
-
-#: cps/templates/index.xml:93
-msgid "Books ordered by Languages"
-msgstr ""
-
-#: cps/templates/index.xml:100
-msgid "Books ordered by Rating"
-msgstr ""
-
-#: cps/templates/index.xml:108
-msgid "Books ordered by file formats"
-msgstr ""
-
-#: cps/templates/index.xml:111 cps/templates/layout.html:134
-msgid "Shelves"
-msgstr ""
-
-#: cps/templates/index.xml:115
-msgid "Books organized in shelves"
 msgstr ""
 
 #: cps/templates/layout.html:28
@@ -1916,6 +1884,14 @@ msgstr ""
 msgid "Browse"
 msgstr "Böngészés"
 
+#: cps/templates/layout.html:134
+msgid "Shelves"
+msgstr ""
+
+#: cps/templates/layout.html:136 cps/templates/layout.html:140
+msgid "(Public)"
+msgstr ""
+
 #: cps/templates/layout.html:138
 msgid "Your Shelves"
 msgstr "Saját polcok"
@@ -1927,6 +1903,10 @@ msgstr "Névjegy"
 #: cps/templates/layout.html:158
 msgid "Previous"
 msgstr "Előző"
+
+#: cps/templates/layout.html:173
+msgid "Next"
+msgstr "Következő"
 
 #: cps/templates/layout.html:185
 msgid "Book Details"
@@ -2309,6 +2289,10 @@ msgstr ""
 msgid "Create/View"
 msgstr ""
 
+#: cps/templates/user_edit.html:80
+msgid "Show Random Books"
+msgstr "Mutass könyveket találomra"
+
 #: cps/templates/user_edit.html:84
 msgid "Add allowed/Denied Custom Column Values"
 msgstr ""
@@ -2328,4 +2312,208 @@ msgstr ""
 #: cps/templates/user_edit.html:176
 msgid "Do you really want to delete the Kobo Token?"
 msgstr ""
+
+#: vendor/tornado/locale.py:285
+msgid "January"
+msgstr ""
+
+#: vendor/tornado/locale.py:286
+msgid "February"
+msgstr ""
+
+#: vendor/tornado/locale.py:287
+msgid "March"
+msgstr ""
+
+#: vendor/tornado/locale.py:288
+msgid "April"
+msgstr ""
+
+#: vendor/tornado/locale.py:289
+msgid "May"
+msgstr ""
+
+#: vendor/tornado/locale.py:290
+msgid "June"
+msgstr ""
+
+#: vendor/tornado/locale.py:291
+msgid "July"
+msgstr ""
+
+#: vendor/tornado/locale.py:292
+msgid "August"
+msgstr ""
+
+#: vendor/tornado/locale.py:293
+msgid "September"
+msgstr ""
+
+#: vendor/tornado/locale.py:294
+msgid "October"
+msgstr ""
+
+#: vendor/tornado/locale.py:295
+msgid "November"
+msgstr ""
+
+#: vendor/tornado/locale.py:296
+msgid "December"
+msgstr ""
+
+#: vendor/tornado/locale.py:299
+msgid "Monday"
+msgstr ""
+
+#: vendor/tornado/locale.py:300
+msgid "Tuesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:301
+msgid "Wednesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:302
+msgid "Thursday"
+msgstr ""
+
+#: vendor/tornado/locale.py:303
+msgid "Friday"
+msgstr ""
+
+#: vendor/tornado/locale.py:304
+msgid "Saturday"
+msgstr ""
+
+#: vendor/tornado/locale.py:305
+msgid "Sunday"
+msgstr ""
+
+#: vendor/tornado/locale.py:368
+msgid "1 second ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:374
+msgid "1 minute ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:379
+msgid "1 hour ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:382
+#, python-format
+msgid "%(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+msgid "yesterday"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+#, python-format
+msgid "yesterday at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:389 vendor/tornado/locale.py:442
+#, python-format
+msgid "%(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:391
+#, python-format
+msgid "%(month_name)s %(day)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:396
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:398
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:436
+#, python-format
+msgid "%(weekday)s, %(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:459
+#, python-format
+msgid "%(commas)s and %(last)s"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:68
+msgctxt "law"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:69
+msgctxt "good"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:71 vendor/tornado/test/locale_test.py:74
+msgctxt "organization"
+msgid "club"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:76 vendor/tornado/test/locale_test.py:77
+msgctxt "stick"
+msgid "club"
+msgstr ""
+
+#~ msgid "Start"
+#~ msgstr "Kezdés"
+
+#~ msgid "Popular publications from this catalog based on Downloads."
+#~ msgstr "Ebből a katalógusból származó népszerű kiadványok letöltések alapján."
+
+#~ msgid "Popular publications from this catalog based on Rating."
+#~ msgstr "Ebből a katalógusból származó népszerű kiadványok értékelések alapján."
+
+#~ msgid "Recently added Books"
+#~ msgstr ""
+
+#~ msgid "The latest Books"
+#~ msgstr "A legfrissebb könyvek"
+
+#~ msgid "Random Books"
+#~ msgstr "Könyvek találomra"
+
+#~ msgid "Books ordered by Author"
+#~ msgstr "Könyvek szerző szerint rendezve"
+
+#~ msgid "Books ordered by publisher"
+#~ msgstr "Könyvek kiadók szerint rendezve"
+
+#~ msgid "Books ordered by category"
+#~ msgstr "Könyvek címke szerint rendezve"
+
+#~ msgid "Books ordered by series"
+#~ msgstr "Könyvek sorozat szerint rendezve"
+
+#~ msgid "Books ordered by Languages"
+#~ msgstr ""
+
+#~ msgid "Books ordered by Rating"
+#~ msgstr ""
+
+#~ msgid "Books ordered by file formats"
+#~ msgstr ""
+
+#~ msgid "Books organized in shelves"
+#~ msgstr ""
 

--- a/cps/translations/it/LC_MESSAGES/messages.po
+++ b/cps/translations/it/LC_MESSAGES/messages.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Calibre-Web\n"
 "Report-Msgid-Bugs-To: https://github.com/janeczku/Calibre-Web\n"
-"POT-Creation-Date: 2020-04-03 19:49+0200\n"
+"POT-Creation-Date: 2020-04-08 23:10+0800\n"
 "PO-Revision-Date: 2017-04-04 15:09+0200\n"
 "Last-Translator: ElQuimm <quimm@webtaste.com>\n"
 "Language: it\n"
@@ -219,7 +219,9 @@ msgstr "non configurato"
 
 #: cps/editbooks.py:214 cps/editbooks.py:396
 msgid "Error opening eBook. File does not exist or file is not accessible"
-msgstr "Errore durante l'apertura del libro. Il file non esiste o il file non è accessibile"
+msgstr ""
+"Errore durante l'apertura del libro. Il file non esiste o il file non è "
+"accessibile"
 
 #: cps/editbooks.py:242
 msgid "edit metadata"
@@ -264,7 +266,9 @@ msgstr "I metadati sono stati aggiornati con successo"
 
 #: cps/editbooks.py:534
 msgid "Error editing book, please check logfile for details"
-msgstr "Errore nella modifica del libro. Per favore verifica i dettagli nel file di registro (logfile)"
+msgstr ""
+"Errore nella modifica del libro. Per favore verifica i dettagli nel file "
+"di registro (logfile)"
 
 #: cps/editbooks.py:581
 #, python-format
@@ -272,8 +276,12 @@ msgid "File %(filename)s could not saved to temp dir"
 msgstr "Il file %(filename)s non può essere salvato nella cartella temporanea"
 
 #: cps/editbooks.py:598
-msgid "Uploaded book probably exists in the library, consider to change before upload new: "
-msgstr "Probabilmnete il libro caricato esiste già nella libreria; considera di cambiare prima di sottoporlo nuovamente: "
+msgid ""
+"Uploaded book probably exists in the library, consider to change before "
+"upload new: "
+msgstr ""
+"Probabilmnete il libro caricato esiste già nella libreria; considera di "
+"cambiare prima di sottoporlo nuovamente: "
 
 #: cps/editbooks.py:613
 #, python-format
@@ -292,7 +300,9 @@ msgstr "Il file %(file)s è stato caricato"
 
 #: cps/editbooks.py:738
 msgid "Source or destination format for conversion missing"
-msgstr "Il formato sorgente o quello di destinazione, necessari alla conversione, mancano"
+msgstr ""
+"Il formato sorgente o quello di destinazione, necessari alla conversione,"
+" mancano"
 
 #: cps/editbooks.py:746
 #, python-format
@@ -305,12 +315,20 @@ msgid "There was an error converting this book: %(res)s"
 msgstr "Si è verificato un errore durante la conversione del libro: %(res)s"
 
 #: cps/gdrive.py:61
-msgid "Google Drive setup not completed, try to deactivate and activate Google Drive again"
-msgstr "La configurazione di Google Drive non è stata completata correttamente. Prova a disattivare e riattivare nuovamente Google Drive"
+msgid ""
+"Google Drive setup not completed, try to deactivate and activate Google "
+"Drive again"
+msgstr ""
+"La configurazione di Google Drive non è stata completata correttamente. "
+"Prova a disattivare e riattivare nuovamente Google Drive"
 
 #: cps/gdrive.py:103
-msgid "Callback domain is not verified, please follow steps to verify domain in google developer console"
-msgstr "Callback domain non è stato verificato. Per favore intraprendi il necessario per verificare il dominio nella developer console di Google"
+msgid ""
+"Callback domain is not verified, please follow steps to verify domain in "
+"google developer console"
+msgstr ""
+"Callback domain non è stato verificato. Per favore intraprendi il "
+"necessario per verificare il dominio nella developer console di Google"
 
 #: cps/helper.py:80
 #, python-format
@@ -376,17 +394,23 @@ msgstr "Il file richiesto non può essere letto. I permessi sono corretti?"
 #: cps/helper.py:322
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
-msgstr "La modifica del titolo da '%(src)s' a '%(dest)s' è terminata con l'errore: %(error)s"
+msgstr ""
+"La modifica del titolo da '%(src)s' a '%(dest)s' è terminata con "
+"l'errore: %(error)s"
 
 #: cps/helper.py:332
 #, python-format
 msgid "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
-msgstr "La modifica dell'autore da '%(src)s' a '%(dest)s' è terminata con l'errore: %(error)s"
+msgstr ""
+"La modifica dell'autore da '%(src)s' a '%(dest)s' è terminata con "
+"l'errore: %(error)s"
 
 #: cps/helper.py:346
 #, python-format
 msgid "Rename file in path '%(src)s' to '%(dest)s' failed with error: %(error)s"
-msgstr "La modifica del file nella cartella da '%(src)s' a '%(dest)s' è terminata con l'errore: %(error)s"
+msgstr ""
+"La modifica del file nella cartella da '%(src)s' a '%(dest)s' è terminata"
+" con l'errore: %(error)s"
 
 #: cps/helper.py:372 cps/helper.py:382 cps/helper.py:390
 #, python-format
@@ -412,7 +436,9 @@ msgstr "Errore nel salvare il file della copertina"
 
 #: cps/helper.py:530
 msgid "Only jpg/jpeg/png/webp files are supported as coverfile"
-msgstr "Solamente i file nei formati jpg/jpeg/png/webp sono supportati per le copertine"
+msgstr ""
+"Solamente i file nei formati jpg/jpeg/png/webp sono supportati per le "
+"copertine"
 
 #: cps/helper.py:544
 msgid "Only jpg/jpeg files are supported as coverfile"
@@ -455,8 +481,12 @@ msgid "Unknown Task: "
 msgstr "Processo sconosciuto: "
 
 #: cps/kobo_auth.py:127
-msgid "PLease access calibre-web from non localhost to get valid api_endpoint for kobo device"
-msgstr "Per favore, per ottenere un valido api-endpoint per Kobo, accedi a Calibre-web non da localhost"
+msgid ""
+"PLease access calibre-web from non localhost to get valid api_endpoint "
+"for kobo device"
+msgstr ""
+"Per favore, per ottenere un valido api-endpoint per Kobo, accedi a "
+"Calibre-web non da localhost"
 
 #: cps/kobo_auth.py:130 cps/kobo_auth.py:150
 msgid "Kobo Setup"
@@ -513,7 +543,9 @@ msgstr "Lo scaffale specificato non è valido"
 #: cps/shelf.py:54
 #, python-format
 msgid "Sorry you are not allowed to add a book to the the shelf: %(shelfname)s"
-msgstr "Mi spiace, ma non sei autorizzato ad aggiungere libri allo scaffale: %(shelfname)s"
+msgstr ""
+"Mi spiace, ma non sei autorizzato ad aggiungere libri allo scaffale: "
+"%(shelfname)s"
 
 #: cps/shelf.py:62
 msgid "You are not allowed to edit public shelves"
@@ -561,7 +593,9 @@ msgstr "Il libro è stato rimosso dallo scaffale: %(sname)s"
 #: cps/shelf.py:190
 #, python-format
 msgid "Sorry you are not allowed to remove a book from this shelf: %(sname)s"
-msgstr "Spiacente, ma non sei autorizzato a togliere libri dallo scaffale: %(sname)s"
+msgstr ""
+"Spiacente, ma non sei autorizzato a togliere libri dallo scaffale: "
+"%(sname)s"
 
 #: cps/shelf.py:215 cps/shelf.py:252
 #, python-format
@@ -602,7 +636,9 @@ msgstr "Scaffale: '%(name)s'"
 
 #: cps/shelf.py:330
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
-msgstr "Errore durante l'apertura dello scaffale. Lo scaffale non esiste o non è accessibile"
+msgstr ""
+"Errore durante l'apertura dello scaffale. Lo scaffale non esiste o non è "
+"accessibile"
 
 #: cps/shelf.py:368
 msgid "Hidden Book"
@@ -621,7 +657,7 @@ msgstr "Aggiunti recentemente"
 msgid "Show recent books"
 msgstr "Mostra l'opzione per la selezione dei libri più recenti"
 
-#: cps/templates/index.xml:17 cps/ub.py:59
+#: cps/ub.py:59
 msgid "Hot Books"
 msgstr "Libri popolari"
 
@@ -629,7 +665,7 @@ msgstr "Libri popolari"
 msgid "Show Hot Books"
 msgstr "Mostra l'opzione per la selezione dei libri più popolari"
 
-#: cps/templates/index.xml:24 cps/ub.py:63 cps/web.py:508
+#: cps/ub.py:63 cps/web.py:508
 msgid "Top Rated Books"
 msgstr "Libri meglio valutati"
 
@@ -637,8 +673,7 @@ msgstr "Libri meglio valutati"
 msgid "Show Top Rated Books"
 msgstr "Mostra l'opzione per la selezione dei libri meglio valutati"
 
-#: cps/templates/index.xml:46 cps/templates/index.xml:50 cps/ub.py:66
-#: cps/web.py:1005
+#: cps/ub.py:66 cps/web.py:1005
 msgid "Read Books"
 msgstr "Libri da leggere"
 
@@ -646,8 +681,7 @@ msgstr "Libri da leggere"
 msgid "Show read and unread"
 msgstr "Mostra l'opzione per la selezione letto e non letto"
 
-#: cps/templates/index.xml:53 cps/templates/index.xml:57 cps/ub.py:70
-#: cps/web.py:1009
+#: cps/ub.py:70 cps/web.py:1009
 msgid "Unread Books"
 msgstr "Libri non letti"
 
@@ -663,7 +697,7 @@ msgstr "Per scoprire"
 msgid "Show random books"
 msgstr "Mostra l'opzione per presentare libri aleatoriamente"
 
-#: cps/templates/index.xml:75 cps/ub.py:76 cps/web.py:787
+#: cps/ub.py:76 cps/web.py:787
 msgid "Categories"
 msgstr "Categorie"
 
@@ -671,8 +705,8 @@ msgstr "Categorie"
 msgid "Show category selection"
 msgstr "Mostra l'opzione per la selezione delle categorie"
 
-#: cps/templates/book_edit.html:69 cps/templates/index.xml:82
-#: cps/templates/search_form.html:53 cps/ub.py:79 cps/web.py:715
+#: cps/templates/book_edit.html:69 cps/templates/search_form.html:53
+#: cps/ub.py:79 cps/web.py:715
 msgid "Series"
 msgstr "Serie"
 
@@ -680,7 +714,7 @@ msgstr "Serie"
 msgid "Show series selection"
 msgstr "Mostra l'opzione per la selezione delle serie"
 
-#: cps/templates/index.xml:61 cps/ub.py:82
+#: cps/ub.py:82
 msgid "Authors"
 msgstr "Autori"
 
@@ -688,7 +722,7 @@ msgstr "Autori"
 msgid "Show author selection"
 msgstr "Mostra l'opzione per la selezione degli autori"
 
-#: cps/templates/index.xml:68 cps/ub.py:86 cps/web.py:699
+#: cps/ub.py:86 cps/web.py:699
 msgid "Publishers"
 msgstr "Editori"
 
@@ -696,8 +730,7 @@ msgstr "Editori"
 msgid "Show publisher selection"
 msgstr "Mostra l'opzione per la selezione degli editori"
 
-#: cps/templates/index.xml:89 cps/templates/search_form.html:74 cps/ub.py:89
-#: cps/web.py:770
+#: cps/templates/search_form.html:74 cps/ub.py:89 cps/web.py:770
 msgid "Languages"
 msgstr "Lingue"
 
@@ -705,7 +738,7 @@ msgstr "Lingue"
 msgid "Show language selection"
 msgstr "Mostra l'opzione per la selezione delle lingue"
 
-#: cps/templates/index.xml:96 cps/ub.py:93
+#: cps/ub.py:93
 msgid "Ratings"
 msgstr "Valutazioni"
 
@@ -713,7 +746,7 @@ msgstr "Valutazioni"
 msgid "Show ratings selection"
 msgstr "Mostra l'opzione per la selezione della valutazione"
 
-#: cps/templates/index.xml:104 cps/ub.py:96
+#: cps/ub.py:96
 msgid "File formats"
 msgstr "Formati file"
 
@@ -730,8 +763,12 @@ msgid "No update available. You already have the latest version installed"
 msgstr "Nessun aggiornamento disponibile. L'ultima versione è già installata"
 
 #: cps/updater.py:333
-msgid "A new update is available. Click on the button below to update to the latest version."
-msgstr "Nuovo aggiornamento disponibile. Clicca sul pulsante sottostante per aggiornare all'ultima versione."
+msgid ""
+"A new update is available. Click on the button below to update to the "
+"latest version."
+msgstr ""
+"Nuovo aggiornamento disponibile. Clicca sul pulsante sottostante per "
+"aggiornare all'ultima versione."
 
 #: cps/updater.py:385
 msgid "Could not fetch update information"
@@ -743,8 +780,12 @@ msgstr "Non sono disponibili informazioni sulla versione"
 
 #: cps/updater.py:456 cps/updater.py:467 cps/updater.py:486
 #, python-format
-msgid "A new update is available. Click on the button below to update to version: %(version)s"
-msgstr "Nuovo aggiornamento disponibile. Clicca sul pulsante sottostante per aggiornare alla versione: %(version)s"
+msgid ""
+"A new update is available. Click on the button below to update to "
+"version: %(version)s"
+msgstr ""
+"Nuovo aggiornamento disponibile. Clicca sul pulsante sottostante per "
+"aggiornare alla versione: %(version)s"
 
 #: cps/updater.py:477
 msgid "Click on the button below to update to the latest stable version."
@@ -767,8 +808,12 @@ msgid "Hot Books (Most Downloaded)"
 msgstr "I libri più richiesti"
 
 #: cps/web.py:580
-msgid "Oops! Selected book title is unavailable. File does not exist or is not accessible"
-msgstr "Oops! Errore durante l'apertura del libro selezionato. Il file non esiste o il file non è accessibile"
+msgid ""
+"Oops! Selected book title is unavailable. File does not exist or is not "
+"accessible"
+msgstr ""
+"Oops! Errore durante l'apertura del libro selezionato. Il file non esiste"
+" o il file non è accessibile"
 
 #: cps/web.py:593
 #, python-format
@@ -817,9 +862,9 @@ msgstr "Elenco dei formati"
 msgid "Tasks"
 msgstr "Compito"
 
-#: cps/templates/book_edit.html:212 cps/templates/feed.xml:33
-#: cps/templates/layout.html:44 cps/templates/layout.html:47
-#: cps/templates/search_form.html:170 cps/web.py:821 cps/web.py:823
+#: cps/templates/book_edit.html:212 cps/templates/layout.html:44
+#: cps/templates/layout.html:47 cps/templates/search_form.html:170
+#: cps/web.py:821 cps/web.py:823
 msgid "Search"
 msgstr "Cerca"
 
@@ -891,7 +936,9 @@ msgstr "ora sei connesso come: '%(nickname)s'"
 
 #: cps/web.py:1155
 msgid "Could not login. LDAP server down, please contact your administrator"
-msgstr "Non posso collegarmi. Il server LDAP non è raggiungibile, per favore contatta l'amministratore"
+msgstr ""
+"Non posso collegarmi. Il server LDAP non è raggiungibile, per favore "
+"contatta l'amministratore"
 
 #: cps/web.py:1159 cps/web.py:1182
 msgid "Wrong Username or Password"
@@ -937,7 +984,9 @@ msgstr "Profilo aggiornato"
 
 #: cps/web.py:1384 cps/web.py:1480
 msgid "Error opening eBook. File does not exist or file is not accessible:"
-msgstr "Errore nell'aprire il libro. Il file non esiste o il file non è accessibile:"
+msgstr ""
+"Errore nell'aprire il libro. Il file non esiste o il file non è "
+"accessibile:"
 
 #: cps/web.py:1396 cps/web.py:1399 cps/web.py:1402 cps/web.py:1409
 #: cps/web.py:1414
@@ -946,7 +995,9 @@ msgstr "Leggi un libro"
 
 #: cps/web.py:1425
 msgid "Error opening eBook. File does not exist or file is not accessible."
-msgstr "Errore nell'aprire il libro. Il file non esiste o il file non è accessibile."
+msgstr ""
+"Errore nell'aprire il libro. Il file non esiste o il file non è "
+"accessibile."
 
 #: cps/worker.py:335
 #, python-format
@@ -958,189 +1009,189 @@ msgstr "Errore nel convertitore: %(error)s"
 msgid "Kindlegen failed with Error %(error)s. Message: %(message)s"
 msgstr "Kindlegen ha restituito l'errore %(error)s. Messaggio: %(message)s"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html:8
 msgid "Users"
 msgstr "Elenco utenti"
 
-#: cps/templates/admin.html:12 cps/templates/login.html:8
+#: cps/templates/admin.html:11 cps/templates/login.html:8
 #: cps/templates/login.html:9 cps/templates/register.html:7
 #: cps/templates/user_edit.html:8
 msgid "Username"
 msgstr "Utente"
 
-#: cps/templates/admin.html:13 cps/templates/register.html:11
+#: cps/templates/admin.html:12 cps/templates/register.html:11
 #: cps/templates/user_edit.html:13
 msgid "E-mail Address"
 msgstr "E-mail"
 
-#: cps/templates/admin.html:14 cps/templates/user_edit.html:26
+#: cps/templates/admin.html:13 cps/templates/user_edit.html:26
 msgid "Send to Kindle E-mail Address"
 msgstr "Invia all'email di Kindle"
 
-#: cps/templates/admin.html:15
+#: cps/templates/admin.html:14
 msgid "Downloads"
 msgstr "Downloads"
 
-#: cps/templates/admin.html:16 cps/templates/layout.html:76
+#: cps/templates/admin.html:15 cps/templates/layout.html:76
 msgid "Admin"
 msgstr "Admin"
 
-#: cps/templates/admin.html:17 cps/templates/detail.html:18
+#: cps/templates/admin.html:16 cps/templates/detail.html:18
 #: cps/templates/detail.html:27 cps/templates/shelf.html:6
 #: cps/templates/shelfdown.html:62
 msgid "Download"
 msgstr "Download"
 
-#: cps/templates/admin.html:18
+#: cps/templates/admin.html:17
 msgid "View Books"
 msgstr "Vedi libri"
 
-#: cps/templates/admin.html:19 cps/templates/layout.html:65
+#: cps/templates/admin.html:18 cps/templates/layout.html:65
 msgid "Upload"
 msgstr "Upload"
 
-#: cps/templates/admin.html:20
+#: cps/templates/admin.html:19
 msgid "Edit"
 msgstr "Modifica"
 
-#: cps/templates/admin.html:38
+#: cps/templates/admin.html:37
 msgid "Add New User"
 msgstr "Aggiungi un nuovo utente"
 
-#: cps/templates/admin.html:44
+#: cps/templates/admin.html:43
 msgid "E-mail Server Settings"
 msgstr "Configurazione server SMTP"
 
-#: cps/templates/admin.html:47 cps/templates/email_edit.html:11
+#: cps/templates/admin.html:46 cps/templates/email_edit.html:11
 msgid "SMTP Hostname"
 msgstr "indirizzo server SMTP"
 
-#: cps/templates/admin.html:48 cps/templates/email_edit.html:15
+#: cps/templates/admin.html:47 cps/templates/email_edit.html:15
 msgid "SMTP Port"
 msgstr "porta SMTP"
 
-#: cps/templates/admin.html:49 cps/templates/email_edit.html:19
+#: cps/templates/admin.html:48 cps/templates/email_edit.html:19
 msgid "Encryption"
 msgstr "SSL"
 
-#: cps/templates/admin.html:50 cps/templates/email_edit.html:27
+#: cps/templates/admin.html:49 cps/templates/email_edit.html:27
 msgid "SMTP Login"
 msgstr "login SMTP"
 
-#: cps/templates/admin.html:51 cps/templates/email_edit.html:35
+#: cps/templates/admin.html:50 cps/templates/email_edit.html:35
 msgid "From E-mail"
 msgstr "E-mail da"
 
-#: cps/templates/admin.html:61
+#: cps/templates/admin.html:60
 msgid "Edit E-mail Server Settings"
 msgstr "Modifica le impostazioni SMTP"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html:66
 msgid "Configuration"
 msgstr "Configurazione"
 
-#: cps/templates/admin.html:70
+#: cps/templates/admin.html:69
 msgid "Calibre Database Directory"
 msgstr "Cartella del database di Calibre"
 
-#: cps/templates/admin.html:74 cps/templates/config_edit.html:122
+#: cps/templates/admin.html:73 cps/templates/config_edit.html:122
 msgid "Log Level"
 msgstr "Livello di log"
 
-#: cps/templates/admin.html:78
+#: cps/templates/admin.html:77
 msgid "Port"
 msgstr "Porta"
 
-#: cps/templates/admin.html:84 cps/templates/config_view_edit.html:27
+#: cps/templates/admin.html:83 cps/templates/config_view_edit.html:27
 msgid "Books per Page"
 msgstr "Libri per pagina"
 
-#: cps/templates/admin.html:88
+#: cps/templates/admin.html:87
 msgid "Uploads"
 msgstr "Uploads"
 
-#: cps/templates/admin.html:92
+#: cps/templates/admin.html:91
 msgid "Anonymous Browsing"
 msgstr "Navigazione anonima"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html:95
 msgid "Public Registration"
 msgstr "Registrazione pubblica"
 
-#: cps/templates/admin.html:100
+#: cps/templates/admin.html:99
 msgid "Magic Link Remote Login"
 msgstr "Magic Link Login remoto"
 
-#: cps/templates/admin.html:104
+#: cps/templates/admin.html:103
 msgid "Reverse Proxy Login"
 msgstr "Login reverse proxy"
 
-#: cps/templates/admin.html:109
+#: cps/templates/admin.html:108
 msgid "Reverse proxy header name"
 msgstr "Nome intestazione reverse proxy"
 
-#: cps/templates/admin.html:114
+#: cps/templates/admin.html:113
 msgid "Edit Basic Configuration"
 msgstr "Edita la configurazione di base"
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html:114
 msgid "Edit UI Configuration"
 msgstr "Edita la configurazione dell'interfaccia utente"
 
-#: cps/templates/admin.html:121
+#: cps/templates/admin.html:120
 msgid "Administration"
 msgstr "Amministrazione"
 
-#: cps/templates/admin.html:122
+#: cps/templates/admin.html:121
 msgid "View Logs"
 msgstr "Visualizza Logfile"
 
-#: cps/templates/admin.html:123
+#: cps/templates/admin.html:122
 msgid "Reconnect Calibre Database"
 msgstr "Ricollega al database di Calibre"
 
-#: cps/templates/admin.html:124
+#: cps/templates/admin.html:123
 msgid "Restart"
 msgstr "Riavvia Calibre-Web"
 
-#: cps/templates/admin.html:125
+#: cps/templates/admin.html:124
 msgid "Shutdown"
 msgstr "Arresta Calibre-Web"
 
-#: cps/templates/admin.html:131
+#: cps/templates/admin.html:130
 msgid "Update"
 msgstr "Aggiornamento"
 
-#: cps/templates/admin.html:135
+#: cps/templates/admin.html:134
 msgid "Version"
 msgstr "Versione"
 
-#: cps/templates/admin.html:136
+#: cps/templates/admin.html:135
 msgid "Details"
 msgstr "Dettagli"
 
-#: cps/templates/admin.html:142
+#: cps/templates/admin.html:141
 msgid "Current version"
 msgstr "Versione attuale"
 
-#: cps/templates/admin.html:148
+#: cps/templates/admin.html:147
 msgid "Check for Update"
 msgstr "Ricerca aggiornamenti"
 
-#: cps/templates/admin.html:149
+#: cps/templates/admin.html:148
 msgid "Perform Update"
 msgstr "Esegui l'aggiornamento"
 
-#: cps/templates/admin.html:161
+#: cps/templates/admin.html:160
 msgid "Are you sure you want to restart?"
 msgstr "Vuoi veramente riavviare Calibre-Web?"
 
-#: cps/templates/admin.html:166 cps/templates/admin.html:180
-#: cps/templates/admin.html:200 cps/templates/shelf.html:72
+#: cps/templates/admin.html:165 cps/templates/admin.html:179
+#: cps/templates/admin.html:199 cps/templates/shelf.html:72
 msgid "OK"
 msgstr "Ok"
 
-#: cps/templates/admin.html:167 cps/templates/admin.html:181
+#: cps/templates/admin.html:166 cps/templates/admin.html:180
 #: cps/templates/book_edit.html:172 cps/templates/book_edit.html:194
 #: cps/templates/config_edit.html:346 cps/templates/config_view_edit.html:151
 #: cps/templates/email_edit.html:40 cps/templates/email_edit.html:92
@@ -1149,11 +1200,11 @@ msgstr "Ok"
 msgid "Cancel"
 msgstr "Annulla"
 
-#: cps/templates/admin.html:179
+#: cps/templates/admin.html:178
 msgid "Are you sure you want to shutdown?"
 msgstr "Vuoi veramente arrestare Calibre-Web?"
 
-#: cps/templates/admin.html:191
+#: cps/templates/admin.html:190
 msgid "Updating, please do not reload this page"
 msgstr "Aggiornamento, non ricaricare la pagina."
 
@@ -1242,8 +1293,12 @@ msgid "Rating"
 msgstr "Valutazione"
 
 #: cps/templates/book_edit.html:81
-msgid "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
-msgstr "Carica la copertina da URL (jpg, la copertina viene caricata e salvata nel database)"
+msgid ""
+"Fetch Cover from URL (JPEG - Image will be downloaded and stored in "
+"database)"
+msgstr ""
+"Carica la copertina da URL (jpg, la copertina viene caricata e salvata "
+"nel database)"
 
 #: cps/templates/book_edit.html:85
 msgid "Upload Cover from Local Disk"
@@ -1386,11 +1441,15 @@ msgstr "Porta del server"
 
 #: cps/templates/config_edit.html:91
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
-msgstr "Percorso del Certfile SSL (lascia vuoto per una configurazione del server senza SSL)"
+msgstr ""
+"Percorso del Certfile SSL (lascia vuoto per una configurazione del server"
+" senza SSL)"
 
 #: cps/templates/config_edit.html:95
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
-msgstr "Percorso del Keyfile SSL (lascia vuoto per una configurazione del server senza SSL)"
+msgstr ""
+"Percorso del Keyfile SSL (lascia vuoto per una configurazione del server "
+"senza SSL)"
 
 #: cps/templates/config_edit.html:99
 msgid "Update Channel"
@@ -1606,7 +1665,9 @@ msgstr "Numero di libri casuali da mostrare"
 
 #: cps/templates/config_view_edit.html:35
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
-msgstr "Numero di autori da mostrare prima di nascondere (0=disabilita mascheramento)"
+msgstr ""
+"Numero di autori da mostrare prima di nascondere (0=disabilita "
+"mascheramento)"
 
 #: cps/templates/config_view_edit.html:39 cps/templates/readcbr.html:112
 msgid "Theme"
@@ -1776,18 +1837,11 @@ msgstr "Dominii bloccati per la registrazione (Blacklist)"
 msgid "Are you sure you want to delete this domain?"
 msgstr "Vuoi veramente eliminare questa regola di dominio?"
 
-#: cps/templates/feed.xml:21 cps/templates/layout.html:173
-msgid "Next"
-msgstr "Prossimo"
-
-#: cps/templates/feed.xml:79 cps/templates/layout.html:136
-#: cps/templates/layout.html:140
-msgid "(Public)"
-msgstr ""
-
 #: cps/templates/generate_kobo_auth_url.html:5
 msgid "Open the .kobo/Kobo eReader.conf file in a text editor and add (or edit):"
-msgstr "Apri il file .kobo/Kobo eReader.conf in un editore di testi e aggiungi (o edita):"
+msgstr ""
+"Apri il file .kobo/Kobo eReader.conf in un editore di testi e aggiungi (o"
+" edita):"
 
 #: cps/templates/http_error.html:38
 msgid "Create Issue"
@@ -1800,70 +1854,6 @@ msgstr "Ritorna alla pagina principale"
 #: cps/templates/index.html:64
 msgid "Group by series"
 msgstr "Raggruppa per serie"
-
-#: cps/templates/index.xml:6
-msgid "Start"
-msgstr "Inizio"
-
-#: cps/templates/index.xml:21
-msgid "Popular publications from this catalog based on Downloads."
-msgstr "Pubblicazioni popolari di questo catalogo in base ai download."
-
-#: cps/templates/index.xml:28
-msgid "Popular publications from this catalog based on Rating."
-msgstr "Pubblicazioni popolari di questo catalogo in base alle valutazioni."
-
-#: cps/templates/index.xml:31
-msgid "Recently added Books"
-msgstr "Libri aggiunti di recente"
-
-#: cps/templates/index.xml:35
-msgid "The latest Books"
-msgstr "Gli ultimi libri"
-
-#: cps/templates/index.xml:38
-msgid "Random Books"
-msgstr "Libri presentati aleatoriamente"
-
-#: cps/templates/index.xml:42 cps/templates/user_edit.html:80
-msgid "Show Random Books"
-msgstr "Mostra libri casualmente"
-
-#: cps/templates/index.xml:65
-msgid "Books ordered by Author"
-msgstr "Libri ordinati per autore"
-
-#: cps/templates/index.xml:72
-msgid "Books ordered by publisher"
-msgstr "Libri ordinati per editore"
-
-#: cps/templates/index.xml:79
-msgid "Books ordered by category"
-msgstr "Libri ordinati per categoria"
-
-#: cps/templates/index.xml:86
-msgid "Books ordered by series"
-msgstr "Libri ordinati per serie"
-
-#: cps/templates/index.xml:93
-msgid "Books ordered by Languages"
-msgstr "Libri ordinati per lingua"
-
-#: cps/templates/index.xml:100
-msgid "Books ordered by Rating"
-msgstr "Libri ordinati per valutazione"
-
-#: cps/templates/index.xml:108
-msgid "Books ordered by file formats"
-msgstr "Libri ordinati per formato"
-
-#: cps/templates/index.xml:111 cps/templates/layout.html:134
-msgid "Shelves"
-msgstr ""
-
-#: cps/templates/index.xml:115
-msgid "Books organized in shelves"
-msgstr ""
 
 #: cps/templates/layout.html:28
 msgid "Home"
@@ -1915,6 +1905,14 @@ msgstr "Per favore non ricaricare la pagina"
 msgid "Browse"
 msgstr "Naviga"
 
+#: cps/templates/layout.html:134
+msgid "Shelves"
+msgstr ""
+
+#: cps/templates/layout.html:136 cps/templates/layout.html:140
+msgid "(Public)"
+msgstr ""
+
 #: cps/templates/layout.html:138
 msgid "Your Shelves"
 msgstr "I tuoi scaffali"
@@ -1926,6 +1924,10 @@ msgstr "Informazioni su"
 #: cps/templates/layout.html:158
 msgid "Previous"
 msgstr "Precedente"
+
+#: cps/templates/layout.html:173
+msgid "Next"
+msgstr "Prossimo"
 
 #: cps/templates/layout.html:185
 msgid "Book Details"
@@ -2130,7 +2132,9 @@ msgstr "Utilizza il tuo altro apparecchio, accedi e visita"
 
 #: cps/templates/remote_login.html:10
 msgid "Once verified, you will automatically be logged in on this device."
-msgstr "Una volta completato, verrai automaticamente connesso con questo dispositivo."
+msgstr ""
+"Una volta completato, verrai automaticamente connesso con questo "
+"dispositivo."
 
 #: cps/templates/remote_login.html:13
 msgid "This verification link will expire in 10 minutes."
@@ -2308,6 +2312,10 @@ msgstr "Token Kobo Sync"
 msgid "Create/View"
 msgstr "Crea/Visualizza"
 
+#: cps/templates/user_edit.html:80
+msgid "Show Random Books"
+msgstr "Mostra libri casualmente"
+
 #: cps/templates/user_edit.html:84
 msgid "Add allowed/Denied Custom Column Values"
 msgstr "Aggiungi valori personali nelle colonne permessi/negati"
@@ -2327,4 +2335,208 @@ msgstr "Genera un URL di autenticazione per Kobo"
 #: cps/templates/user_edit.html:176
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "Vuoi veramente eliminare questo token di Kobo?"
+
+#: vendor/tornado/locale.py:285
+msgid "January"
+msgstr ""
+
+#: vendor/tornado/locale.py:286
+msgid "February"
+msgstr ""
+
+#: vendor/tornado/locale.py:287
+msgid "March"
+msgstr ""
+
+#: vendor/tornado/locale.py:288
+msgid "April"
+msgstr ""
+
+#: vendor/tornado/locale.py:289
+msgid "May"
+msgstr ""
+
+#: vendor/tornado/locale.py:290
+msgid "June"
+msgstr ""
+
+#: vendor/tornado/locale.py:291
+msgid "July"
+msgstr ""
+
+#: vendor/tornado/locale.py:292
+msgid "August"
+msgstr ""
+
+#: vendor/tornado/locale.py:293
+msgid "September"
+msgstr ""
+
+#: vendor/tornado/locale.py:294
+msgid "October"
+msgstr ""
+
+#: vendor/tornado/locale.py:295
+msgid "November"
+msgstr ""
+
+#: vendor/tornado/locale.py:296
+msgid "December"
+msgstr ""
+
+#: vendor/tornado/locale.py:299
+msgid "Monday"
+msgstr ""
+
+#: vendor/tornado/locale.py:300
+msgid "Tuesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:301
+msgid "Wednesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:302
+msgid "Thursday"
+msgstr ""
+
+#: vendor/tornado/locale.py:303
+msgid "Friday"
+msgstr ""
+
+#: vendor/tornado/locale.py:304
+msgid "Saturday"
+msgstr ""
+
+#: vendor/tornado/locale.py:305
+msgid "Sunday"
+msgstr ""
+
+#: vendor/tornado/locale.py:368
+msgid "1 second ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:374
+msgid "1 minute ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:379
+msgid "1 hour ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:382
+#, python-format
+msgid "%(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+msgid "yesterday"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+#, python-format
+msgid "yesterday at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:389 vendor/tornado/locale.py:442
+#, python-format
+msgid "%(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:391
+#, python-format
+msgid "%(month_name)s %(day)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:396
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:398
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:436
+#, python-format
+msgid "%(weekday)s, %(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:459
+#, python-format
+msgid "%(commas)s and %(last)s"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:68
+msgctxt "law"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:69
+msgctxt "good"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:71 vendor/tornado/test/locale_test.py:74
+msgctxt "organization"
+msgid "club"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:76 vendor/tornado/test/locale_test.py:77
+msgctxt "stick"
+msgid "club"
+msgstr ""
+
+#~ msgid "Start"
+#~ msgstr "Inizio"
+
+#~ msgid "Popular publications from this catalog based on Downloads."
+#~ msgstr "Pubblicazioni popolari di questo catalogo in base ai download."
+
+#~ msgid "Popular publications from this catalog based on Rating."
+#~ msgstr "Pubblicazioni popolari di questo catalogo in base alle valutazioni."
+
+#~ msgid "Recently added Books"
+#~ msgstr "Libri aggiunti di recente"
+
+#~ msgid "The latest Books"
+#~ msgstr "Gli ultimi libri"
+
+#~ msgid "Random Books"
+#~ msgstr "Libri presentati aleatoriamente"
+
+#~ msgid "Books ordered by Author"
+#~ msgstr "Libri ordinati per autore"
+
+#~ msgid "Books ordered by publisher"
+#~ msgstr "Libri ordinati per editore"
+
+#~ msgid "Books ordered by category"
+#~ msgstr "Libri ordinati per categoria"
+
+#~ msgid "Books ordered by series"
+#~ msgstr "Libri ordinati per serie"
+
+#~ msgid "Books ordered by Languages"
+#~ msgstr "Libri ordinati per lingua"
+
+#~ msgid "Books ordered by Rating"
+#~ msgstr "Libri ordinati per valutazione"
+
+#~ msgid "Books ordered by file formats"
+#~ msgstr "Libri ordinati per formato"
+
+#~ msgid "Books organized in shelves"
+#~ msgstr ""
 

--- a/cps/translations/ja/LC_MESSAGES/messages.po
+++ b/cps/translations/ja/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Calibre-Web\n"
 "Report-Msgid-Bugs-To: https://github.com/janeczku/Calibre-Web\n"
-"POT-Creation-Date: 2020-04-03 19:49+0200\n"
+"POT-Creation-Date: 2020-04-08 23:10+0800\n"
 "PO-Revision-Date: 2018-02-07 02:20-0500\n"
 "Last-Translator: white <space_white@yahoo.com>\n"
 "Language: ja\n"
@@ -273,7 +273,9 @@ msgid "File %(filename)s could not saved to temp dir"
 msgstr ""
 
 #: cps/editbooks.py:598
-msgid "Uploaded book probably exists in the library, consider to change before upload new: "
+msgid ""
+"Uploaded book probably exists in the library, consider to change before "
+"upload new: "
 msgstr ""
 
 #: cps/editbooks.py:613
@@ -306,11 +308,15 @@ msgid "There was an error converting this book: %(res)s"
 msgstr "この本の変換中にエラーが発生しました: %(res)s"
 
 #: cps/gdrive.py:61
-msgid "Google Drive setup not completed, try to deactivate and activate Google Drive again"
+msgid ""
+"Google Drive setup not completed, try to deactivate and activate Google "
+"Drive again"
 msgstr "Googleドライブの設定が完了していません。Googleドライブを無効化してから再度有効にしてみてください"
 
 #: cps/gdrive.py:103
-msgid "Callback domain is not verified, please follow steps to verify domain in google developer console"
+msgid ""
+"Callback domain is not verified, please follow steps to verify domain in "
+"google developer console"
 msgstr "コールバックドメインが認証されていません。Google Developer Consoleでドメインを認証してください"
 
 #: cps/helper.py:80
@@ -456,7 +462,9 @@ msgid "Unknown Task: "
 msgstr "不明なタスク: "
 
 #: cps/kobo_auth.py:127
-msgid "PLease access calibre-web from non localhost to get valid api_endpoint for kobo device"
+msgid ""
+"PLease access calibre-web from non localhost to get valid api_endpoint "
+"for kobo device"
 msgstr ""
 
 #: cps/kobo_auth.py:130 cps/kobo_auth.py:150
@@ -622,7 +630,7 @@ msgstr "最近追加した本"
 msgid "Show recent books"
 msgstr "最近追加された本を表示"
 
-#: cps/templates/index.xml:17 cps/ub.py:59
+#: cps/ub.py:59
 msgid "Hot Books"
 msgstr "人気の本"
 
@@ -630,7 +638,7 @@ msgstr "人気の本"
 msgid "Show Hot Books"
 msgstr ""
 
-#: cps/templates/index.xml:24 cps/ub.py:63 cps/web.py:508
+#: cps/ub.py:63 cps/web.py:508
 msgid "Top Rated Books"
 msgstr ""
 
@@ -638,8 +646,7 @@ msgstr ""
 msgid "Show Top Rated Books"
 msgstr ""
 
-#: cps/templates/index.xml:46 cps/templates/index.xml:50 cps/ub.py:66
-#: cps/web.py:1005
+#: cps/ub.py:66 cps/web.py:1005
 msgid "Read Books"
 msgstr "読んだ本"
 
@@ -647,8 +654,7 @@ msgstr "読んだ本"
 msgid "Show read and unread"
 msgstr "既読の本と未読の本を表示"
 
-#: cps/templates/index.xml:53 cps/templates/index.xml:57 cps/ub.py:70
-#: cps/web.py:1009
+#: cps/ub.py:70 cps/web.py:1009
 msgid "Unread Books"
 msgstr "未読の本"
 
@@ -664,7 +670,7 @@ msgstr "見つける"
 msgid "Show random books"
 msgstr "ランダムで本を表示"
 
-#: cps/templates/index.xml:75 cps/ub.py:76 cps/web.py:787
+#: cps/ub.py:76 cps/web.py:787
 msgid "Categories"
 msgstr "カテゴリ"
 
@@ -672,8 +678,8 @@ msgstr "カテゴリ"
 msgid "Show category selection"
 msgstr "カテゴリ選択を表示"
 
-#: cps/templates/book_edit.html:69 cps/templates/index.xml:82
-#: cps/templates/search_form.html:53 cps/ub.py:79 cps/web.py:715
+#: cps/templates/book_edit.html:69 cps/templates/search_form.html:53
+#: cps/ub.py:79 cps/web.py:715
 msgid "Series"
 msgstr "シリーズ"
 
@@ -681,7 +687,7 @@ msgstr "シリーズ"
 msgid "Show series selection"
 msgstr "シリーズ選択を表示"
 
-#: cps/templates/index.xml:61 cps/ub.py:82
+#: cps/ub.py:82
 msgid "Authors"
 msgstr "著者"
 
@@ -689,7 +695,7 @@ msgstr "著者"
 msgid "Show author selection"
 msgstr "著者選択を表示"
 
-#: cps/templates/index.xml:68 cps/ub.py:86 cps/web.py:699
+#: cps/ub.py:86 cps/web.py:699
 msgid "Publishers"
 msgstr "出版社"
 
@@ -697,8 +703,7 @@ msgstr "出版社"
 msgid "Show publisher selection"
 msgstr "出版社選択を表示"
 
-#: cps/templates/index.xml:89 cps/templates/search_form.html:74 cps/ub.py:89
-#: cps/web.py:770
+#: cps/templates/search_form.html:74 cps/ub.py:89 cps/web.py:770
 msgid "Languages"
 msgstr "言語"
 
@@ -706,7 +711,7 @@ msgstr "言語"
 msgid "Show language selection"
 msgstr "言語選択を表示"
 
-#: cps/templates/index.xml:96 cps/ub.py:93
+#: cps/ub.py:93
 msgid "Ratings"
 msgstr ""
 
@@ -714,7 +719,7 @@ msgstr ""
 msgid "Show ratings selection"
 msgstr ""
 
-#: cps/templates/index.xml:104 cps/ub.py:96
+#: cps/ub.py:96
 msgid "File formats"
 msgstr ""
 
@@ -731,7 +736,9 @@ msgid "No update available. You already have the latest version installed"
 msgstr "アップデートはありません。すでに最新バージョンがインストールされています"
 
 #: cps/updater.py:333
-msgid "A new update is available. Click on the button below to update to the latest version."
+msgid ""
+"A new update is available. Click on the button below to update to the "
+"latest version."
 msgstr "アップデートが利用可能です。下のボタンをクリックして最新バージョンにアップデートしてください。"
 
 #: cps/updater.py:385
@@ -744,7 +751,9 @@ msgstr "リリース情報がありません"
 
 #: cps/updater.py:456 cps/updater.py:467 cps/updater.py:486
 #, python-format
-msgid "A new update is available. Click on the button below to update to version: %(version)s"
+msgid ""
+"A new update is available. Click on the button below to update to "
+"version: %(version)s"
 msgstr "アップデートが利用可能です。下のボタンをクリックしてバージョン: %(version)s にアップデートしてください。"
 
 #: cps/updater.py:477
@@ -768,7 +777,9 @@ msgid "Hot Books (Most Downloaded)"
 msgstr ""
 
 #: cps/web.py:580
-msgid "Oops! Selected book title is unavailable. File does not exist or is not accessible"
+msgid ""
+"Oops! Selected book title is unavailable. File does not exist or is not "
+"accessible"
 msgstr ""
 
 #: cps/web.py:593
@@ -818,9 +829,9 @@ msgstr ""
 msgid "Tasks"
 msgstr "タスク"
 
-#: cps/templates/book_edit.html:212 cps/templates/feed.xml:33
-#: cps/templates/layout.html:44 cps/templates/layout.html:47
-#: cps/templates/search_form.html:170 cps/web.py:821 cps/web.py:823
+#: cps/templates/book_edit.html:212 cps/templates/layout.html:44
+#: cps/templates/layout.html:47 cps/templates/search_form.html:170
+#: cps/web.py:821 cps/web.py:823
 msgid "Search"
 msgstr "検索"
 
@@ -959,189 +970,189 @@ msgstr "Ebook-converter が失敗しました: %(error)s"
 msgid "Kindlegen failed with Error %(error)s. Message: %(message)s"
 msgstr "Kindlegen が失敗しました。エラー: %(error)s, メッセージ: %(message)s"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html:8
 msgid "Users"
 msgstr ""
 
-#: cps/templates/admin.html:12 cps/templates/login.html:8
+#: cps/templates/admin.html:11 cps/templates/login.html:8
 #: cps/templates/login.html:9 cps/templates/register.html:7
 #: cps/templates/user_edit.html:8
 msgid "Username"
 msgstr "ユーザ名"
 
-#: cps/templates/admin.html:13 cps/templates/register.html:11
+#: cps/templates/admin.html:12 cps/templates/register.html:11
 #: cps/templates/user_edit.html:13
 msgid "E-mail Address"
 msgstr ""
 
-#: cps/templates/admin.html:14 cps/templates/user_edit.html:26
+#: cps/templates/admin.html:13 cps/templates/user_edit.html:26
 msgid "Send to Kindle E-mail Address"
 msgstr ""
 
-#: cps/templates/admin.html:15
+#: cps/templates/admin.html:14
 msgid "Downloads"
 msgstr ""
 
-#: cps/templates/admin.html:16 cps/templates/layout.html:76
+#: cps/templates/admin.html:15 cps/templates/layout.html:76
 msgid "Admin"
 msgstr "管理者"
 
-#: cps/templates/admin.html:17 cps/templates/detail.html:18
+#: cps/templates/admin.html:16 cps/templates/detail.html:18
 #: cps/templates/detail.html:27 cps/templates/shelf.html:6
 #: cps/templates/shelfdown.html:62
 msgid "Download"
 msgstr "ダウンロード"
 
-#: cps/templates/admin.html:18
+#: cps/templates/admin.html:17
 msgid "View Books"
 msgstr ""
 
-#: cps/templates/admin.html:19 cps/templates/layout.html:65
+#: cps/templates/admin.html:18 cps/templates/layout.html:65
 msgid "Upload"
 msgstr "アップロード"
 
-#: cps/templates/admin.html:20
+#: cps/templates/admin.html:19
 msgid "Edit"
 msgstr "編集"
 
-#: cps/templates/admin.html:38
+#: cps/templates/admin.html:37
 msgid "Add New User"
 msgstr ""
 
-#: cps/templates/admin.html:44
+#: cps/templates/admin.html:43
 msgid "E-mail Server Settings"
 msgstr ""
 
-#: cps/templates/admin.html:47 cps/templates/email_edit.html:11
+#: cps/templates/admin.html:46 cps/templates/email_edit.html:11
 msgid "SMTP Hostname"
 msgstr ""
 
-#: cps/templates/admin.html:48 cps/templates/email_edit.html:15
+#: cps/templates/admin.html:47 cps/templates/email_edit.html:15
 msgid "SMTP Port"
 msgstr ""
 
-#: cps/templates/admin.html:49 cps/templates/email_edit.html:19
+#: cps/templates/admin.html:48 cps/templates/email_edit.html:19
 msgid "Encryption"
 msgstr "暗号化"
 
-#: cps/templates/admin.html:50 cps/templates/email_edit.html:27
+#: cps/templates/admin.html:49 cps/templates/email_edit.html:27
 msgid "SMTP Login"
 msgstr ""
 
-#: cps/templates/admin.html:51 cps/templates/email_edit.html:35
+#: cps/templates/admin.html:50 cps/templates/email_edit.html:35
 msgid "From E-mail"
 msgstr ""
 
-#: cps/templates/admin.html:61
+#: cps/templates/admin.html:60
 msgid "Edit E-mail Server Settings"
 msgstr "SMTP設定を変更"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html:66
 msgid "Configuration"
 msgstr "設定"
 
-#: cps/templates/admin.html:70
+#: cps/templates/admin.html:69
 msgid "Calibre Database Directory"
 msgstr ""
 
-#: cps/templates/admin.html:74 cps/templates/config_edit.html:122
+#: cps/templates/admin.html:73 cps/templates/config_edit.html:122
 msgid "Log Level"
 msgstr "ログレベル"
 
-#: cps/templates/admin.html:78
+#: cps/templates/admin.html:77
 msgid "Port"
 msgstr "ポート番号"
 
-#: cps/templates/admin.html:84 cps/templates/config_view_edit.html:27
+#: cps/templates/admin.html:83 cps/templates/config_view_edit.html:27
 msgid "Books per Page"
 msgstr ""
 
-#: cps/templates/admin.html:88
+#: cps/templates/admin.html:87
 msgid "Uploads"
 msgstr ""
 
-#: cps/templates/admin.html:92
+#: cps/templates/admin.html:91
 msgid "Anonymous Browsing"
 msgstr ""
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html:95
 msgid "Public Registration"
 msgstr ""
 
-#: cps/templates/admin.html:100
+#: cps/templates/admin.html:99
 msgid "Magic Link Remote Login"
 msgstr ""
 
-#: cps/templates/admin.html:104
+#: cps/templates/admin.html:103
 msgid "Reverse Proxy Login"
 msgstr ""
 
-#: cps/templates/admin.html:109
+#: cps/templates/admin.html:108
 msgid "Reverse proxy header name"
 msgstr ""
 
-#: cps/templates/admin.html:114
+#: cps/templates/admin.html:113
 msgid "Edit Basic Configuration"
 msgstr ""
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html:114
 msgid "Edit UI Configuration"
 msgstr ""
 
-#: cps/templates/admin.html:121
+#: cps/templates/admin.html:120
 msgid "Administration"
 msgstr "管理"
 
-#: cps/templates/admin.html:122
+#: cps/templates/admin.html:121
 msgid "View Logs"
 msgstr ""
 
-#: cps/templates/admin.html:123
+#: cps/templates/admin.html:122
 msgid "Reconnect Calibre Database"
 msgstr ""
 
-#: cps/templates/admin.html:124
+#: cps/templates/admin.html:123
 msgid "Restart"
 msgstr ""
 
-#: cps/templates/admin.html:125
+#: cps/templates/admin.html:124
 msgid "Shutdown"
 msgstr ""
 
-#: cps/templates/admin.html:131
+#: cps/templates/admin.html:130
 msgid "Update"
 msgstr "アップデート"
 
-#: cps/templates/admin.html:135
+#: cps/templates/admin.html:134
 msgid "Version"
 msgstr "バージョン"
 
-#: cps/templates/admin.html:136
+#: cps/templates/admin.html:135
 msgid "Details"
 msgstr "詳細"
 
-#: cps/templates/admin.html:142
+#: cps/templates/admin.html:141
 msgid "Current version"
 msgstr "現在のバージョン"
 
-#: cps/templates/admin.html:148
+#: cps/templates/admin.html:147
 msgid "Check for Update"
 msgstr ""
 
-#: cps/templates/admin.html:149
+#: cps/templates/admin.html:148
 msgid "Perform Update"
 msgstr "更新を実行"
 
-#: cps/templates/admin.html:161
+#: cps/templates/admin.html:160
 msgid "Are you sure you want to restart?"
 msgstr ""
 
-#: cps/templates/admin.html:166 cps/templates/admin.html:180
-#: cps/templates/admin.html:200 cps/templates/shelf.html:72
+#: cps/templates/admin.html:165 cps/templates/admin.html:179
+#: cps/templates/admin.html:199 cps/templates/shelf.html:72
 msgid "OK"
 msgstr ""
 
-#: cps/templates/admin.html:167 cps/templates/admin.html:181
+#: cps/templates/admin.html:166 cps/templates/admin.html:180
 #: cps/templates/book_edit.html:172 cps/templates/book_edit.html:194
 #: cps/templates/config_edit.html:346 cps/templates/config_view_edit.html:151
 #: cps/templates/email_edit.html:40 cps/templates/email_edit.html:92
@@ -1150,11 +1161,11 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: cps/templates/admin.html:179
+#: cps/templates/admin.html:178
 msgid "Are you sure you want to shutdown?"
 msgstr ""
 
-#: cps/templates/admin.html:191
+#: cps/templates/admin.html:190
 msgid "Updating, please do not reload this page"
 msgstr ""
 
@@ -1243,7 +1254,9 @@ msgid "Rating"
 msgstr "評価"
 
 #: cps/templates/book_edit.html:81
-msgid "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
+msgid ""
+"Fetch Cover from URL (JPEG - Image will be downloaded and stored in "
+"database)"
 msgstr ""
 
 #: cps/templates/book_edit.html:85
@@ -1777,15 +1790,6 @@ msgstr ""
 msgid "Are you sure you want to delete this domain?"
 msgstr ""
 
-#: cps/templates/feed.xml:21 cps/templates/layout.html:173
-msgid "Next"
-msgstr "次"
-
-#: cps/templates/feed.xml:79 cps/templates/layout.html:136
-#: cps/templates/layout.html:140
-msgid "(Public)"
-msgstr ""
-
 #: cps/templates/generate_kobo_auth_url.html:5
 msgid "Open the .kobo/Kobo eReader.conf file in a text editor and add (or edit):"
 msgstr ""
@@ -1800,70 +1804,6 @@ msgstr ""
 
 #: cps/templates/index.html:64
 msgid "Group by series"
-msgstr ""
-
-#: cps/templates/index.xml:6
-msgid "Start"
-msgstr "開始"
-
-#: cps/templates/index.xml:21
-msgid "Popular publications from this catalog based on Downloads."
-msgstr "ダウンロード数に基づいた、この出版社が出している有名な本"
-
-#: cps/templates/index.xml:28
-msgid "Popular publications from this catalog based on Rating."
-msgstr "評価に基づいた、この出版社が出している有名な本"
-
-#: cps/templates/index.xml:31
-msgid "Recently added Books"
-msgstr ""
-
-#: cps/templates/index.xml:35
-msgid "The latest Books"
-msgstr "最新の本"
-
-#: cps/templates/index.xml:38
-msgid "Random Books"
-msgstr "ランダム"
-
-#: cps/templates/index.xml:42 cps/templates/user_edit.html:80
-msgid "Show Random Books"
-msgstr "ランダムで本を表示"
-
-#: cps/templates/index.xml:65
-msgid "Books ordered by Author"
-msgstr "著者名順"
-
-#: cps/templates/index.xml:72
-msgid "Books ordered by publisher"
-msgstr "出版社順"
-
-#: cps/templates/index.xml:79
-msgid "Books ordered by category"
-msgstr "カテゴリ順"
-
-#: cps/templates/index.xml:86
-msgid "Books ordered by series"
-msgstr "シリーズ順"
-
-#: cps/templates/index.xml:93
-msgid "Books ordered by Languages"
-msgstr ""
-
-#: cps/templates/index.xml:100
-msgid "Books ordered by Rating"
-msgstr ""
-
-#: cps/templates/index.xml:108
-msgid "Books ordered by file formats"
-msgstr ""
-
-#: cps/templates/index.xml:111 cps/templates/layout.html:134
-msgid "Shelves"
-msgstr ""
-
-#: cps/templates/index.xml:115
-msgid "Books organized in shelves"
 msgstr ""
 
 #: cps/templates/layout.html:28
@@ -1916,6 +1856,14 @@ msgstr ""
 msgid "Browse"
 msgstr "閲覧"
 
+#: cps/templates/layout.html:134
+msgid "Shelves"
+msgstr ""
+
+#: cps/templates/layout.html:136 cps/templates/layout.html:140
+msgid "(Public)"
+msgstr ""
+
 #: cps/templates/layout.html:138
 msgid "Your Shelves"
 msgstr "あなたの本棚"
@@ -1927,6 +1875,10 @@ msgstr "このサイトについて"
 #: cps/templates/layout.html:158
 msgid "Previous"
 msgstr "前"
+
+#: cps/templates/layout.html:173
+msgid "Next"
+msgstr "次"
 
 #: cps/templates/layout.html:185
 msgid "Book Details"
@@ -2309,6 +2261,10 @@ msgstr ""
 msgid "Create/View"
 msgstr ""
 
+#: cps/templates/user_edit.html:80
+msgid "Show Random Books"
+msgstr "ランダムで本を表示"
+
 #: cps/templates/user_edit.html:84
 msgid "Add allowed/Denied Custom Column Values"
 msgstr ""
@@ -2328,4 +2284,208 @@ msgstr ""
 #: cps/templates/user_edit.html:176
 msgid "Do you really want to delete the Kobo Token?"
 msgstr ""
+
+#: vendor/tornado/locale.py:285
+msgid "January"
+msgstr ""
+
+#: vendor/tornado/locale.py:286
+msgid "February"
+msgstr ""
+
+#: vendor/tornado/locale.py:287
+msgid "March"
+msgstr ""
+
+#: vendor/tornado/locale.py:288
+msgid "April"
+msgstr ""
+
+#: vendor/tornado/locale.py:289
+msgid "May"
+msgstr ""
+
+#: vendor/tornado/locale.py:290
+msgid "June"
+msgstr ""
+
+#: vendor/tornado/locale.py:291
+msgid "July"
+msgstr ""
+
+#: vendor/tornado/locale.py:292
+msgid "August"
+msgstr ""
+
+#: vendor/tornado/locale.py:293
+msgid "September"
+msgstr ""
+
+#: vendor/tornado/locale.py:294
+msgid "October"
+msgstr ""
+
+#: vendor/tornado/locale.py:295
+msgid "November"
+msgstr ""
+
+#: vendor/tornado/locale.py:296
+msgid "December"
+msgstr ""
+
+#: vendor/tornado/locale.py:299
+msgid "Monday"
+msgstr ""
+
+#: vendor/tornado/locale.py:300
+msgid "Tuesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:301
+msgid "Wednesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:302
+msgid "Thursday"
+msgstr ""
+
+#: vendor/tornado/locale.py:303
+msgid "Friday"
+msgstr ""
+
+#: vendor/tornado/locale.py:304
+msgid "Saturday"
+msgstr ""
+
+#: vendor/tornado/locale.py:305
+msgid "Sunday"
+msgstr ""
+
+#: vendor/tornado/locale.py:368
+msgid "1 second ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:374
+msgid "1 minute ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:379
+msgid "1 hour ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:382
+#, python-format
+msgid "%(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+msgid "yesterday"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+#, python-format
+msgid "yesterday at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:389 vendor/tornado/locale.py:442
+#, python-format
+msgid "%(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:391
+#, python-format
+msgid "%(month_name)s %(day)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:396
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:398
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:436
+#, python-format
+msgid "%(weekday)s, %(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:459
+#, python-format
+msgid "%(commas)s and %(last)s"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:68
+msgctxt "law"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:69
+msgctxt "good"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:71 vendor/tornado/test/locale_test.py:74
+msgctxt "organization"
+msgid "club"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:76 vendor/tornado/test/locale_test.py:77
+msgctxt "stick"
+msgid "club"
+msgstr ""
+
+#~ msgid "Start"
+#~ msgstr "開始"
+
+#~ msgid "Popular publications from this catalog based on Downloads."
+#~ msgstr "ダウンロード数に基づいた、この出版社が出している有名な本"
+
+#~ msgid "Popular publications from this catalog based on Rating."
+#~ msgstr "評価に基づいた、この出版社が出している有名な本"
+
+#~ msgid "Recently added Books"
+#~ msgstr ""
+
+#~ msgid "The latest Books"
+#~ msgstr "最新の本"
+
+#~ msgid "Random Books"
+#~ msgstr "ランダム"
+
+#~ msgid "Books ordered by Author"
+#~ msgstr "著者名順"
+
+#~ msgid "Books ordered by publisher"
+#~ msgstr "出版社順"
+
+#~ msgid "Books ordered by category"
+#~ msgstr "カテゴリ順"
+
+#~ msgid "Books ordered by series"
+#~ msgstr "シリーズ順"
+
+#~ msgid "Books ordered by Languages"
+#~ msgstr ""
+
+#~ msgid "Books ordered by Rating"
+#~ msgstr ""
+
+#~ msgid "Books ordered by file formats"
+#~ msgstr ""
+
+#~ msgid "Books organized in shelves"
+#~ msgstr ""
 

--- a/cps/translations/km/LC_MESSAGES/messages.po
+++ b/cps/translations/km/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Calibre-Web\n"
 "Report-Msgid-Bugs-To: https://github.com/janeczku/Calibre-Web\n"
-"POT-Creation-Date: 2020-04-03 19:49+0200\n"
+"POT-Creation-Date: 2020-04-08 23:10+0800\n"
 "PO-Revision-Date: 2018-08-27 17:06+0700\n"
 "Last-Translator: \n"
 "Language: km_KH\n"
@@ -274,7 +274,9 @@ msgid "File %(filename)s could not saved to temp dir"
 msgstr ""
 
 #: cps/editbooks.py:598
-msgid "Uploaded book probably exists in the library, consider to change before upload new: "
+msgid ""
+"Uploaded book probably exists in the library, consider to change before "
+"upload new: "
 msgstr ""
 
 #: cps/editbooks.py:613
@@ -307,12 +309,18 @@ msgid "There was an error converting this book: %(res)s"
 msgstr ""
 
 #: cps/gdrive.py:61
-msgid "Google Drive setup not completed, try to deactivate and activate Google Drive again"
+msgid ""
+"Google Drive setup not completed, try to deactivate and activate Google "
+"Drive again"
 msgstr ""
 
 #: cps/gdrive.py:103
-msgid "Callback domain is not verified, please follow steps to verify domain in google developer console"
-msgstr "Callback domain មិនទាន់បានផ្ទៀងផ្ទាត់ឲប្រើទេ សូមធ្វើតាមជំហានដើម្បីផ្ទៀងផ្ទាត់ domain នៅក្នុង Google Developer Console"
+msgid ""
+"Callback domain is not verified, please follow steps to verify domain in "
+"google developer console"
+msgstr ""
+"Callback domain មិនទាន់បានផ្ទៀងផ្ទាត់ឲប្រើទេ "
+"សូមធ្វើតាមជំហានដើម្បីផ្ទៀងផ្ទាត់ domain នៅក្នុង Google Developer Console"
 
 #: cps/helper.py:80
 #, python-format
@@ -457,7 +465,9 @@ msgid "Unknown Task: "
 msgstr ""
 
 #: cps/kobo_auth.py:127
-msgid "PLease access calibre-web from non localhost to get valid api_endpoint for kobo device"
+msgid ""
+"PLease access calibre-web from non localhost to get valid api_endpoint "
+"for kobo device"
 msgstr ""
 
 #: cps/kobo_auth.py:130 cps/kobo_auth.py:150
@@ -623,7 +633,7 @@ msgstr "ទើបបន្ថែមថ្មីៗ"
 msgid "Show recent books"
 msgstr "បង្ហាញសៀវភៅមកថ្មី"
 
-#: cps/templates/index.xml:17 cps/ub.py:59
+#: cps/ub.py:59
 msgid "Hot Books"
 msgstr "សៀវភៅដែលមានប្រជាប្រិយភាព"
 
@@ -631,7 +641,7 @@ msgstr "សៀវភៅដែលមានប្រជាប្រិយភាព
 msgid "Show Hot Books"
 msgstr "បង្ហាញសៀវភៅដែលមានប្រជាប្រិយភាព"
 
-#: cps/templates/index.xml:24 cps/ub.py:63 cps/web.py:508
+#: cps/ub.py:63 cps/web.py:508
 msgid "Top Rated Books"
 msgstr "សៀវភៅដែលមានការវាយតម្លៃល្អជាងគេ"
 
@@ -639,8 +649,7 @@ msgstr "សៀវភៅដែលមានការវាយតម្លៃល្
 msgid "Show Top Rated Books"
 msgstr "បង្ហាញសៀវភៅដែលមានការវាយតម្លៃល្អជាងគេ"
 
-#: cps/templates/index.xml:46 cps/templates/index.xml:50 cps/ub.py:66
-#: cps/web.py:1005
+#: cps/ub.py:66 cps/web.py:1005
 msgid "Read Books"
 msgstr "សៀវភៅដែលបានអានរួច"
 
@@ -648,8 +657,7 @@ msgstr "សៀវភៅដែលបានអានរួច"
 msgid "Show read and unread"
 msgstr "បង្ហាញអានរួច និងមិនទាន់អាន"
 
-#: cps/templates/index.xml:53 cps/templates/index.xml:57 cps/ub.py:70
-#: cps/web.py:1009
+#: cps/ub.py:70 cps/web.py:1009
 msgid "Unread Books"
 msgstr "សៀវភៅដែលមិនទាន់បានអាន"
 
@@ -665,7 +673,7 @@ msgstr "ស្រាវជ្រាវ"
 msgid "Show random books"
 msgstr "បង្ហាញសៀវភៅចៃដន្យ"
 
-#: cps/templates/index.xml:75 cps/ub.py:76 cps/web.py:787
+#: cps/ub.py:76 cps/web.py:787
 msgid "Categories"
 msgstr "ប្រភេទនានា"
 
@@ -673,8 +681,8 @@ msgstr "ប្រភេទនានា"
 msgid "Show category selection"
 msgstr "បង្ហាញជម្រើសប្រភេទ"
 
-#: cps/templates/book_edit.html:69 cps/templates/index.xml:82
-#: cps/templates/search_form.html:53 cps/ub.py:79 cps/web.py:715
+#: cps/templates/book_edit.html:69 cps/templates/search_form.html:53
+#: cps/ub.py:79 cps/web.py:715
 msgid "Series"
 msgstr "ស៊េរី"
 
@@ -682,7 +690,7 @@ msgstr "ស៊េរី"
 msgid "Show series selection"
 msgstr "បង្ហាញជម្រើសស៊េរី"
 
-#: cps/templates/index.xml:61 cps/ub.py:82
+#: cps/ub.py:82
 msgid "Authors"
 msgstr "អ្នកនិពន្ធ"
 
@@ -690,7 +698,7 @@ msgstr "អ្នកនិពន្ធ"
 msgid "Show author selection"
 msgstr "បង្ហាញជម្រើសអ្នកនិពន្ធ"
 
-#: cps/templates/index.xml:68 cps/ub.py:86 cps/web.py:699
+#: cps/ub.py:86 cps/web.py:699
 msgid "Publishers"
 msgstr ""
 
@@ -698,8 +706,7 @@ msgstr ""
 msgid "Show publisher selection"
 msgstr ""
 
-#: cps/templates/index.xml:89 cps/templates/search_form.html:74 cps/ub.py:89
-#: cps/web.py:770
+#: cps/templates/search_form.html:74 cps/ub.py:89 cps/web.py:770
 msgid "Languages"
 msgstr "ភាសានានា"
 
@@ -707,7 +714,7 @@ msgstr "ភាសានានា"
 msgid "Show language selection"
 msgstr "បង្ហាញផ្នែកភាសា"
 
-#: cps/templates/index.xml:96 cps/ub.py:93
+#: cps/ub.py:93
 msgid "Ratings"
 msgstr ""
 
@@ -715,7 +722,7 @@ msgstr ""
 msgid "Show ratings selection"
 msgstr ""
 
-#: cps/templates/index.xml:104 cps/ub.py:96
+#: cps/ub.py:96
 msgid "File formats"
 msgstr ""
 
@@ -732,7 +739,9 @@ msgid "No update available. You already have the latest version installed"
 msgstr ""
 
 #: cps/updater.py:333
-msgid "A new update is available. Click on the button below to update to the latest version."
+msgid ""
+"A new update is available. Click on the button below to update to the "
+"latest version."
 msgstr ""
 
 #: cps/updater.py:385
@@ -745,7 +754,9 @@ msgstr ""
 
 #: cps/updater.py:456 cps/updater.py:467 cps/updater.py:486
 #, python-format
-msgid "A new update is available. Click on the button below to update to version: %(version)s"
+msgid ""
+"A new update is available. Click on the button below to update to "
+"version: %(version)s"
 msgstr ""
 
 #: cps/updater.py:477
@@ -769,7 +780,9 @@ msgid "Hot Books (Most Downloaded)"
 msgstr "សៀវភៅដែលត្រូវបានទាញយកច្រើនជាងគេ"
 
 #: cps/web.py:580
-msgid "Oops! Selected book title is unavailable. File does not exist or is not accessible"
+msgid ""
+"Oops! Selected book title is unavailable. File does not exist or is not "
+"accessible"
 msgstr ""
 
 #: cps/web.py:593
@@ -819,9 +832,9 @@ msgstr ""
 msgid "Tasks"
 msgstr "កិច្ចការនានា"
 
-#: cps/templates/book_edit.html:212 cps/templates/feed.xml:33
-#: cps/templates/layout.html:44 cps/templates/layout.html:47
-#: cps/templates/search_form.html:170 cps/web.py:821 cps/web.py:823
+#: cps/templates/book_edit.html:212 cps/templates/layout.html:44
+#: cps/templates/layout.html:47 cps/templates/search_form.html:170
+#: cps/web.py:821 cps/web.py:823
 msgid "Search"
 msgstr "ស្វែងរក"
 
@@ -960,189 +973,189 @@ msgstr "Ebook-converter បានបរាជ័យ៖ %(error)s"
 msgid "Kindlegen failed with Error %(error)s. Message: %(message)s"
 msgstr "Kindlegen បានបរាជ័យដោយមានកំហុស %(error)s. សារ៖ %(message)s"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html:8
 msgid "Users"
 msgstr "បញ្ជីអ្នកប្រើប្រាស់"
 
-#: cps/templates/admin.html:12 cps/templates/login.html:8
+#: cps/templates/admin.html:11 cps/templates/login.html:8
 #: cps/templates/login.html:9 cps/templates/register.html:7
 #: cps/templates/user_edit.html:8
 msgid "Username"
 msgstr "ឈ្មោះហៅក្រៅ"
 
-#: cps/templates/admin.html:13 cps/templates/register.html:11
+#: cps/templates/admin.html:12 cps/templates/register.html:11
 #: cps/templates/user_edit.html:13
 msgid "E-mail Address"
 msgstr ""
 
-#: cps/templates/admin.html:14 cps/templates/user_edit.html:26
+#: cps/templates/admin.html:13 cps/templates/user_edit.html:26
 msgid "Send to Kindle E-mail Address"
 msgstr "ឧបករណ៍ Kindle"
 
-#: cps/templates/admin.html:15
+#: cps/templates/admin.html:14
 msgid "Downloads"
 msgstr "ឯកសារ DLS"
 
-#: cps/templates/admin.html:16 cps/templates/layout.html:76
+#: cps/templates/admin.html:15 cps/templates/layout.html:76
 msgid "Admin"
 msgstr "រដ្ឋបាល"
 
-#: cps/templates/admin.html:17 cps/templates/detail.html:18
+#: cps/templates/admin.html:16 cps/templates/detail.html:18
 #: cps/templates/detail.html:27 cps/templates/shelf.html:6
 #: cps/templates/shelfdown.html:62
 msgid "Download"
 msgstr "ទាញយក"
 
-#: cps/templates/admin.html:18
+#: cps/templates/admin.html:17
 msgid "View Books"
 msgstr ""
 
-#: cps/templates/admin.html:19 cps/templates/layout.html:65
+#: cps/templates/admin.html:18 cps/templates/layout.html:65
 msgid "Upload"
 msgstr "អាប់ឡូដ"
 
-#: cps/templates/admin.html:20
+#: cps/templates/admin.html:19
 msgid "Edit"
 msgstr "កែប្រែ"
 
-#: cps/templates/admin.html:38
+#: cps/templates/admin.html:37
 msgid "Add New User"
 msgstr ""
 
-#: cps/templates/admin.html:44
+#: cps/templates/admin.html:43
 msgid "E-mail Server Settings"
 msgstr ""
 
-#: cps/templates/admin.html:47 cps/templates/email_edit.html:11
+#: cps/templates/admin.html:46 cps/templates/email_edit.html:11
 msgid "SMTP Hostname"
 msgstr "ឈ្មោះម៉ាស៊ីន SMTP"
 
-#: cps/templates/admin.html:48 cps/templates/email_edit.html:15
+#: cps/templates/admin.html:47 cps/templates/email_edit.html:15
 msgid "SMTP Port"
 msgstr "លេខ port SMTP"
 
-#: cps/templates/admin.html:49 cps/templates/email_edit.html:19
+#: cps/templates/admin.html:48 cps/templates/email_edit.html:19
 msgid "Encryption"
 msgstr "SSL"
 
-#: cps/templates/admin.html:50 cps/templates/email_edit.html:27
+#: cps/templates/admin.html:49 cps/templates/email_edit.html:27
 msgid "SMTP Login"
 msgstr "អ្នកចូលប្រើ SMTP"
 
-#: cps/templates/admin.html:51 cps/templates/email_edit.html:35
+#: cps/templates/admin.html:50 cps/templates/email_edit.html:35
 msgid "From E-mail"
 msgstr "ពីអ៊ីមែល"
 
-#: cps/templates/admin.html:61
+#: cps/templates/admin.html:60
 msgid "Edit E-mail Server Settings"
 msgstr "ប្តូរការកំណត់ SMTP"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html:66
 msgid "Configuration"
 msgstr "ការកំណត់"
 
-#: cps/templates/admin.html:70
+#: cps/templates/admin.html:69
 msgid "Calibre Database Directory"
 msgstr "ទីតាំង database Calibre"
 
-#: cps/templates/admin.html:74 cps/templates/config_edit.html:122
+#: cps/templates/admin.html:73 cps/templates/config_edit.html:122
 msgid "Log Level"
 msgstr ""
 
-#: cps/templates/admin.html:78
+#: cps/templates/admin.html:77
 msgid "Port"
 msgstr "លេខ port"
 
-#: cps/templates/admin.html:84 cps/templates/config_view_edit.html:27
+#: cps/templates/admin.html:83 cps/templates/config_view_edit.html:27
 msgid "Books per Page"
 msgstr "ចំនួនសៀវភៅក្នុងមួយទំព័រ"
 
-#: cps/templates/admin.html:88
+#: cps/templates/admin.html:87
 msgid "Uploads"
 msgstr "កំពុងអាប់ឡូដ"
 
-#: cps/templates/admin.html:92
+#: cps/templates/admin.html:91
 msgid "Anonymous Browsing"
 msgstr ""
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html:95
 msgid "Public Registration"
 msgstr "ការចុះឈ្មាះសាធារណៈ"
 
-#: cps/templates/admin.html:100
+#: cps/templates/admin.html:99
 msgid "Magic Link Remote Login"
 msgstr "ការចូលប្រើប្រាស់ពីចម្ងាយ"
 
-#: cps/templates/admin.html:104
+#: cps/templates/admin.html:103
 msgid "Reverse Proxy Login"
 msgstr ""
 
-#: cps/templates/admin.html:109
+#: cps/templates/admin.html:108
 msgid "Reverse proxy header name"
 msgstr ""
 
-#: cps/templates/admin.html:114
+#: cps/templates/admin.html:113
 msgid "Edit Basic Configuration"
 msgstr ""
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html:114
 msgid "Edit UI Configuration"
 msgstr ""
 
-#: cps/templates/admin.html:121
+#: cps/templates/admin.html:120
 msgid "Administration"
 msgstr "កិច្ចការរដ្ឋបាល"
 
-#: cps/templates/admin.html:122
+#: cps/templates/admin.html:121
 msgid "View Logs"
 msgstr ""
 
-#: cps/templates/admin.html:123
+#: cps/templates/admin.html:122
 msgid "Reconnect Calibre Database"
 msgstr "ភ្ជាប់ទៅ database Calibre ម្តងទៀត"
 
-#: cps/templates/admin.html:124
+#: cps/templates/admin.html:123
 msgid "Restart"
 msgstr ""
 
-#: cps/templates/admin.html:125
+#: cps/templates/admin.html:124
 msgid "Shutdown"
 msgstr ""
 
-#: cps/templates/admin.html:131
+#: cps/templates/admin.html:130
 msgid "Update"
 msgstr ""
 
-#: cps/templates/admin.html:135
+#: cps/templates/admin.html:134
 msgid "Version"
 msgstr ""
 
-#: cps/templates/admin.html:136
+#: cps/templates/admin.html:135
 msgid "Details"
 msgstr ""
 
-#: cps/templates/admin.html:142
+#: cps/templates/admin.html:141
 msgid "Current version"
 msgstr ""
 
-#: cps/templates/admin.html:148
+#: cps/templates/admin.html:147
 msgid "Check for Update"
 msgstr "រកមើលបច្ចុប្បន្នភាព"
 
-#: cps/templates/admin.html:149
+#: cps/templates/admin.html:148
 msgid "Perform Update"
 msgstr "ធ្វើបច្ចុប្បន្នភាព"
 
-#: cps/templates/admin.html:161
+#: cps/templates/admin.html:160
 msgid "Are you sure you want to restart?"
 msgstr ""
 
-#: cps/templates/admin.html:166 cps/templates/admin.html:180
-#: cps/templates/admin.html:200 cps/templates/shelf.html:72
+#: cps/templates/admin.html:165 cps/templates/admin.html:179
+#: cps/templates/admin.html:199 cps/templates/shelf.html:72
 msgid "OK"
 msgstr "បាទ/ចាស"
 
-#: cps/templates/admin.html:167 cps/templates/admin.html:181
+#: cps/templates/admin.html:166 cps/templates/admin.html:180
 #: cps/templates/book_edit.html:172 cps/templates/book_edit.html:194
 #: cps/templates/config_edit.html:346 cps/templates/config_view_edit.html:151
 #: cps/templates/email_edit.html:40 cps/templates/email_edit.html:92
@@ -1151,11 +1164,11 @@ msgstr "បាទ/ចាស"
 msgid "Cancel"
 msgstr ""
 
-#: cps/templates/admin.html:179
+#: cps/templates/admin.html:178
 msgid "Are you sure you want to shutdown?"
 msgstr ""
 
-#: cps/templates/admin.html:191
+#: cps/templates/admin.html:190
 msgid "Updating, please do not reload this page"
 msgstr "កំពុងធ្វើបច្ចុប្បន្នភាព សូមកុំបើកទំព័រជាថ្មី"
 
@@ -1244,8 +1257,12 @@ msgid "Rating"
 msgstr "ការវាយតម្លៃ"
 
 #: cps/templates/book_edit.html:81
-msgid "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
-msgstr "URL របស់ក្របមុខ (ឯកសារ JPG ក្របមុខត្រូវបានទាញយក និងរក្សាទុកក្នុង database ក្រោយមកចន្លោះនេះទទេម្តងទៀត)"
+msgid ""
+"Fetch Cover from URL (JPEG - Image will be downloaded and stored in "
+"database)"
+msgstr ""
+"URL របស់ក្របមុខ (ឯកសារ JPG ក្របមុខត្រូវបានទាញយក និងរក្សាទុកក្នុង database"
+" ក្រោយមកចន្លោះនេះទទេម្តងទៀត)"
 
 #: cps/templates/book_edit.html:85
 msgid "Upload Cover from Local Disk"
@@ -1778,15 +1795,6 @@ msgstr ""
 msgid "Are you sure you want to delete this domain?"
 msgstr ""
 
-#: cps/templates/feed.xml:21 cps/templates/layout.html:173
-msgid "Next"
-msgstr "បន្ទាប់"
-
-#: cps/templates/feed.xml:79 cps/templates/layout.html:136
-#: cps/templates/layout.html:140
-msgid "(Public)"
-msgstr ""
-
 #: cps/templates/generate_kobo_auth_url.html:5
 msgid "Open the .kobo/Kobo eReader.conf file in a text editor and add (or edit):"
 msgstr ""
@@ -1801,70 +1809,6 @@ msgstr ""
 
 #: cps/templates/index.html:64
 msgid "Group by series"
-msgstr ""
-
-#: cps/templates/index.xml:6
-msgid "Start"
-msgstr "ចាប់ផ្តើម"
-
-#: cps/templates/index.xml:21
-msgid "Popular publications from this catalog based on Downloads."
-msgstr "ការបោះពុម្ភផ្សាយដែលមានប្រជាប្រិយភាពពីកាតាឡុកនេះផ្អែកលើការទាញយក"
-
-#: cps/templates/index.xml:28
-msgid "Popular publications from this catalog based on Rating."
-msgstr "ការបោះពុម្ភផ្សាយដែលមានប្រជាប្រិយភាពពីកាតាឡុកនេះផ្អែកលើការវាយតម្លៃ"
-
-#: cps/templates/index.xml:31
-msgid "Recently added Books"
-msgstr ""
-
-#: cps/templates/index.xml:35
-msgid "The latest Books"
-msgstr "សៀវភៅចុងក្រោយគេ"
-
-#: cps/templates/index.xml:38
-msgid "Random Books"
-msgstr "សៀវភៅចៃដន្យ"
-
-#: cps/templates/index.xml:42 cps/templates/user_edit.html:80
-msgid "Show Random Books"
-msgstr "បង្ហាញសៀវភៅចៃដន្យ"
-
-#: cps/templates/index.xml:65
-msgid "Books ordered by Author"
-msgstr "សៀវភៅរៀបតាមលំដាប់អ្នកនិពន្ធ"
-
-#: cps/templates/index.xml:72
-msgid "Books ordered by publisher"
-msgstr ""
-
-#: cps/templates/index.xml:79
-msgid "Books ordered by category"
-msgstr "សៀវភៅរៀបតាមលំដាប់ប្រភេទ"
-
-#: cps/templates/index.xml:86
-msgid "Books ordered by series"
-msgstr "សៀវភៅរៀបតាមលំដាប់ស៊េរី"
-
-#: cps/templates/index.xml:93
-msgid "Books ordered by Languages"
-msgstr ""
-
-#: cps/templates/index.xml:100
-msgid "Books ordered by Rating"
-msgstr ""
-
-#: cps/templates/index.xml:108
-msgid "Books ordered by file formats"
-msgstr ""
-
-#: cps/templates/index.xml:111 cps/templates/layout.html:134
-msgid "Shelves"
-msgstr ""
-
-#: cps/templates/index.xml:115
-msgid "Books organized in shelves"
 msgstr ""
 
 #: cps/templates/layout.html:28
@@ -1917,6 +1861,14 @@ msgstr ""
 msgid "Browse"
 msgstr "រុករក"
 
+#: cps/templates/layout.html:134
+msgid "Shelves"
+msgstr ""
+
+#: cps/templates/layout.html:136 cps/templates/layout.html:140
+msgid "(Public)"
+msgstr ""
+
 #: cps/templates/layout.html:138
 msgid "Your Shelves"
 msgstr "ធ្នើរបស់អ្នក"
@@ -1928,6 +1880,10 @@ msgstr "អំពី"
 #: cps/templates/layout.html:158
 msgid "Previous"
 msgstr "មុន"
+
+#: cps/templates/layout.html:173
+msgid "Next"
+msgstr "បន្ទាប់"
 
 #: cps/templates/layout.html:185
 msgid "Book Details"
@@ -2310,6 +2266,10 @@ msgstr ""
 msgid "Create/View"
 msgstr ""
 
+#: cps/templates/user_edit.html:80
+msgid "Show Random Books"
+msgstr "បង្ហាញសៀវភៅចៃដន្យ"
+
 #: cps/templates/user_edit.html:84
 msgid "Add allowed/Denied Custom Column Values"
 msgstr ""
@@ -2329,4 +2289,208 @@ msgstr ""
 #: cps/templates/user_edit.html:176
 msgid "Do you really want to delete the Kobo Token?"
 msgstr ""
+
+#: vendor/tornado/locale.py:285
+msgid "January"
+msgstr ""
+
+#: vendor/tornado/locale.py:286
+msgid "February"
+msgstr ""
+
+#: vendor/tornado/locale.py:287
+msgid "March"
+msgstr ""
+
+#: vendor/tornado/locale.py:288
+msgid "April"
+msgstr ""
+
+#: vendor/tornado/locale.py:289
+msgid "May"
+msgstr ""
+
+#: vendor/tornado/locale.py:290
+msgid "June"
+msgstr ""
+
+#: vendor/tornado/locale.py:291
+msgid "July"
+msgstr ""
+
+#: vendor/tornado/locale.py:292
+msgid "August"
+msgstr ""
+
+#: vendor/tornado/locale.py:293
+msgid "September"
+msgstr ""
+
+#: vendor/tornado/locale.py:294
+msgid "October"
+msgstr ""
+
+#: vendor/tornado/locale.py:295
+msgid "November"
+msgstr ""
+
+#: vendor/tornado/locale.py:296
+msgid "December"
+msgstr ""
+
+#: vendor/tornado/locale.py:299
+msgid "Monday"
+msgstr ""
+
+#: vendor/tornado/locale.py:300
+msgid "Tuesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:301
+msgid "Wednesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:302
+msgid "Thursday"
+msgstr ""
+
+#: vendor/tornado/locale.py:303
+msgid "Friday"
+msgstr ""
+
+#: vendor/tornado/locale.py:304
+msgid "Saturday"
+msgstr ""
+
+#: vendor/tornado/locale.py:305
+msgid "Sunday"
+msgstr ""
+
+#: vendor/tornado/locale.py:368
+msgid "1 second ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:374
+msgid "1 minute ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:379
+msgid "1 hour ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:382
+#, python-format
+msgid "%(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+msgid "yesterday"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+#, python-format
+msgid "yesterday at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:389 vendor/tornado/locale.py:442
+#, python-format
+msgid "%(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:391
+#, python-format
+msgid "%(month_name)s %(day)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:396
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:398
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:436
+#, python-format
+msgid "%(weekday)s, %(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:459
+#, python-format
+msgid "%(commas)s and %(last)s"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:68
+msgctxt "law"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:69
+msgctxt "good"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:71 vendor/tornado/test/locale_test.py:74
+msgctxt "organization"
+msgid "club"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:76 vendor/tornado/test/locale_test.py:77
+msgctxt "stick"
+msgid "club"
+msgstr ""
+
+#~ msgid "Start"
+#~ msgstr "ចាប់ផ្តើម"
+
+#~ msgid "Popular publications from this catalog based on Downloads."
+#~ msgstr "ការបោះពុម្ភផ្សាយដែលមានប្រជាប្រិយភាពពីកាតាឡុកនេះផ្អែកលើការទាញយក"
+
+#~ msgid "Popular publications from this catalog based on Rating."
+#~ msgstr "ការបោះពុម្ភផ្សាយដែលមានប្រជាប្រិយភាពពីកាតាឡុកនេះផ្អែកលើការវាយតម្លៃ"
+
+#~ msgid "Recently added Books"
+#~ msgstr ""
+
+#~ msgid "The latest Books"
+#~ msgstr "សៀវភៅចុងក្រោយគេ"
+
+#~ msgid "Random Books"
+#~ msgstr "សៀវភៅចៃដន្យ"
+
+#~ msgid "Books ordered by Author"
+#~ msgstr "សៀវភៅរៀបតាមលំដាប់អ្នកនិពន្ធ"
+
+#~ msgid "Books ordered by publisher"
+#~ msgstr ""
+
+#~ msgid "Books ordered by category"
+#~ msgstr "សៀវភៅរៀបតាមលំដាប់ប្រភេទ"
+
+#~ msgid "Books ordered by series"
+#~ msgstr "សៀវភៅរៀបតាមលំដាប់ស៊េរី"
+
+#~ msgid "Books ordered by Languages"
+#~ msgstr ""
+
+#~ msgid "Books ordered by Rating"
+#~ msgstr ""
+
+#~ msgid "Books ordered by file formats"
+#~ msgstr ""
+
+#~ msgid "Books organized in shelves"
+#~ msgstr ""
 

--- a/cps/translations/nl/LC_MESSAGES/messages.po
+++ b/cps/translations/nl/LC_MESSAGES/messages.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Calibre-Web (GPLV3)\n"
 "Report-Msgid-Bugs-To: https://github.com/janeczku/Calibre-Web\n"
-"POT-Creation-Date: 2020-04-03 19:49+0200\n"
+"POT-Creation-Date: 2020-04-08 23:10+0800\n"
 "PO-Revision-Date: 2020-03-06 19:28+0100\n"
 "Last-Translator: Ed Driesen <ed.driesen@telenet.be>\n"
 "Language: nl\n"
@@ -85,7 +85,9 @@ msgstr "Het e-mailadres bevat geen geldige domeinnaam"
 
 #: cps/admin.py:710 cps/admin.py:725
 msgid "Found an existing account for this e-mail address or nickname."
-msgstr "Er is een bestaand account met dit e-mailadres of deze gebruikersnaam aangetroffen."
+msgstr ""
+"Er is een bestaand account met dit e-mailadres of deze gebruikersnaam "
+"aangetroffen."
 
 #: cps/admin.py:721
 #, python-format
@@ -274,8 +276,12 @@ msgid "File %(filename)s could not saved to temp dir"
 msgstr "Bestand %(filename)s kon niet in de tijdelijke map opgeslaan worden"
 
 #: cps/editbooks.py:598
-msgid "Uploaded book probably exists in the library, consider to change before upload new: "
-msgstr "Geüpload boek bestaat waarschijnlijk in de bibliotheek, overweeg wijzigingen alvorens opnieuw te proberen: "
+msgid ""
+"Uploaded book probably exists in the library, consider to change before "
+"upload new: "
+msgstr ""
+"Geüpload boek bestaat waarschijnlijk in de bibliotheek, overweeg "
+"wijzigingen alvorens opnieuw te proberen: "
 
 #: cps/editbooks.py:613
 #, python-format
@@ -307,12 +313,18 @@ msgid "There was an error converting this book: %(res)s"
 msgstr "Er is een fout opgetreden bij het converteren van dit boek: %(res)s"
 
 #: cps/gdrive.py:61
-msgid "Google Drive setup not completed, try to deactivate and activate Google Drive again"
+msgid ""
+"Google Drive setup not completed, try to deactivate and activate Google "
+"Drive again"
 msgstr "Het instellen van Google Drive is niet afgerond; heractiveer Google Drive"
 
 #: cps/gdrive.py:103
-msgid "Callback domain is not verified, please follow steps to verify domain in google developer console"
-msgstr "Het callback-domein is niet geverifieerd. Volg de stappen in de Google-ontwikkelaarsconsole om het domein te verifiëren"
+msgid ""
+"Callback domain is not verified, please follow steps to verify domain in "
+"google developer console"
+msgstr ""
+"Het callback-domein is niet geverifieerd. Volg de stappen in de Google-"
+"ontwikkelaarsconsole om het domein te verifiëren"
 
 #: cps/helper.py:80
 #, python-format
@@ -373,7 +385,9 @@ msgstr "E-mail: %(book)s"
 
 #: cps/helper.py:215
 msgid "The requested file could not be read. Maybe wrong permissions?"
-msgstr "Het opgevraagde bestand kan niet worden uitgelezen. Ben je hiertoe gemachtigd?"
+msgstr ""
+"Het opgevraagde bestand kan niet worden uitgelezen. Ben je hiertoe "
+"gemachtigd?"
 
 #: cps/helper.py:322
 #, python-format
@@ -388,7 +402,9 @@ msgstr "Kan de auteursnaam '%(src)s' niet wijzigen in '%(dest)s': %(error)s"
 #: cps/helper.py:346
 #, python-format
 msgid "Rename file in path '%(src)s' to '%(dest)s' failed with error: %(error)s"
-msgstr "Kan de naam van het bestand in '%(src)s' niet wijzigen in '%(dest)s': %(error)s"
+msgstr ""
+"Kan de naam van het bestand in '%(src)s' niet wijzigen in '%(dest)s': "
+"%(error)s"
 
 #: cps/helper.py:372 cps/helper.py:382 cps/helper.py:390
 #, python-format
@@ -457,8 +473,12 @@ msgid "Unknown Task: "
 msgstr "Onbekende taak: "
 
 #: cps/kobo_auth.py:127
-msgid "PLease access calibre-web from non localhost to get valid api_endpoint for kobo device"
-msgstr "Gelieve calibre-web van elders dan localhost te benaderen om een geldige api_endpoint te verkrijgen voor je kobo toestel"
+msgid ""
+"PLease access calibre-web from non localhost to get valid api_endpoint "
+"for kobo device"
+msgstr ""
+"Gelieve calibre-web van elders dan localhost te benaderen om een geldige "
+"api_endpoint te verkrijgen voor je kobo toestel"
 
 #: cps/kobo_auth.py:130 cps/kobo_auth.py:150
 msgid "Kobo Setup"
@@ -604,7 +624,9 @@ msgstr "Boekenplank: '%(name)s'"
 
 #: cps/shelf.py:330
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
-msgstr "Kan boekenplank niet openen: de boekenplank bestaat niet of is ontoegankelijk"
+msgstr ""
+"Kan boekenplank niet openen: de boekenplank bestaat niet of is "
+"ontoegankelijk"
 
 #: cps/shelf.py:368
 msgid "Hidden Book"
@@ -623,7 +645,7 @@ msgstr "Recent toegevoegd"
 msgid "Show recent books"
 msgstr "Recent toegevoegde boeken tonen"
 
-#: cps/templates/index.xml:17 cps/ub.py:59
+#: cps/ub.py:59
 msgid "Hot Books"
 msgstr "Populaire boeken"
 
@@ -631,7 +653,7 @@ msgstr "Populaire boeken"
 msgid "Show Hot Books"
 msgstr "Populaire boeken tonen"
 
-#: cps/templates/index.xml:24 cps/ub.py:63 cps/web.py:508
+#: cps/ub.py:63 cps/web.py:508
 msgid "Top Rated Books"
 msgstr "Best beoordeelde boeken"
 
@@ -639,8 +661,7 @@ msgstr "Best beoordeelde boeken"
 msgid "Show Top Rated Books"
 msgstr "Best beoordeelde boeken tonen"
 
-#: cps/templates/index.xml:46 cps/templates/index.xml:50 cps/ub.py:66
-#: cps/web.py:1005
+#: cps/ub.py:66 cps/web.py:1005
 msgid "Read Books"
 msgstr "Gelezen boeken"
 
@@ -648,8 +669,7 @@ msgstr "Gelezen boeken"
 msgid "Show read and unread"
 msgstr "Gelezen/Ongelezen boeken tonen"
 
-#: cps/templates/index.xml:53 cps/templates/index.xml:57 cps/ub.py:70
-#: cps/web.py:1009
+#: cps/ub.py:70 cps/web.py:1009
 msgid "Unread Books"
 msgstr "Ongelezen boeken"
 
@@ -665,7 +685,7 @@ msgstr "Willekeurige boeken"
 msgid "Show random books"
 msgstr "Willekeurige boeken tonen"
 
-#: cps/templates/index.xml:75 cps/ub.py:76 cps/web.py:787
+#: cps/ub.py:76 cps/web.py:787
 msgid "Categories"
 msgstr "Categorieën"
 
@@ -673,8 +693,8 @@ msgstr "Categorieën"
 msgid "Show category selection"
 msgstr "Categoriekeuze tonen"
 
-#: cps/templates/book_edit.html:69 cps/templates/index.xml:82
-#: cps/templates/search_form.html:53 cps/ub.py:79 cps/web.py:715
+#: cps/templates/book_edit.html:69 cps/templates/search_form.html:53
+#: cps/ub.py:79 cps/web.py:715
 msgid "Series"
 msgstr "Boekenreeksen"
 
@@ -682,7 +702,7 @@ msgstr "Boekenreeksen"
 msgid "Show series selection"
 msgstr "Boekenreeksen keuze tonen"
 
-#: cps/templates/index.xml:61 cps/ub.py:82
+#: cps/ub.py:82
 msgid "Authors"
 msgstr "Auteurs"
 
@@ -690,7 +710,7 @@ msgstr "Auteurs"
 msgid "Show author selection"
 msgstr "Auteurkeuze tonen"
 
-#: cps/templates/index.xml:68 cps/ub.py:86 cps/web.py:699
+#: cps/ub.py:86 cps/web.py:699
 msgid "Publishers"
 msgstr "Uitgevers"
 
@@ -698,8 +718,7 @@ msgstr "Uitgevers"
 msgid "Show publisher selection"
 msgstr "Uitgeverskeuze tonen"
 
-#: cps/templates/index.xml:89 cps/templates/search_form.html:74 cps/ub.py:89
-#: cps/web.py:770
+#: cps/templates/search_form.html:74 cps/ub.py:89 cps/web.py:770
 msgid "Languages"
 msgstr "Talen"
 
@@ -707,7 +726,7 @@ msgstr "Talen"
 msgid "Show language selection"
 msgstr "Taalkeuze tonen"
 
-#: cps/templates/index.xml:96 cps/ub.py:93
+#: cps/ub.py:93
 msgid "Ratings"
 msgstr "Beoordelingen"
 
@@ -715,7 +734,7 @@ msgstr "Beoordelingen"
 msgid "Show ratings selection"
 msgstr "Beoordelingen tonen"
 
-#: cps/templates/index.xml:104 cps/ub.py:96
+#: cps/ub.py:96
 msgid "File formats"
 msgstr "Bestandsformaten"
 
@@ -732,8 +751,12 @@ msgid "No update available. You already have the latest version installed"
 msgstr "Geen update beschikbaar. Je beschikt al over de nieuwste versie"
 
 #: cps/updater.py:333
-msgid "A new update is available. Click on the button below to update to the latest version."
-msgstr "Er is een update beschikbaar. Klik op de knop hieronder om te updaten naar de nieuwste versie."
+msgid ""
+"A new update is available. Click on the button below to update to the "
+"latest version."
+msgstr ""
+"Er is een update beschikbaar. Klik op de knop hieronder om te updaten "
+"naar de nieuwste versie."
 
 #: cps/updater.py:385
 msgid "Could not fetch update information"
@@ -745,8 +768,12 @@ msgstr "Geen wijzigingslog beschikbaar"
 
 #: cps/updater.py:456 cps/updater.py:467 cps/updater.py:486
 #, python-format
-msgid "A new update is available. Click on the button below to update to version: %(version)s"
-msgstr "Er is een update beschikbaar. Klik op de knop hieronder om te updaten naar versie: %(version)s"
+msgid ""
+"A new update is available. Click on the button below to update to "
+"version: %(version)s"
+msgstr ""
+"Er is een update beschikbaar. Klik op de knop hieronder om te updaten "
+"naar versie: %(version)s"
 
 #: cps/updater.py:477
 msgid "Click on the button below to update to the latest stable version."
@@ -769,8 +796,12 @@ msgid "Hot Books (Most Downloaded)"
 msgstr "Populaire boeken (meest gedownload)"
 
 #: cps/web.py:580
-msgid "Oops! Selected book title is unavailable. File does not exist or is not accessible"
-msgstr "Oeps! Geselecteerd boek is niet beschikbaar. Bestand bestaat niet of is niet toegankelijk"
+msgid ""
+"Oops! Selected book title is unavailable. File does not exist or is not "
+"accessible"
+msgstr ""
+"Oeps! Geselecteerd boek is niet beschikbaar. Bestand bestaat niet of is "
+"niet toegankelijk"
 
 #: cps/web.py:593
 #, python-format
@@ -819,9 +850,9 @@ msgstr "Alle bestandsformaten"
 msgid "Tasks"
 msgstr "Taken"
 
-#: cps/templates/book_edit.html:212 cps/templates/feed.xml:33
-#: cps/templates/layout.html:44 cps/templates/layout.html:47
-#: cps/templates/search_form.html:170 cps/web.py:821 cps/web.py:823
+#: cps/templates/book_edit.html:212 cps/templates/layout.html:44
+#: cps/templates/layout.html:47 cps/templates/search_form.html:170
+#: cps/web.py:821 cps/web.py:823
 msgid "Search"
 msgstr "Zoeken"
 
@@ -850,7 +881,9 @@ msgstr "zoeken"
 #: cps/web.py:1060
 #, python-format
 msgid "Book successfully queued for sending to %(kindlemail)s"
-msgstr "Het boek is in de wachtrij geplaatst om te worden verstuurd aan %(kindlemail)s"
+msgstr ""
+"Het boek is in de wachtrij geplaatst om te worden verstuurd aan "
+"%(kindlemail)s"
 
 #: cps/web.py:1064
 #, python-format
@@ -863,7 +896,9 @@ msgstr "Stel je kindle-e-mailadres in..."
 
 #: cps/web.py:1083
 msgid "E-Mail server is not configured, please contact your administrator!"
-msgstr "E-Mail server is niet geconfigureerd, contacteer alstublieft je administrator!"
+msgstr ""
+"E-Mail server is niet geconfigureerd, contacteer alstublieft je "
+"administrator!"
 
 #: cps/web.py:1084 cps/web.py:1090 cps/web.py:1115 cps/web.py:1119
 #: cps/web.py:1124 cps/web.py:1128
@@ -939,7 +974,9 @@ msgstr "Profiel bijgewerkt"
 
 #: cps/web.py:1384 cps/web.py:1480
 msgid "Error opening eBook. File does not exist or file is not accessible:"
-msgstr "Fout tijdens het openen van eBook. Bestand bestaat niet of is niet toegankelijk:"
+msgstr ""
+"Fout tijdens het openen van eBook. Bestand bestaat niet of is niet "
+"toegankelijk:"
 
 #: cps/web.py:1396 cps/web.py:1399 cps/web.py:1402 cps/web.py:1409
 #: cps/web.py:1414
@@ -948,7 +985,9 @@ msgstr "Lees een boek"
 
 #: cps/web.py:1425
 msgid "Error opening eBook. File does not exist or file is not accessible."
-msgstr "Fout tijdens het openen van eBook. Bestand bestaat niet of is niet toegankelijk."
+msgstr ""
+"Fout tijdens het openen van eBook. Bestand bestaat niet of is niet "
+"toegankelijk."
 
 #: cps/worker.py:335
 #, python-format
@@ -960,189 +999,189 @@ msgstr "E-boek-conversie mislukt: %(error)s"
 msgid "Kindlegen failed with Error %(error)s. Message: %(message)s"
 msgstr "KindleGen mislukt; fout: %(error)s. Bericht: %(message)s"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html:8
 msgid "Users"
 msgstr "Gebruikerslijst"
 
-#: cps/templates/admin.html:12 cps/templates/login.html:8
+#: cps/templates/admin.html:11 cps/templates/login.html:8
 #: cps/templates/login.html:9 cps/templates/register.html:7
 #: cps/templates/user_edit.html:8
 msgid "Username"
 msgstr "Gebruikersnaam"
 
-#: cps/templates/admin.html:13 cps/templates/register.html:11
+#: cps/templates/admin.html:12 cps/templates/register.html:11
 #: cps/templates/user_edit.html:13
 msgid "E-mail Address"
 msgstr "E-mailadres"
 
-#: cps/templates/admin.html:14 cps/templates/user_edit.html:26
+#: cps/templates/admin.html:13 cps/templates/user_edit.html:26
 msgid "Send to Kindle E-mail Address"
 msgstr "Kindle-e-mailadres"
 
-#: cps/templates/admin.html:15
+#: cps/templates/admin.html:14
 msgid "Downloads"
 msgstr "Downloads"
 
-#: cps/templates/admin.html:16 cps/templates/layout.html:76
+#: cps/templates/admin.html:15 cps/templates/layout.html:76
 msgid "Admin"
 msgstr "Beheer"
 
-#: cps/templates/admin.html:17 cps/templates/detail.html:18
+#: cps/templates/admin.html:16 cps/templates/detail.html:18
 #: cps/templates/detail.html:27 cps/templates/shelf.html:6
 #: cps/templates/shelfdown.html:62
 msgid "Download"
 msgstr "Downloaden"
 
-#: cps/templates/admin.html:18
+#: cps/templates/admin.html:17
 msgid "View Books"
 msgstr "Boeken lezen"
 
-#: cps/templates/admin.html:19 cps/templates/layout.html:65
+#: cps/templates/admin.html:18 cps/templates/layout.html:65
 msgid "Upload"
 msgstr "Uploaden"
 
-#: cps/templates/admin.html:20
+#: cps/templates/admin.html:19
 msgid "Edit"
 msgstr "Bewerken"
 
-#: cps/templates/admin.html:38
+#: cps/templates/admin.html:37
 msgid "Add New User"
 msgstr "Voeg Nieuwe Gebruiker toe"
 
-#: cps/templates/admin.html:44
+#: cps/templates/admin.html:43
 msgid "E-mail Server Settings"
 msgstr "SMTP-serverinstellingen"
 
-#: cps/templates/admin.html:47 cps/templates/email_edit.html:11
+#: cps/templates/admin.html:46 cps/templates/email_edit.html:11
 msgid "SMTP Hostname"
 msgstr "SMTP-hostnaam"
 
-#: cps/templates/admin.html:48 cps/templates/email_edit.html:15
+#: cps/templates/admin.html:47 cps/templates/email_edit.html:15
 msgid "SMTP Port"
 msgstr "SMTP-poort"
 
-#: cps/templates/admin.html:49 cps/templates/email_edit.html:19
+#: cps/templates/admin.html:48 cps/templates/email_edit.html:19
 msgid "Encryption"
 msgstr "SSL"
 
-#: cps/templates/admin.html:50 cps/templates/email_edit.html:27
+#: cps/templates/admin.html:49 cps/templates/email_edit.html:27
 msgid "SMTP Login"
 msgstr "SMTP-gebruikersnaam"
 
-#: cps/templates/admin.html:51 cps/templates/email_edit.html:35
+#: cps/templates/admin.html:50 cps/templates/email_edit.html:35
 msgid "From E-mail"
 msgstr "Van e-mail"
 
-#: cps/templates/admin.html:61
+#: cps/templates/admin.html:60
 msgid "Edit E-mail Server Settings"
 msgstr "SMTP-instellingen bewerken"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html:66
 msgid "Configuration"
 msgstr "Instellingen"
 
-#: cps/templates/admin.html:70
+#: cps/templates/admin.html:69
 msgid "Calibre Database Directory"
 msgstr "Calibre DB-map"
 
-#: cps/templates/admin.html:74 cps/templates/config_edit.html:122
+#: cps/templates/admin.html:73 cps/templates/config_edit.html:122
 msgid "Log Level"
 msgstr "Logniveau"
 
-#: cps/templates/admin.html:78
+#: cps/templates/admin.html:77
 msgid "Port"
 msgstr "Poort"
 
-#: cps/templates/admin.html:84 cps/templates/config_view_edit.html:27
+#: cps/templates/admin.html:83 cps/templates/config_view_edit.html:27
 msgid "Books per Page"
 msgstr "Aantal boeken per pagina"
 
-#: cps/templates/admin.html:88
+#: cps/templates/admin.html:87
 msgid "Uploads"
 msgstr "Uploaden toestaan"
 
-#: cps/templates/admin.html:92
+#: cps/templates/admin.html:91
 msgid "Anonymous Browsing"
 msgstr "Anoniem verkennen"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html:95
 msgid "Public Registration"
 msgstr "Openbare registratie"
 
-#: cps/templates/admin.html:100
+#: cps/templates/admin.html:99
 msgid "Magic Link Remote Login"
 msgstr "Inloggen op afstand"
 
-#: cps/templates/admin.html:104
+#: cps/templates/admin.html:103
 msgid "Reverse Proxy Login"
 msgstr "Reverse Proxy Login"
 
-#: cps/templates/admin.html:109
+#: cps/templates/admin.html:108
 msgid "Reverse proxy header name"
 msgstr "Reverse proxy header naam"
 
-#: cps/templates/admin.html:114
+#: cps/templates/admin.html:113
 msgid "Edit Basic Configuration"
 msgstr "Bewerk Basis Configuratie"
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html:114
 msgid "Edit UI Configuration"
 msgstr "Bewerk Gebruikersinterface Configuratie"
 
-#: cps/templates/admin.html:121
+#: cps/templates/admin.html:120
 msgid "Administration"
 msgstr "Systeembeheer"
 
-#: cps/templates/admin.html:122
+#: cps/templates/admin.html:121
 msgid "View Logs"
 msgstr "Logboeken bekijken"
 
-#: cps/templates/admin.html:123
+#: cps/templates/admin.html:122
 msgid "Reconnect Calibre Database"
 msgstr "Opnieuw verbinden met Calibre DB"
 
-#: cps/templates/admin.html:124
+#: cps/templates/admin.html:123
 msgid "Restart"
 msgstr "Calibre-Web herstarten"
 
-#: cps/templates/admin.html:125
+#: cps/templates/admin.html:124
 msgid "Shutdown"
 msgstr "Calibre-Web stoppen"
 
-#: cps/templates/admin.html:131
+#: cps/templates/admin.html:130
 msgid "Update"
 msgstr "Bijwerken"
 
-#: cps/templates/admin.html:135
+#: cps/templates/admin.html:134
 msgid "Version"
 msgstr "Versie"
 
-#: cps/templates/admin.html:136
+#: cps/templates/admin.html:135
 msgid "Details"
 msgstr "Details"
 
-#: cps/templates/admin.html:142
+#: cps/templates/admin.html:141
 msgid "Current version"
 msgstr "Huidige versie"
 
-#: cps/templates/admin.html:148
+#: cps/templates/admin.html:147
 msgid "Check for Update"
 msgstr "Controleren op updates"
 
-#: cps/templates/admin.html:149
+#: cps/templates/admin.html:148
 msgid "Perform Update"
 msgstr "Update uitvoeren"
 
-#: cps/templates/admin.html:161
+#: cps/templates/admin.html:160
 msgid "Are you sure you want to restart?"
 msgstr "Weet je zeker dat je Calibre-Web wilt herstarten?"
 
-#: cps/templates/admin.html:166 cps/templates/admin.html:180
-#: cps/templates/admin.html:200 cps/templates/shelf.html:72
+#: cps/templates/admin.html:165 cps/templates/admin.html:179
+#: cps/templates/admin.html:199 cps/templates/shelf.html:72
 msgid "OK"
 msgstr "Oké"
 
-#: cps/templates/admin.html:167 cps/templates/admin.html:181
+#: cps/templates/admin.html:166 cps/templates/admin.html:180
 #: cps/templates/book_edit.html:172 cps/templates/book_edit.html:194
 #: cps/templates/config_edit.html:346 cps/templates/config_view_edit.html:151
 #: cps/templates/email_edit.html:40 cps/templates/email_edit.html:92
@@ -1151,11 +1190,11 @@ msgstr "Oké"
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: cps/templates/admin.html:179
+#: cps/templates/admin.html:178
 msgid "Are you sure you want to shutdown?"
 msgstr "Weet je zeker dat je Calibre-Web wilt stoppen?"
 
-#: cps/templates/admin.html:191
+#: cps/templates/admin.html:190
 msgid "Updating, please do not reload this page"
 msgstr "Bezig met bijwerken; vernieuw de pagina niet"
 
@@ -1244,8 +1283,12 @@ msgid "Rating"
 msgstr "Beoordeling"
 
 #: cps/templates/book_edit.html:81
-msgid "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
-msgstr "Boekomslag-url (jpg - de omslag wordt gedownload en opgeslagen in de databank; het invoerveld is nadien leeg)"
+msgid ""
+"Fetch Cover from URL (JPEG - Image will be downloaded and stored in "
+"database)"
+msgstr ""
+"Boekomslag-url (jpg - de omslag wordt gedownload en opgeslagen in de "
+"databank; het invoerveld is nadien leeg)"
 
 #: cps/templates/book_edit.html:85
 msgid "Upload Cover from Local Disk"
@@ -1428,7 +1471,9 @@ msgstr "Toegangslog aanzetten"
 
 #: cps/templates/config_edit.html:139
 msgid "Location and name of access logfile (access.log for no entry)"
-msgstr "Locatie en naam van het toegangslog (access.log indien niet gespecificeerd)"
+msgstr ""
+"Locatie en naam van het toegangslog (access.log indien niet "
+"gespecificeerd)"
 
 #: cps/templates/config_edit.html:150
 msgid "Feature Configuration"
@@ -1778,18 +1823,11 @@ msgstr "Geweigerde domeinen (zwarte lijst/ \"blacklist\")"
 msgid "Are you sure you want to delete this domain?"
 msgstr "Weet je zeker dat je deze domeinregel wilt verwijderen?"
 
-#: cps/templates/feed.xml:21 cps/templates/layout.html:173
-msgid "Next"
-msgstr "Volgende"
-
-#: cps/templates/feed.xml:79 cps/templates/layout.html:136
-#: cps/templates/layout.html:140
-msgid "(Public)"
-msgstr ""
-
 #: cps/templates/generate_kobo_auth_url.html:5
 msgid "Open the .kobo/Kobo eReader.conf file in a text editor and add (or edit):"
-msgstr "Open het .kobo/Kobo eReader.conf bestand in een teksteditor en voeg toe (of bewerk):"
+msgstr ""
+"Open het .kobo/Kobo eReader.conf bestand in een teksteditor en voeg toe "
+"(of bewerk):"
 
 #: cps/templates/http_error.html:38
 msgid "Create Issue"
@@ -1802,70 +1840,6 @@ msgstr "Terug naar startpagina"
 #: cps/templates/index.html:64
 msgid "Group by series"
 msgstr "Sorteren op reeks"
-
-#: cps/templates/index.xml:6
-msgid "Start"
-msgstr "Starten"
-
-#: cps/templates/index.xml:21
-msgid "Popular publications from this catalog based on Downloads."
-msgstr "Populaire publicaties uit deze catalogus, gebaseerd op Downloads."
-
-#: cps/templates/index.xml:28
-msgid "Popular publications from this catalog based on Rating."
-msgstr "Populaire publicaties uit deze catalogus, gebaseerd op Beoordeling."
-
-#: cps/templates/index.xml:31
-msgid "Recently added Books"
-msgstr "Recent Toegevoegde Boeken"
-
-#: cps/templates/index.xml:35
-msgid "The latest Books"
-msgstr "Recentste boeken"
-
-#: cps/templates/index.xml:38
-msgid "Random Books"
-msgstr "Willekeurige boeken"
-
-#: cps/templates/index.xml:42 cps/templates/user_edit.html:80
-msgid "Show Random Books"
-msgstr "Willekeurige boeken tonen"
-
-#: cps/templates/index.xml:65
-msgid "Books ordered by Author"
-msgstr "Boeken gesorteerd op auteur"
-
-#: cps/templates/index.xml:72
-msgid "Books ordered by publisher"
-msgstr "Boeken gesorteerd op uitgever"
-
-#: cps/templates/index.xml:79
-msgid "Books ordered by category"
-msgstr "Boeken gesorteerd op categorie"
-
-#: cps/templates/index.xml:86
-msgid "Books ordered by series"
-msgstr "Boeken gesorteerd op reeks"
-
-#: cps/templates/index.xml:93
-msgid "Books ordered by Languages"
-msgstr "Boeken gesorteerd op Taal"
-
-#: cps/templates/index.xml:100
-msgid "Books ordered by Rating"
-msgstr ""
-
-#: cps/templates/index.xml:108
-msgid "Books ordered by file formats"
-msgstr "Boeken gesorteerd op bestandsformaat"
-
-#: cps/templates/index.xml:111 cps/templates/layout.html:134
-msgid "Shelves"
-msgstr ""
-
-#: cps/templates/index.xml:115
-msgid "Books organized in shelves"
-msgstr ""
 
 #: cps/templates/layout.html:28
 msgid "Home"
@@ -1917,6 +1891,14 @@ msgstr "Gelieve de pagina niet te vernieuwen"
 msgid "Browse"
 msgstr "Verkennen"
 
+#: cps/templates/layout.html:134
+msgid "Shelves"
+msgstr ""
+
+#: cps/templates/layout.html:136 cps/templates/layout.html:140
+msgid "(Public)"
+msgstr ""
+
 #: cps/templates/layout.html:138
 msgid "Your Shelves"
 msgstr "Jouw boekenplanken"
@@ -1928,6 +1910,10 @@ msgstr "Informatie"
 #: cps/templates/layout.html:158
 msgid "Previous"
 msgstr "Vorige"
+
+#: cps/templates/layout.html:173
+msgid "Next"
+msgstr "Volgende"
 
 #: cps/templates/layout.html:185
 msgid "Book Details"
@@ -2310,6 +2296,10 @@ msgstr "Kobo Sync Token"
 msgid "Create/View"
 msgstr "Aanmaken/Bekijk"
 
+#: cps/templates/user_edit.html:80
+msgid "Show Random Books"
+msgstr "Willekeurige boeken tonen"
+
 #: cps/templates/user_edit.html:84
 msgid "Add allowed/Denied Custom Column Values"
 msgstr "Voeg Toegestaan/Geweigerd aangepaste kolom waarden toe"
@@ -2329,4 +2319,208 @@ msgstr "Genereer Kobo Auth URL"
 #: cps/templates/user_edit.html:176
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "Wil je werkelijk je Kobo Token verwijderen?"
+
+#: vendor/tornado/locale.py:285
+msgid "January"
+msgstr ""
+
+#: vendor/tornado/locale.py:286
+msgid "February"
+msgstr ""
+
+#: vendor/tornado/locale.py:287
+msgid "March"
+msgstr ""
+
+#: vendor/tornado/locale.py:288
+msgid "April"
+msgstr ""
+
+#: vendor/tornado/locale.py:289
+msgid "May"
+msgstr ""
+
+#: vendor/tornado/locale.py:290
+msgid "June"
+msgstr ""
+
+#: vendor/tornado/locale.py:291
+msgid "July"
+msgstr ""
+
+#: vendor/tornado/locale.py:292
+msgid "August"
+msgstr ""
+
+#: vendor/tornado/locale.py:293
+msgid "September"
+msgstr ""
+
+#: vendor/tornado/locale.py:294
+msgid "October"
+msgstr ""
+
+#: vendor/tornado/locale.py:295
+msgid "November"
+msgstr ""
+
+#: vendor/tornado/locale.py:296
+msgid "December"
+msgstr ""
+
+#: vendor/tornado/locale.py:299
+msgid "Monday"
+msgstr ""
+
+#: vendor/tornado/locale.py:300
+msgid "Tuesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:301
+msgid "Wednesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:302
+msgid "Thursday"
+msgstr ""
+
+#: vendor/tornado/locale.py:303
+msgid "Friday"
+msgstr ""
+
+#: vendor/tornado/locale.py:304
+msgid "Saturday"
+msgstr ""
+
+#: vendor/tornado/locale.py:305
+msgid "Sunday"
+msgstr ""
+
+#: vendor/tornado/locale.py:368
+msgid "1 second ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:374
+msgid "1 minute ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:379
+msgid "1 hour ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:382
+#, python-format
+msgid "%(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+msgid "yesterday"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+#, python-format
+msgid "yesterday at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:389 vendor/tornado/locale.py:442
+#, python-format
+msgid "%(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:391
+#, python-format
+msgid "%(month_name)s %(day)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:396
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:398
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:436
+#, python-format
+msgid "%(weekday)s, %(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:459
+#, python-format
+msgid "%(commas)s and %(last)s"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:68
+msgctxt "law"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:69
+msgctxt "good"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:71 vendor/tornado/test/locale_test.py:74
+msgctxt "organization"
+msgid "club"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:76 vendor/tornado/test/locale_test.py:77
+msgctxt "stick"
+msgid "club"
+msgstr ""
+
+#~ msgid "Start"
+#~ msgstr "Starten"
+
+#~ msgid "Popular publications from this catalog based on Downloads."
+#~ msgstr "Populaire publicaties uit deze catalogus, gebaseerd op Downloads."
+
+#~ msgid "Popular publications from this catalog based on Rating."
+#~ msgstr "Populaire publicaties uit deze catalogus, gebaseerd op Beoordeling."
+
+#~ msgid "Recently added Books"
+#~ msgstr "Recent Toegevoegde Boeken"
+
+#~ msgid "The latest Books"
+#~ msgstr "Recentste boeken"
+
+#~ msgid "Random Books"
+#~ msgstr "Willekeurige boeken"
+
+#~ msgid "Books ordered by Author"
+#~ msgstr "Boeken gesorteerd op auteur"
+
+#~ msgid "Books ordered by publisher"
+#~ msgstr "Boeken gesorteerd op uitgever"
+
+#~ msgid "Books ordered by category"
+#~ msgstr "Boeken gesorteerd op categorie"
+
+#~ msgid "Books ordered by series"
+#~ msgstr "Boeken gesorteerd op reeks"
+
+#~ msgid "Books ordered by Languages"
+#~ msgstr "Boeken gesorteerd op Taal"
+
+#~ msgid "Books ordered by Rating"
+#~ msgstr ""
+
+#~ msgid "Books ordered by file formats"
+#~ msgstr "Boeken gesorteerd op bestandsformaat"
+
+#~ msgid "Books organized in shelves"
+#~ msgstr ""
 

--- a/cps/translations/pl/LC_MESSAGES/messages.po
+++ b/cps/translations/pl/LC_MESSAGES/messages.po
@@ -8,12 +8,13 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Calibre Web - polski (POT: 2019-08-06 18:35)\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-03 19:49+0200\n"
+"POT-Creation-Date: 2020-04-08 23:10+0800\n"
 "PO-Revision-Date: 2020-03-31 21:50+0200\n"
 "Last-Translator: Jerzy Piątek <jerzy.piatek@gmail.com>\n"
 "Language: pl\n"
 "Language-Team: \n"
-"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && "
+"(n%100<10 || n%100>=20) ? 1 : 2)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -122,7 +123,9 @@ msgstr "Użytkownik '%(nick)s' został usunięty"
 
 #: cps/admin.py:806
 msgid "No admin user remaining, can't delete user"
-msgstr "Nie można usunąć użytkownika. Brak na serwerze innego konta z prawami administratora"
+msgstr ""
+"Nie można usunąć użytkownika. Brak na serwerze innego konta z prawami "
+"administratora"
 
 #: cps/admin.py:842 cps/web.py:1361
 msgid "Found an existing account for this e-mail address."
@@ -269,7 +272,9 @@ msgstr "Metadane zostały pomyślnie zaktualizowane"
 
 #: cps/editbooks.py:534
 msgid "Error editing book, please check logfile for details"
-msgstr "Błąd podczas edycji książki, sprawdź plik dziennika, aby uzyskać szczegółowe informacje"
+msgstr ""
+"Błąd podczas edycji książki, sprawdź plik dziennika, aby uzyskać "
+"szczegółowe informacje"
 
 #: cps/editbooks.py:581
 #, python-format
@@ -277,8 +282,12 @@ msgid "File %(filename)s could not saved to temp dir"
 msgstr "Nie można zapisać pliku %(filename)s w katalogu tymczasowym"
 
 #: cps/editbooks.py:598
-msgid "Uploaded book probably exists in the library, consider to change before upload new: "
-msgstr "Wysłana książka prawdopodobnie istnieje w bibliotece, rozważ zmianę przed przesłaniem nowej: "
+msgid ""
+"Uploaded book probably exists in the library, consider to change before "
+"upload new: "
+msgstr ""
+"Wysłana książka prawdopodobnie istnieje w bibliotece, rozważ zmianę przed"
+" przesłaniem nowej: "
 
 #: cps/editbooks.py:613
 #, python-format
@@ -302,7 +311,9 @@ msgstr "Brak formatu źródłowego lub docelowego do konwersji"
 #: cps/editbooks.py:746
 #, python-format
 msgid "Book successfully queued for converting to %(book_format)s"
-msgstr "Książka została pomyślnie umieszczona w zadaniach do konwersji %(book_format)s"
+msgstr ""
+"Książka została pomyślnie umieszczona w zadaniach do konwersji "
+"%(book_format)s"
 
 #: cps/editbooks.py:750
 #, python-format
@@ -310,12 +321,20 @@ msgid "There was an error converting this book: %(res)s"
 msgstr "Podczas konwersji książki wystąpił błąd: %(res)s"
 
 #: cps/gdrive.py:61
-msgid "Google Drive setup not completed, try to deactivate and activate Google Drive again"
-msgstr "Konfiguracja Google Drive nie została zakończona, spróbuj dezaktywować i ponownie aktywować Google Drive"
+msgid ""
+"Google Drive setup not completed, try to deactivate and activate Google "
+"Drive again"
+msgstr ""
+"Konfiguracja Google Drive nie została zakończona, spróbuj dezaktywować i "
+"ponownie aktywować Google Drive"
 
 #: cps/gdrive.py:103
-msgid "Callback domain is not verified, please follow steps to verify domain in google developer console"
-msgstr "Zwrotna domena nie jest zweryfikowana, proszę zweryfikowania domenę w konsoli deweloperskiej google"
+msgid ""
+"Callback domain is not verified, please follow steps to verify domain in "
+"google developer console"
+msgstr ""
+"Zwrotna domena nie jest zweryfikowana, proszę zweryfikowania domenę w "
+"konsoli deweloperskiej google"
 
 #: cps/helper.py:80
 #, python-format
@@ -383,7 +402,9 @@ msgstr "Żądany plik nie mógł zostać odczytany. Sprawdź uprawnienia?"
 #: cps/helper.py:322
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
-msgstr "Zmiana nazwy tytułu z: „%(src)s” na „%(dest)s” zakończyła się niepowodzeniem z błędem: %(error)s"
+msgstr ""
+"Zmiana nazwy tytułu z: „%(src)s” na „%(dest)s” zakończyła się "
+"niepowodzeniem z błędem: %(error)s"
 
 #: cps/helper.py:332
 #, python-format
@@ -393,7 +414,9 @@ msgstr "Zmiana autora z: '%(src)s' na '%(dest)s' zakończyło się błędem: %(e
 #: cps/helper.py:346
 #, python-format
 msgid "Rename file in path '%(src)s' to '%(dest)s' failed with error: %(error)s"
-msgstr "Zmiana nazwy pliku w ścieżce '%(src)s' na '%(dest)s' zakończyło się błędem: %(error)s"
+msgstr ""
+"Zmiana nazwy pliku w ścieżce '%(src)s' na '%(dest)s' zakończyło się "
+"błędem: %(error)s"
 
 #: cps/helper.py:372 cps/helper.py:382 cps/helper.py:390
 #, python-format
@@ -462,8 +485,12 @@ msgid "Unknown Task: "
 msgstr "Nieznane zadanie: "
 
 #: cps/kobo_auth.py:127
-msgid "PLease access calibre-web from non localhost to get valid api_endpoint for kobo device"
-msgstr "Aby uzyskać prawidłowy api_endpoint dla urządzenia kobo, należy skorzystać z dostępu do calibre-web spoza localhost"
+msgid ""
+"PLease access calibre-web from non localhost to get valid api_endpoint "
+"for kobo device"
+msgstr ""
+"Aby uzyskać prawidłowy api_endpoint dla urządzenia kobo, należy "
+"skorzystać z dostępu do calibre-web spoza localhost"
 
 #: cps/kobo_auth.py:130 cps/kobo_auth.py:150
 msgid "Kobo Setup"
@@ -521,7 +548,9 @@ msgstr "Podano niewłaściwą półkę"
 #: cps/shelf.py:54
 #, python-format
 msgid "Sorry you are not allowed to add a book to the the shelf: %(shelfname)s"
-msgstr "Niestety, nie posiadasz uprawnień do dodania książki do półki: %(shelfname)s"
+msgstr ""
+"Niestety, nie posiadasz uprawnień do dodania książki do półki: "
+"%(shelfname)s"
 
 #: cps/shelf.py:62
 msgid "You are not allowed to edit public shelves"
@@ -629,7 +658,7 @@ msgstr "Ostatnio dodane"
 msgid "Show recent books"
 msgstr "Pokaż menu ostatnio dodanych książek"
 
-#: cps/templates/index.xml:17 cps/ub.py:59
+#: cps/ub.py:59
 msgid "Hot Books"
 msgstr "Najpopularniejsze"
 
@@ -637,7 +666,7 @@ msgstr "Najpopularniejsze"
 msgid "Show Hot Books"
 msgstr "Pokaż menu najpopularniejszych książek"
 
-#: cps/templates/index.xml:24 cps/ub.py:63 cps/web.py:508
+#: cps/ub.py:63 cps/web.py:508
 msgid "Top Rated Books"
 msgstr "Najwyżej ocenione"
 
@@ -645,8 +674,7 @@ msgstr "Najwyżej ocenione"
 msgid "Show Top Rated Books"
 msgstr "Pokaż menu najwyżej ocenionych książek"
 
-#: cps/templates/index.xml:46 cps/templates/index.xml:50 cps/ub.py:66
-#: cps/web.py:1005
+#: cps/ub.py:66 cps/web.py:1005
 msgid "Read Books"
 msgstr "Przeczytane"
 
@@ -654,8 +682,7 @@ msgstr "Przeczytane"
 msgid "Show read and unread"
 msgstr "Pokaż menu przeczytane i nieprzeczytane"
 
-#: cps/templates/index.xml:53 cps/templates/index.xml:57 cps/ub.py:70
-#: cps/web.py:1009
+#: cps/ub.py:70 cps/web.py:1009
 msgid "Unread Books"
 msgstr "Nieprzeczytane"
 
@@ -671,7 +698,7 @@ msgstr "Odkrywaj"
 msgid "Show random books"
 msgstr "Pokaż menu losowych książek"
 
-#: cps/templates/index.xml:75 cps/ub.py:76 cps/web.py:787
+#: cps/ub.py:76 cps/web.py:787
 msgid "Categories"
 msgstr "Kategorie"
 
@@ -679,8 +706,8 @@ msgstr "Kategorie"
 msgid "Show category selection"
 msgstr "Pokaż menu wyboru kategorii"
 
-#: cps/templates/book_edit.html:69 cps/templates/index.xml:82
-#: cps/templates/search_form.html:53 cps/ub.py:79 cps/web.py:715
+#: cps/templates/book_edit.html:69 cps/templates/search_form.html:53
+#: cps/ub.py:79 cps/web.py:715
 msgid "Series"
 msgstr "Cykle"
 
@@ -688,7 +715,7 @@ msgstr "Cykle"
 msgid "Show series selection"
 msgstr "Pokaż menu wyboru cyklu"
 
-#: cps/templates/index.xml:61 cps/ub.py:82
+#: cps/ub.py:82
 msgid "Authors"
 msgstr "Autorzy"
 
@@ -696,7 +723,7 @@ msgstr "Autorzy"
 msgid "Show author selection"
 msgstr "Pokaż menu wyboru autora"
 
-#: cps/templates/index.xml:68 cps/ub.py:86 cps/web.py:699
+#: cps/ub.py:86 cps/web.py:699
 msgid "Publishers"
 msgstr "Wydawcy"
 
@@ -704,8 +731,7 @@ msgstr "Wydawcy"
 msgid "Show publisher selection"
 msgstr "Pokaż menu wyboru wydawcy"
 
-#: cps/templates/index.xml:89 cps/templates/search_form.html:74 cps/ub.py:89
-#: cps/web.py:770
+#: cps/templates/search_form.html:74 cps/ub.py:89 cps/web.py:770
 msgid "Languages"
 msgstr "Języki"
 
@@ -713,7 +739,7 @@ msgstr "Języki"
 msgid "Show language selection"
 msgstr "Pokaż menu wyboru języka"
 
-#: cps/templates/index.xml:96 cps/ub.py:93
+#: cps/ub.py:93
 msgid "Ratings"
 msgstr "Oceny"
 
@@ -721,7 +747,7 @@ msgstr "Oceny"
 msgid "Show ratings selection"
 msgstr "Pokaż menu listy ocen"
 
-#: cps/templates/index.xml:104 cps/ub.py:96
+#: cps/ub.py:96
 msgid "File formats"
 msgstr "Formaty plików"
 
@@ -738,8 +764,12 @@ msgid "No update available. You already have the latest version installed"
 msgstr "Brak dostępnej aktualizacji. Masz już zainstalowaną najnowszą wersję"
 
 #: cps/updater.py:333
-msgid "A new update is available. Click on the button below to update to the latest version."
-msgstr "Dostępna jest nowa aktualizacja. Kliknij przycisk poniżej, aby zaktualizować do najnowszej wersji."
+msgid ""
+"A new update is available. Click on the button below to update to the "
+"latest version."
+msgstr ""
+"Dostępna jest nowa aktualizacja. Kliknij przycisk poniżej, aby "
+"zaktualizować do najnowszej wersji."
 
 #: cps/updater.py:385
 msgid "Could not fetch update information"
@@ -751,12 +781,18 @@ msgstr "Brak dostępnych informacji o wersji"
 
 #: cps/updater.py:456 cps/updater.py:467 cps/updater.py:486
 #, python-format
-msgid "A new update is available. Click on the button below to update to version: %(version)s"
-msgstr "Dostępna jest nowa aktualizacja. Kliknij przycisk poniżej, aby zaktualizować do wersji: %(version)s"
+msgid ""
+"A new update is available. Click on the button below to update to "
+"version: %(version)s"
+msgstr ""
+"Dostępna jest nowa aktualizacja. Kliknij przycisk poniżej, aby "
+"zaktualizować do wersji: %(version)s"
 
 #: cps/updater.py:477
 msgid "Click on the button below to update to the latest stable version."
-msgstr "Kliknij przycisk poniżej, aby zaktualizować do najnowszej stabilnej wersji."
+msgstr ""
+"Kliknij przycisk poniżej, aby zaktualizować do najnowszej stabilnej "
+"wersji."
 
 #: cps/web.py:480
 msgid "Recently Added Books"
@@ -775,7 +811,9 @@ msgid "Hot Books (Most Downloaded)"
 msgstr "Najpopularniejsze książki (najczęściej pobierane)"
 
 #: cps/web.py:580
-msgid "Oops! Selected book title is unavailable. File does not exist or is not accessible"
+msgid ""
+"Oops! Selected book title is unavailable. File does not exist or is not "
+"accessible"
 msgstr "Błąd otwierania e-booka. Plik nie istnieje lub jest niedostępny"
 
 #: cps/web.py:593
@@ -825,9 +863,9 @@ msgstr "Lista formatów"
 msgid "Tasks"
 msgstr "Zadania"
 
-#: cps/templates/book_edit.html:212 cps/templates/feed.xml:33
-#: cps/templates/layout.html:44 cps/templates/layout.html:47
-#: cps/templates/search_form.html:170 cps/web.py:821 cps/web.py:823
+#: cps/templates/book_edit.html:212 cps/templates/layout.html:44
+#: cps/templates/layout.html:47 cps/templates/search_form.html:170
+#: cps/web.py:821 cps/web.py:823
 msgid "Search"
 msgstr "Szukaj"
 
@@ -899,7 +937,9 @@ msgstr "zalogowałeś się jako: '%(nickname)s'"
 
 #: cps/web.py:1155
 msgid "Could not login. LDAP server down, please contact your administrator"
-msgstr "Brak możliwości zalogowania. Serwer LDAP jest niedostępny, skontaktuj się z administratorem"
+msgstr ""
+"Brak możliwości zalogowania. Serwer LDAP jest niedostępny, skontaktuj się"
+" z administratorem"
 
 #: cps/web.py:1159 cps/web.py:1182
 msgid "Wrong Username or Password"
@@ -966,191 +1006,191 @@ msgstr "Konwertowanie nie powiodło się: %(error)s"
 msgid "Kindlegen failed with Error %(error)s. Message: %(message)s"
 msgstr "Niepowodzenie! Błąd Kindlegen %(error)s. Komunikat: %(message)s"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html:8
 msgid "Users"
 msgstr "Lista użytkowników"
 
-#: cps/templates/admin.html:12 cps/templates/login.html:8
+#: cps/templates/admin.html:11 cps/templates/login.html:8
 #: cps/templates/login.html:9 cps/templates/register.html:7
 #: cps/templates/user_edit.html:8
 msgid "Username"
 msgstr "Nazwa użytkownika"
 
-#: cps/templates/admin.html:13 cps/templates/register.html:11
+#: cps/templates/admin.html:12 cps/templates/register.html:11
 #: cps/templates/user_edit.html:13
 msgid "E-mail Address"
 msgstr "E-mail"
 
-#: cps/templates/admin.html:14 cps/templates/user_edit.html:26
+#: cps/templates/admin.html:13 cps/templates/user_edit.html:26
 msgid "Send to Kindle E-mail Address"
 msgstr "Adres e-mail dla wysyłania do Kindle"
 
-#: cps/templates/admin.html:15
+#: cps/templates/admin.html:14
 msgid "Downloads"
 msgstr "DLS"
 
 # ???
-#: cps/templates/admin.html:16 cps/templates/layout.html:76
+#: cps/templates/admin.html:15 cps/templates/layout.html:76
 msgid "Admin"
 msgstr "Panel administratora"
 
 # ???
-#: cps/templates/admin.html:17 cps/templates/detail.html:18
+#: cps/templates/admin.html:16 cps/templates/detail.html:18
 #: cps/templates/detail.html:27 cps/templates/shelf.html:6
 #: cps/templates/shelfdown.html:62
 msgid "Download"
 msgstr "Pobieranie"
 
-#: cps/templates/admin.html:18
+#: cps/templates/admin.html:17
 msgid "View Books"
 msgstr "Przeglądanie"
 
-#: cps/templates/admin.html:19 cps/templates/layout.html:65
+#: cps/templates/admin.html:18 cps/templates/layout.html:65
 msgid "Upload"
 msgstr "Wysyłanie"
 
-#: cps/templates/admin.html:20
+#: cps/templates/admin.html:19
 msgid "Edit"
 msgstr "Edycja"
 
-#: cps/templates/admin.html:38
+#: cps/templates/admin.html:37
 msgid "Add New User"
 msgstr "Dodaj nowego użytkownika"
 
-#: cps/templates/admin.html:44
+#: cps/templates/admin.html:43
 msgid "E-mail Server Settings"
 msgstr "Ustawienia serwera e-mail SMTP"
 
-#: cps/templates/admin.html:47 cps/templates/email_edit.html:11
+#: cps/templates/admin.html:46 cps/templates/email_edit.html:11
 msgid "SMTP Hostname"
 msgstr "Adres serwera SMTP"
 
-#: cps/templates/admin.html:48 cps/templates/email_edit.html:15
+#: cps/templates/admin.html:47 cps/templates/email_edit.html:15
 msgid "SMTP Port"
 msgstr "Port serwera SMTP"
 
-#: cps/templates/admin.html:49 cps/templates/email_edit.html:19
+#: cps/templates/admin.html:48 cps/templates/email_edit.html:19
 msgid "Encryption"
 msgstr "SSL"
 
-#: cps/templates/admin.html:50 cps/templates/email_edit.html:27
+#: cps/templates/admin.html:49 cps/templates/email_edit.html:27
 msgid "SMTP Login"
 msgstr "Nazwa użytkownika SMTP"
 
-#: cps/templates/admin.html:51 cps/templates/email_edit.html:35
+#: cps/templates/admin.html:50 cps/templates/email_edit.html:35
 msgid "From E-mail"
 msgstr "Wyślij z adresu e-mail"
 
-#: cps/templates/admin.html:61
+#: cps/templates/admin.html:60
 msgid "Edit E-mail Server Settings"
 msgstr "Zmień ustawienia SMTP"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html:66
 msgid "Configuration"
 msgstr "Konfiguracja"
 
-#: cps/templates/admin.html:70
+#: cps/templates/admin.html:69
 msgid "Calibre Database Directory"
 msgstr "Folder bazy danych Calibre"
 
-#: cps/templates/admin.html:74 cps/templates/config_edit.html:122
+#: cps/templates/admin.html:73 cps/templates/config_edit.html:122
 msgid "Log Level"
 msgstr "Poziom dziennika"
 
-#: cps/templates/admin.html:78
+#: cps/templates/admin.html:77
 msgid "Port"
 msgstr "Port"
 
-#: cps/templates/admin.html:84 cps/templates/config_view_edit.html:27
+#: cps/templates/admin.html:83 cps/templates/config_view_edit.html:27
 msgid "Books per Page"
 msgstr "Liczba książek na stronie"
 
-#: cps/templates/admin.html:88
+#: cps/templates/admin.html:87
 msgid "Uploads"
 msgstr "Wysyłanie"
 
-#: cps/templates/admin.html:92
+#: cps/templates/admin.html:91
 msgid "Anonymous Browsing"
 msgstr "Anonimowe przeglądanie"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html:95
 msgid "Public Registration"
 msgstr "Publiczna rejestracja"
 
-#: cps/templates/admin.html:100
+#: cps/templates/admin.html:99
 msgid "Magic Link Remote Login"
 msgstr "Zdalne logowanie (Magic Link)"
 
-#: cps/templates/admin.html:104
+#: cps/templates/admin.html:103
 msgid "Reverse Proxy Login"
 msgstr "Logowanie reverse proxy"
 
-#: cps/templates/admin.html:109
+#: cps/templates/admin.html:108
 msgid "Reverse proxy header name"
 msgstr "Nazwa nagłówka reverse proxy"
 
-#: cps/templates/admin.html:114
+#: cps/templates/admin.html:113
 msgid "Edit Basic Configuration"
 msgstr "Edytuj podstawową konfigurację"
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html:114
 msgid "Edit UI Configuration"
 msgstr "Edytuj konfigurację interfejsu"
 
-#: cps/templates/admin.html:121
+#: cps/templates/admin.html:120
 msgid "Administration"
 msgstr "Zarządzanie"
 
-#: cps/templates/admin.html:122
+#: cps/templates/admin.html:121
 msgid "View Logs"
 msgstr "Podgląd dziennika"
 
-#: cps/templates/admin.html:123
+#: cps/templates/admin.html:122
 msgid "Reconnect Calibre Database"
 msgstr "Połącz ponownie z bazą danych Calibre"
 
-#: cps/templates/admin.html:124
+#: cps/templates/admin.html:123
 msgid "Restart"
 msgstr "Uruchom ponownie Calibre Web"
 
-#: cps/templates/admin.html:125
+#: cps/templates/admin.html:124
 msgid "Shutdown"
 msgstr "Zatrzymaj Calibre Web"
 
-#: cps/templates/admin.html:131
+#: cps/templates/admin.html:130
 msgid "Update"
 msgstr "Update (aktualizacja)"
 
-#: cps/templates/admin.html:135
+#: cps/templates/admin.html:134
 msgid "Version"
 msgstr "Wersja"
 
-#: cps/templates/admin.html:136
+#: cps/templates/admin.html:135
 msgid "Details"
 msgstr "Szczegóły"
 
-#: cps/templates/admin.html:142
+#: cps/templates/admin.html:141
 msgid "Current version"
 msgstr "Bieżąca wersja"
 
-#: cps/templates/admin.html:148
+#: cps/templates/admin.html:147
 msgid "Check for Update"
 msgstr "Sprawdź aktualizacje"
 
-#: cps/templates/admin.html:149
+#: cps/templates/admin.html:148
 msgid "Perform Update"
 msgstr "Wykonaj aktualizację"
 
-#: cps/templates/admin.html:161
+#: cps/templates/admin.html:160
 msgid "Are you sure you want to restart?"
 msgstr "Na pewno chcesz uruchomić ponownie Calibre Web?"
 
-#: cps/templates/admin.html:166 cps/templates/admin.html:180
-#: cps/templates/admin.html:200 cps/templates/shelf.html:72
+#: cps/templates/admin.html:165 cps/templates/admin.html:179
+#: cps/templates/admin.html:199 cps/templates/shelf.html:72
 msgid "OK"
 msgstr "OK"
 
-#: cps/templates/admin.html:167 cps/templates/admin.html:181
+#: cps/templates/admin.html:166 cps/templates/admin.html:180
 #: cps/templates/book_edit.html:172 cps/templates/book_edit.html:194
 #: cps/templates/config_edit.html:346 cps/templates/config_view_edit.html:151
 #: cps/templates/email_edit.html:40 cps/templates/email_edit.html:92
@@ -1159,11 +1199,11 @@ msgstr "OK"
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: cps/templates/admin.html:179
+#: cps/templates/admin.html:178
 msgid "Are you sure you want to shutdown?"
 msgstr "Na pewno chcesz zatrzymać Calibre Web?"
 
-#: cps/templates/admin.html:191
+#: cps/templates/admin.html:190
 msgid "Updating, please do not reload this page"
 msgstr "Aktualizowanie, proszę nie odświeżać strony"
 
@@ -1255,7 +1295,9 @@ msgid "Rating"
 msgstr "Ocena"
 
 #: cps/templates/book_edit.html:81
-msgid "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
+msgid ""
+"Fetch Cover from URL (JPEG - Image will be downloaded and stored in "
+"database)"
 msgstr "Pobierz okładkę z linku (JPEG - obraz zostanie pobrany i zapisany w bazie)"
 
 #: cps/templates/book_edit.html:85
@@ -1641,7 +1683,9 @@ msgstr "Wyrażenie regularne dla ignorowanych kolumn"
 
 #: cps/templates/config_view_edit.html:50
 msgid "Link Read/Unread Status to Calibre Column"
-msgstr "Link do statusu Przeczytanych/Nieprzeczytanych książek z kolumny Calibre (własna kolumna)"
+msgstr ""
+"Link do statusu Przeczytanych/Nieprzeczytanych książek z kolumny Calibre "
+"(własna kolumna)"
 
 #: cps/templates/config_view_edit.html:59
 msgid "View Restrictions based on Calibre column"
@@ -1791,18 +1835,11 @@ msgstr "Domeny zabronione (czarna lista)"
 msgid "Are you sure you want to delete this domain?"
 msgstr "Czy na pewno chcesz usunąć tę domenę?"
 
-#: cps/templates/feed.xml:21 cps/templates/layout.html:173
-msgid "Next"
-msgstr "Następne"
-
-#: cps/templates/feed.xml:79 cps/templates/layout.html:136
-#: cps/templates/layout.html:140
-msgid "(Public)"
-msgstr ""
-
 #: cps/templates/generate_kobo_auth_url.html:5
 msgid "Open the .kobo/Kobo eReader.conf file in a text editor and add (or edit):"
-msgstr "Otwórz plik .kobo/Kobo eReader.conf w edytorze tekstu i dodaj (lub edytuj):"
+msgstr ""
+"Otwórz plik .kobo/Kobo eReader.conf w edytorze tekstu i dodaj (lub "
+"edytuj):"
 
 # | msgid "Create a Shelf"
 #: cps/templates/http_error.html:38
@@ -1817,70 +1854,6 @@ msgstr "Powrót do głównego menu"
 #: cps/templates/index.html:64
 msgid "Group by series"
 msgstr "Grupuj według cyklu"
-
-#: cps/templates/index.xml:6
-msgid "Start"
-msgstr "Rozpocznij"
-
-#: cps/templates/index.xml:21
-msgid "Popular publications from this catalog based on Downloads."
-msgstr "Popularne publikacje z tego katalogu bazujące na pobranych."
-
-#: cps/templates/index.xml:28
-msgid "Popular publications from this catalog based on Rating."
-msgstr "Popularne publikacje z tego katalogu bazujące na ocenach."
-
-#: cps/templates/index.xml:31
-msgid "Recently added Books"
-msgstr "Ostatnio dodane książki"
-
-#: cps/templates/index.xml:35
-msgid "The latest Books"
-msgstr "Ostatnie książki"
-
-#: cps/templates/index.xml:38
-msgid "Random Books"
-msgstr "Losowe książki"
-
-#: cps/templates/index.xml:42 cps/templates/user_edit.html:80
-msgid "Show Random Books"
-msgstr "Pokazuj losowe książki"
-
-#: cps/templates/index.xml:65
-msgid "Books ordered by Author"
-msgstr "Książki sortowane według autorów"
-
-#: cps/templates/index.xml:72
-msgid "Books ordered by publisher"
-msgstr "Książki sortowane według wydawców"
-
-#: cps/templates/index.xml:79
-msgid "Books ordered by category"
-msgstr "Książki sortowane według kategorii"
-
-#: cps/templates/index.xml:86
-msgid "Books ordered by series"
-msgstr "Książki sortowane według cyklu"
-
-#: cps/templates/index.xml:93
-msgid "Books ordered by Languages"
-msgstr "Ksiązki sortowane według języka"
-
-#: cps/templates/index.xml:100
-msgid "Books ordered by Rating"
-msgstr "Książki sortowane według oceny"
-
-#: cps/templates/index.xml:108
-msgid "Books ordered by file formats"
-msgstr "Ksiązki sortowane według formatu"
-
-#: cps/templates/index.xml:111 cps/templates/layout.html:134
-msgid "Shelves"
-msgstr ""
-
-#: cps/templates/index.xml:115
-msgid "Books organized in shelves"
-msgstr ""
 
 #: cps/templates/layout.html:28
 msgid "Home"
@@ -1932,6 +1905,14 @@ msgstr "Proszę nie odświeżać strony"
 msgid "Browse"
 msgstr "Przeglądaj"
 
+#: cps/templates/layout.html:134
+msgid "Shelves"
+msgstr ""
+
+#: cps/templates/layout.html:136 cps/templates/layout.html:140
+msgid "(Public)"
+msgstr ""
+
 #: cps/templates/layout.html:138
 msgid "Your Shelves"
 msgstr "Twoje półki"
@@ -1944,6 +1925,10 @@ msgstr "Informacje"
 #: cps/templates/layout.html:158
 msgid "Previous"
 msgstr "Poprzedni"
+
+#: cps/templates/layout.html:173
+msgid "Next"
+msgstr "Następne"
 
 #: cps/templates/layout.html:185
 msgid "Book Details"
@@ -2329,6 +2314,10 @@ msgstr "Token Kobo Sync"
 msgid "Create/View"
 msgstr "Utwórz/Przeglądaj"
 
+#: cps/templates/user_edit.html:80
+msgid "Show Random Books"
+msgstr "Pokazuj losowe książki"
+
 #: cps/templates/user_edit.html:84
 msgid "Add allowed/Denied Custom Column Values"
 msgstr "Dodaj dozwolone/zabronione wartości własnych kolumn"
@@ -2349,4 +2338,208 @@ msgstr "Generuj Kobo Auth URL"
 #: cps/templates/user_edit.html:176
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "Czy na pewno chcesz usunąć Token Kobo?"
+
+#: vendor/tornado/locale.py:285
+msgid "January"
+msgstr ""
+
+#: vendor/tornado/locale.py:286
+msgid "February"
+msgstr ""
+
+#: vendor/tornado/locale.py:287
+msgid "March"
+msgstr ""
+
+#: vendor/tornado/locale.py:288
+msgid "April"
+msgstr ""
+
+#: vendor/tornado/locale.py:289
+msgid "May"
+msgstr ""
+
+#: vendor/tornado/locale.py:290
+msgid "June"
+msgstr ""
+
+#: vendor/tornado/locale.py:291
+msgid "July"
+msgstr ""
+
+#: vendor/tornado/locale.py:292
+msgid "August"
+msgstr ""
+
+#: vendor/tornado/locale.py:293
+msgid "September"
+msgstr ""
+
+#: vendor/tornado/locale.py:294
+msgid "October"
+msgstr ""
+
+#: vendor/tornado/locale.py:295
+msgid "November"
+msgstr ""
+
+#: vendor/tornado/locale.py:296
+msgid "December"
+msgstr ""
+
+#: vendor/tornado/locale.py:299
+msgid "Monday"
+msgstr ""
+
+#: vendor/tornado/locale.py:300
+msgid "Tuesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:301
+msgid "Wednesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:302
+msgid "Thursday"
+msgstr ""
+
+#: vendor/tornado/locale.py:303
+msgid "Friday"
+msgstr ""
+
+#: vendor/tornado/locale.py:304
+msgid "Saturday"
+msgstr ""
+
+#: vendor/tornado/locale.py:305
+msgid "Sunday"
+msgstr ""
+
+#: vendor/tornado/locale.py:368
+msgid "1 second ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:374
+msgid "1 minute ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:379
+msgid "1 hour ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:382
+#, python-format
+msgid "%(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+msgid "yesterday"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+#, python-format
+msgid "yesterday at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:389 vendor/tornado/locale.py:442
+#, python-format
+msgid "%(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:391
+#, python-format
+msgid "%(month_name)s %(day)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:396
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:398
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:436
+#, python-format
+msgid "%(weekday)s, %(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:459
+#, python-format
+msgid "%(commas)s and %(last)s"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:68
+msgctxt "law"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:69
+msgctxt "good"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:71 vendor/tornado/test/locale_test.py:74
+msgctxt "organization"
+msgid "club"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:76 vendor/tornado/test/locale_test.py:77
+msgctxt "stick"
+msgid "club"
+msgstr ""
+
+#~ msgid "Start"
+#~ msgstr "Rozpocznij"
+
+#~ msgid "Popular publications from this catalog based on Downloads."
+#~ msgstr "Popularne publikacje z tego katalogu bazujące na pobranych."
+
+#~ msgid "Popular publications from this catalog based on Rating."
+#~ msgstr "Popularne publikacje z tego katalogu bazujące na ocenach."
+
+#~ msgid "Recently added Books"
+#~ msgstr "Ostatnio dodane książki"
+
+#~ msgid "The latest Books"
+#~ msgstr "Ostatnie książki"
+
+#~ msgid "Random Books"
+#~ msgstr "Losowe książki"
+
+#~ msgid "Books ordered by Author"
+#~ msgstr "Książki sortowane według autorów"
+
+#~ msgid "Books ordered by publisher"
+#~ msgstr "Książki sortowane według wydawców"
+
+#~ msgid "Books ordered by category"
+#~ msgstr "Książki sortowane według kategorii"
+
+#~ msgid "Books ordered by series"
+#~ msgstr "Książki sortowane według cyklu"
+
+#~ msgid "Books ordered by Languages"
+#~ msgstr "Ksiązki sortowane według języka"
+
+#~ msgid "Books ordered by Rating"
+#~ msgstr "Książki sortowane według oceny"
+
+#~ msgid "Books ordered by file formats"
+#~ msgstr "Ksiązki sortowane według formatu"
+
+#~ msgid "Books organized in shelves"
+#~ msgstr ""
 

--- a/cps/translations/ru/LC_MESSAGES/messages.po
+++ b/cps/translations/ru/LC_MESSAGES/messages.po
@@ -8,12 +8,13 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Calibre-Web\n"
 "Report-Msgid-Bugs-To: https://github.com/janeczku/Calibre-Web\n"
-"POT-Creation-Date: 2020-04-03 19:49+0200\n"
+"POT-Creation-Date: 2020-04-08 23:10+0800\n"
 "PO-Revision-Date: 2020-03-07 11:12+0100\n"
 "Last-Translator: ZIZA\n"
 "Language: ru\n"
 "Language-Team: \n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -266,7 +267,9 @@ msgstr "Метаданные обновлены"
 
 #: cps/editbooks.py:534
 msgid "Error editing book, please check logfile for details"
-msgstr "Ошибка редактирования книги. Пожалуйста, проверьте лог-файл для дополнительной информации"
+msgstr ""
+"Ошибка редактирования книги. Пожалуйста, проверьте лог-файл для "
+"дополнительной информации"
 
 #: cps/editbooks.py:581
 #, python-format
@@ -274,8 +277,12 @@ msgid "File %(filename)s could not saved to temp dir"
 msgstr "Файл %(filename)s не удалось сохранить во временную папку"
 
 #: cps/editbooks.py:598
-msgid "Uploaded book probably exists in the library, consider to change before upload new: "
-msgstr "Загруженная книга, вероятно, существует в библиотеке, перед тем как загрузить новую, рассмотрите возможность изменения:"
+msgid ""
+"Uploaded book probably exists in the library, consider to change before "
+"upload new: "
+msgstr ""
+"Загруженная книга, вероятно, существует в библиотеке, перед тем как "
+"загрузить новую, рассмотрите возможность изменения:"
 
 #: cps/editbooks.py:613
 #, python-format
@@ -307,12 +314,20 @@ msgid "There was an error converting this book: %(res)s"
 msgstr "Произошла ошибка при конвертирования этой книги: %(res)s"
 
 #: cps/gdrive.py:61
-msgid "Google Drive setup not completed, try to deactivate and activate Google Drive again"
-msgstr "Настройка Google Drive не завершена, попробуйте деактивировать и снова активировать Google Drive"
+msgid ""
+"Google Drive setup not completed, try to deactivate and activate Google "
+"Drive again"
+msgstr ""
+"Настройка Google Drive не завершена, попробуйте деактивировать и снова "
+"активировать Google Drive"
 
 #: cps/gdrive.py:103
-msgid "Callback domain is not verified, please follow steps to verify domain in google developer console"
-msgstr "Не удалось проверить домен обратного вызова, пожалуйста, выполните шаги для проверки домена в консоли разработчика Google."
+msgid ""
+"Callback domain is not verified, please follow steps to verify domain in "
+"google developer console"
+msgstr ""
+"Не удалось проверить домен обратного вызова, пожалуйста, выполните шаги "
+"для проверки домена в консоли разработчика Google."
 
 #: cps/helper.py:80
 #, python-format
@@ -378,17 +393,23 @@ msgstr "Запрашиваемый файл не может быть прочи�
 #: cps/helper.py:322
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
-msgstr "Переименовывание заголовка с: '%(src)s' на '%(dest)s' не удалось из-за ошибки: %(error)s"
+msgstr ""
+"Переименовывание заголовка с: '%(src)s' на '%(dest)s' не удалось из-за "
+"ошибки: %(error)s"
 
 #: cps/helper.py:332
 #, python-format
 msgid "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
-msgstr "Переименовывание автора с: '%(src)s' на '%(dest)s' не удалось из-за ошибки: %(error)s"
+msgstr ""
+"Переименовывание автора с: '%(src)s' на '%(dest)s' не удалось из-за "
+"ошибки: %(error)s"
 
 #: cps/helper.py:346
 #, python-format
 msgid "Rename file in path '%(src)s' to '%(dest)s' failed with error: %(error)s"
-msgstr "Не удалось переименовать файл по пути '%(src)s' to '%(dest)s' из-за ошибки: %(error)s"
+msgstr ""
+"Не удалось переименовать файл по пути '%(src)s' to '%(dest)s' из-за "
+"ошибки: %(error)s"
 
 #: cps/helper.py:372 cps/helper.py:382 cps/helper.py:390
 #, python-format
@@ -457,8 +478,12 @@ msgid "Unknown Task: "
 msgstr "Неизвестная задача:"
 
 #: cps/kobo_auth.py:127
-msgid "PLease access calibre-web from non localhost to get valid api_endpoint for kobo device"
-msgstr "Пожалуйста, подключитесь к Calibre-Web не с локального хоста, чтобы получить действительный api_endpoint для устройства Kobo"
+msgid ""
+"PLease access calibre-web from non localhost to get valid api_endpoint "
+"for kobo device"
+msgstr ""
+"Пожалуйста, подключитесь к Calibre-Web не с локального хоста, чтобы "
+"получить действительный api_endpoint для устройства Kobo"
 
 #: cps/kobo_auth.py:130 cps/kobo_auth.py:150
 msgid "Kobo Setup"
@@ -623,7 +648,7 @@ msgstr "Недавно Добавленные"
 msgid "Show recent books"
 msgstr "Показывать недавние книги"
 
-#: cps/templates/index.xml:17 cps/ub.py:59
+#: cps/ub.py:59
 msgid "Hot Books"
 msgstr "Популярные Книги"
 
@@ -631,7 +656,7 @@ msgstr "Популярные Книги"
 msgid "Show Hot Books"
 msgstr "Показывать популярные книги"
 
-#: cps/templates/index.xml:24 cps/ub.py:63 cps/web.py:508
+#: cps/ub.py:63 cps/web.py:508
 msgid "Top Rated Books"
 msgstr "Книги с наилучшим рейтингом"
 
@@ -639,8 +664,7 @@ msgstr "Книги с наилучшим рейтингом"
 msgid "Show Top Rated Books"
 msgstr "Показывать книги с наивысшим рейтингом"
 
-#: cps/templates/index.xml:46 cps/templates/index.xml:50 cps/ub.py:66
-#: cps/web.py:1005
+#: cps/ub.py:66 cps/web.py:1005
 msgid "Read Books"
 msgstr "Прочитанные Книги"
 
@@ -648,8 +672,7 @@ msgstr "Прочитанные Книги"
 msgid "Show read and unread"
 msgstr "Показывать прочитанные и непрочитанные"
 
-#: cps/templates/index.xml:53 cps/templates/index.xml:57 cps/ub.py:70
-#: cps/web.py:1009
+#: cps/ub.py:70 cps/web.py:1009
 msgid "Unread Books"
 msgstr "Непрочитанные Книги"
 
@@ -665,7 +688,7 @@ msgstr "Обзор"
 msgid "Show random books"
 msgstr "Показывать случайные книги"
 
-#: cps/templates/index.xml:75 cps/ub.py:76 cps/web.py:787
+#: cps/ub.py:76 cps/web.py:787
 msgid "Categories"
 msgstr "Категории"
 
@@ -673,8 +696,8 @@ msgstr "Категории"
 msgid "Show category selection"
 msgstr "Показывать выбор категории"
 
-#: cps/templates/book_edit.html:69 cps/templates/index.xml:82
-#: cps/templates/search_form.html:53 cps/ub.py:79 cps/web.py:715
+#: cps/templates/book_edit.html:69 cps/templates/search_form.html:53
+#: cps/ub.py:79 cps/web.py:715
 msgid "Series"
 msgstr "Серии"
 
@@ -682,7 +705,7 @@ msgstr "Серии"
 msgid "Show series selection"
 msgstr "Показывать выбор серии"
 
-#: cps/templates/index.xml:61 cps/ub.py:82
+#: cps/ub.py:82
 msgid "Authors"
 msgstr "Авторы"
 
@@ -690,7 +713,7 @@ msgstr "Авторы"
 msgid "Show author selection"
 msgstr "Показывать выбор автора"
 
-#: cps/templates/index.xml:68 cps/ub.py:86 cps/web.py:699
+#: cps/ub.py:86 cps/web.py:699
 msgid "Publishers"
 msgstr "Издатели"
 
@@ -698,8 +721,7 @@ msgstr "Издатели"
 msgid "Show publisher selection"
 msgstr "Показать выбор издателя"
 
-#: cps/templates/index.xml:89 cps/templates/search_form.html:74 cps/ub.py:89
-#: cps/web.py:770
+#: cps/templates/search_form.html:74 cps/ub.py:89 cps/web.py:770
 msgid "Languages"
 msgstr "Языки"
 
@@ -707,7 +729,7 @@ msgstr "Языки"
 msgid "Show language selection"
 msgstr "Показывать выбор языка"
 
-#: cps/templates/index.xml:96 cps/ub.py:93
+#: cps/ub.py:93
 msgid "Ratings"
 msgstr "Рейтинги"
 
@@ -715,7 +737,7 @@ msgstr "Рейтинги"
 msgid "Show ratings selection"
 msgstr "Показать выбор рейтинга"
 
-#: cps/templates/index.xml:104 cps/ub.py:96
+#: cps/ub.py:96
 msgid "File formats"
 msgstr "Форматы файлов"
 
@@ -732,8 +754,12 @@ msgid "No update available. You already have the latest version installed"
 msgstr "Нет доступных обновлений. Вы используете последнюю версию"
 
 #: cps/updater.py:333
-msgid "A new update is available. Click on the button below to update to the latest version."
-msgstr "Новое обновление доступно. Нажмите на кнопку ниже, чтобы обновить до последней версии."
+msgid ""
+"A new update is available. Click on the button below to update to the "
+"latest version."
+msgstr ""
+"Новое обновление доступно. Нажмите на кнопку ниже, чтобы обновить до "
+"последней версии."
 
 #: cps/updater.py:385
 msgid "Could not fetch update information"
@@ -745,8 +771,12 @@ msgstr "Информация о выпуске недоступна"
 
 #: cps/updater.py:456 cps/updater.py:467 cps/updater.py:486
 #, python-format
-msgid "A new update is available. Click on the button below to update to version: %(version)s"
-msgstr "Новое обновление доступно. Нажмите на кнопку ниже, чтобы обновиться до версии: %(version)s"
+msgid ""
+"A new update is available. Click on the button below to update to "
+"version: %(version)s"
+msgstr ""
+"Новое обновление доступно. Нажмите на кнопку ниже, чтобы обновиться до "
+"версии: %(version)s"
 
 #: cps/updater.py:477
 msgid "Click on the button below to update to the latest stable version."
@@ -769,7 +799,9 @@ msgid "Hot Books (Most Downloaded)"
 msgstr "Популярные книги (часто загружаемые)"
 
 #: cps/web.py:580
-msgid "Oops! Selected book title is unavailable. File does not exist or is not accessible"
+msgid ""
+"Oops! Selected book title is unavailable. File does not exist or is not "
+"accessible"
 msgstr "Невозможно открыть книгу. Файл не существует или недоступен"
 
 #: cps/web.py:593
@@ -819,9 +851,9 @@ msgstr "Список форматов файлов"
 msgid "Tasks"
 msgstr "Задания"
 
-#: cps/templates/book_edit.html:212 cps/templates/feed.xml:33
-#: cps/templates/layout.html:44 cps/templates/layout.html:47
-#: cps/templates/search_form.html:170 cps/web.py:821 cps/web.py:823
+#: cps/templates/book_edit.html:212 cps/templates/layout.html:44
+#: cps/templates/layout.html:47 cps/templates/search_form.html:170
+#: cps/web.py:821 cps/web.py:823
 msgid "Search"
 msgstr "Поиск"
 
@@ -960,189 +992,189 @@ msgstr "Ошибка Ebook-конвертора: %(error)s"
 msgid "Kindlegen failed with Error %(error)s. Message: %(message)s"
 msgstr "Kindlegen - неудачно, с ошибкой %(error)s. Сообщение: %(message)s"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html:8
 msgid "Users"
 msgstr "Список пользователей"
 
-#: cps/templates/admin.html:12 cps/templates/login.html:8
+#: cps/templates/admin.html:11 cps/templates/login.html:8
 #: cps/templates/login.html:9 cps/templates/register.html:7
 #: cps/templates/user_edit.html:8
 msgid "Username"
 msgstr "Имя пользователя"
 
-#: cps/templates/admin.html:13 cps/templates/register.html:11
+#: cps/templates/admin.html:12 cps/templates/register.html:11
 #: cps/templates/user_edit.html:13
 msgid "E-mail Address"
 msgstr "Адрес электронной почты"
 
-#: cps/templates/admin.html:14 cps/templates/user_edit.html:26
+#: cps/templates/admin.html:13 cps/templates/user_edit.html:26
 msgid "Send to Kindle E-mail Address"
 msgstr "Отправить на Kindle Адрес электронной почты"
 
-#: cps/templates/admin.html:15
+#: cps/templates/admin.html:14
 msgid "Downloads"
 msgstr "Скачать"
 
-#: cps/templates/admin.html:16 cps/templates/layout.html:76
+#: cps/templates/admin.html:15 cps/templates/layout.html:76
 msgid "Admin"
 msgstr "Управление"
 
-#: cps/templates/admin.html:17 cps/templates/detail.html:18
+#: cps/templates/admin.html:16 cps/templates/detail.html:18
 #: cps/templates/detail.html:27 cps/templates/shelf.html:6
 #: cps/templates/shelfdown.html:62
 msgid "Download"
 msgstr "Скачать"
 
-#: cps/templates/admin.html:18
+#: cps/templates/admin.html:17
 msgid "View Books"
 msgstr "Посмотреть электронные книги"
 
-#: cps/templates/admin.html:19 cps/templates/layout.html:65
+#: cps/templates/admin.html:18 cps/templates/layout.html:65
 msgid "Upload"
 msgstr "Загрузить"
 
-#: cps/templates/admin.html:20
+#: cps/templates/admin.html:19
 msgid "Edit"
 msgstr "Редактировать"
 
-#: cps/templates/admin.html:38
+#: cps/templates/admin.html:37
 msgid "Add New User"
 msgstr "Добавить нового пользователя"
 
-#: cps/templates/admin.html:44
+#: cps/templates/admin.html:43
 msgid "E-mail Server Settings"
 msgstr "Настройки SMTP-сервера"
 
-#: cps/templates/admin.html:47 cps/templates/email_edit.html:11
+#: cps/templates/admin.html:46 cps/templates/email_edit.html:11
 msgid "SMTP Hostname"
 msgstr "SMTP-сервер"
 
-#: cps/templates/admin.html:48 cps/templates/email_edit.html:15
+#: cps/templates/admin.html:47 cps/templates/email_edit.html:15
 msgid "SMTP Port"
 msgstr "SMTP-порт"
 
-#: cps/templates/admin.html:49 cps/templates/email_edit.html:19
+#: cps/templates/admin.html:48 cps/templates/email_edit.html:19
 msgid "Encryption"
 msgstr "SSL"
 
-#: cps/templates/admin.html:50 cps/templates/email_edit.html:27
+#: cps/templates/admin.html:49 cps/templates/email_edit.html:27
 msgid "SMTP Login"
 msgstr "SMTP-логин"
 
-#: cps/templates/admin.html:51 cps/templates/email_edit.html:35
+#: cps/templates/admin.html:50 cps/templates/email_edit.html:35
 msgid "From E-mail"
 msgstr "Отправитель"
 
-#: cps/templates/admin.html:61
+#: cps/templates/admin.html:60
 msgid "Edit E-mail Server Settings"
 msgstr "Изменить настройки SMTP"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html:66
 msgid "Configuration"
 msgstr "Настройки сервера"
 
-#: cps/templates/admin.html:70
+#: cps/templates/admin.html:69
 msgid "Calibre Database Directory"
 msgstr "Расположение базы данных Calibre"
 
-#: cps/templates/admin.html:74 cps/templates/config_edit.html:122
+#: cps/templates/admin.html:73 cps/templates/config_edit.html:122
 msgid "Log Level"
 msgstr "Уровень логирования"
 
-#: cps/templates/admin.html:78
+#: cps/templates/admin.html:77
 msgid "Port"
 msgstr "Порт"
 
-#: cps/templates/admin.html:84 cps/templates/config_view_edit.html:27
+#: cps/templates/admin.html:83 cps/templates/config_view_edit.html:27
 msgid "Books per Page"
 msgstr "Количество книг на странице"
 
-#: cps/templates/admin.html:88
+#: cps/templates/admin.html:87
 msgid "Uploads"
 msgstr "Загрузка на сервер"
 
-#: cps/templates/admin.html:92
+#: cps/templates/admin.html:91
 msgid "Anonymous Browsing"
 msgstr "Анонимный просмотр"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html:95
 msgid "Public Registration"
 msgstr "Публичная регистрация"
 
-#: cps/templates/admin.html:100
+#: cps/templates/admin.html:99
 msgid "Magic Link Remote Login"
 msgstr "Удалённый логин"
 
-#: cps/templates/admin.html:104
+#: cps/templates/admin.html:103
 msgid "Reverse Proxy Login"
 msgstr "Логин обратного прокси"
 
-#: cps/templates/admin.html:109
+#: cps/templates/admin.html:108
 msgid "Reverse proxy header name"
 msgstr "Имя заголовка обратного прокси"
 
-#: cps/templates/admin.html:114
+#: cps/templates/admin.html:113
 msgid "Edit Basic Configuration"
 msgstr "Изменить основные настройки"
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html:114
 msgid "Edit UI Configuration"
 msgstr "Изменить настройки интерфейса"
 
-#: cps/templates/admin.html:121
+#: cps/templates/admin.html:120
 msgid "Administration"
 msgstr "Управление"
 
-#: cps/templates/admin.html:122
+#: cps/templates/admin.html:121
 msgid "View Logs"
 msgstr "Просмотреть лог файл"
 
-#: cps/templates/admin.html:123
+#: cps/templates/admin.html:122
 msgid "Reconnect Calibre Database"
 msgstr "Пере подключиться к базе жанных Calibre"
 
-#: cps/templates/admin.html:124
+#: cps/templates/admin.html:123
 msgid "Restart"
 msgstr "Перезагрузить Calibre-Web"
 
-#: cps/templates/admin.html:125
+#: cps/templates/admin.html:124
 msgid "Shutdown"
 msgstr "Остановить Calibre-Web"
 
-#: cps/templates/admin.html:131
+#: cps/templates/admin.html:130
 msgid "Update"
 msgstr "Обновление"
 
-#: cps/templates/admin.html:135
+#: cps/templates/admin.html:134
 msgid "Version"
 msgstr "Версия"
 
-#: cps/templates/admin.html:136
+#: cps/templates/admin.html:135
 msgid "Details"
 msgstr "Подробности"
 
-#: cps/templates/admin.html:142
+#: cps/templates/admin.html:141
 msgid "Current version"
 msgstr "Текущая версия"
 
-#: cps/templates/admin.html:148
+#: cps/templates/admin.html:147
 msgid "Check for Update"
 msgstr "Проверка обновлений"
 
-#: cps/templates/admin.html:149
+#: cps/templates/admin.html:148
 msgid "Perform Update"
 msgstr "Установить обновления"
 
-#: cps/templates/admin.html:161
+#: cps/templates/admin.html:160
 msgid "Are you sure you want to restart?"
 msgstr "Вы действительно хотите перезагрузить Calibre-Web?"
 
-#: cps/templates/admin.html:166 cps/templates/admin.html:180
-#: cps/templates/admin.html:200 cps/templates/shelf.html:72
+#: cps/templates/admin.html:165 cps/templates/admin.html:179
+#: cps/templates/admin.html:199 cps/templates/shelf.html:72
 msgid "OK"
 msgstr "Ok"
 
-#: cps/templates/admin.html:167 cps/templates/admin.html:181
+#: cps/templates/admin.html:166 cps/templates/admin.html:180
 #: cps/templates/book_edit.html:172 cps/templates/book_edit.html:194
 #: cps/templates/config_edit.html:346 cps/templates/config_view_edit.html:151
 #: cps/templates/email_edit.html:40 cps/templates/email_edit.html:92
@@ -1151,11 +1183,11 @@ msgstr "Ok"
 msgid "Cancel"
 msgstr "Отмена"
 
-#: cps/templates/admin.html:179
+#: cps/templates/admin.html:178
 msgid "Are you sure you want to shutdown?"
 msgstr "Вы действительно хотите остановить Calibre-Web?"
 
-#: cps/templates/admin.html:191
+#: cps/templates/admin.html:190
 msgid "Updating, please do not reload this page"
 msgstr "Установка обновлений, пожалуйста, не обновляйте страницу."
 
@@ -1244,8 +1276,12 @@ msgid "Rating"
 msgstr "Рейтинг"
 
 #: cps/templates/book_edit.html:81
-msgid "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
-msgstr "URL обложки(jpg, обложка загружается и сохраняется в базе данных, после этого поле снова пустое)"
+msgid ""
+"Fetch Cover from URL (JPEG - Image will be downloaded and stored in "
+"database)"
+msgstr ""
+"URL обложки(jpg, обложка загружается и сохраняется в базе данных, после "
+"этого поле снова пустое)"
 
 #: cps/templates/book_edit.html:85
 msgid "Upload Cover from Local Disk"
@@ -1778,18 +1814,11 @@ msgstr "Запрещенные домены (черный список)"
 msgid "Are you sure you want to delete this domain?"
 msgstr "Вы действительно желаете удалить это правило домена?"
 
-#: cps/templates/feed.xml:21 cps/templates/layout.html:173
-msgid "Next"
-msgstr "Далее"
-
-#: cps/templates/feed.xml:79 cps/templates/layout.html:136
-#: cps/templates/layout.html:140
-msgid "(Public)"
-msgstr ""
-
 #: cps/templates/generate_kobo_auth_url.html:5
 msgid "Open the .kobo/Kobo eReader.conf file in a text editor and add (or edit):"
-msgstr "Откройте файл .kobo / Kobo eReader.conf в текстовом редакторе и добавьте (или отредактируйте):"
+msgstr ""
+"Откройте файл .kobo / Kobo eReader.conf в текстовом редакторе и добавьте "
+"(или отредактируйте):"
 
 #: cps/templates/http_error.html:38
 msgid "Create Issue"
@@ -1802,70 +1831,6 @@ msgstr "Вернуться на главную"
 #: cps/templates/index.html:64
 msgid "Group by series"
 msgstr "Сгрупировать по серии"
-
-#: cps/templates/index.xml:6
-msgid "Start"
-msgstr "Старт"
-
-#: cps/templates/index.xml:21
-msgid "Popular publications from this catalog based on Downloads."
-msgstr "Популярные книги в этом каталоге, на основе количества Скачиваний"
-
-#: cps/templates/index.xml:28
-msgid "Popular publications from this catalog based on Rating."
-msgstr "Популярные книги из этого каталога на основании Рейтинга"
-
-#: cps/templates/index.xml:31
-msgid "Recently added Books"
-msgstr "Недавно добавленные книги"
-
-#: cps/templates/index.xml:35
-msgid "The latest Books"
-msgstr "Последние Книги"
-
-#: cps/templates/index.xml:38
-msgid "Random Books"
-msgstr "Случайный выбор"
-
-#: cps/templates/index.xml:42 cps/templates/user_edit.html:80
-msgid "Show Random Books"
-msgstr "Показывать Случайные Книги"
-
-#: cps/templates/index.xml:65
-msgid "Books ordered by Author"
-msgstr "Книги, отсортированные по Автору"
-
-#: cps/templates/index.xml:72
-msgid "Books ordered by publisher"
-msgstr "Книги, отсортированные по издателю"
-
-#: cps/templates/index.xml:79
-msgid "Books ordered by category"
-msgstr "Книги, отсортированные по категории"
-
-#: cps/templates/index.xml:86
-msgid "Books ordered by series"
-msgstr "Книги, отсортированные по серии"
-
-#: cps/templates/index.xml:93
-msgid "Books ordered by Languages"
-msgstr "Книги отсортированы по языкам"
-
-#: cps/templates/index.xml:100
-msgid "Books ordered by Rating"
-msgstr ""
-
-#: cps/templates/index.xml:108
-msgid "Books ordered by file formats"
-msgstr "Книги отсортированы по формату файла"
-
-#: cps/templates/index.xml:111 cps/templates/layout.html:134
-msgid "Shelves"
-msgstr ""
-
-#: cps/templates/index.xml:115
-msgid "Books organized in shelves"
-msgstr ""
 
 #: cps/templates/layout.html:28
 msgid "Home"
@@ -1917,6 +1882,14 @@ msgstr "Пожалуйста не обновляйте страницу"
 msgid "Browse"
 msgstr "Просмотр"
 
+#: cps/templates/layout.html:134
+msgid "Shelves"
+msgstr ""
+
+#: cps/templates/layout.html:136 cps/templates/layout.html:140
+msgid "(Public)"
+msgstr ""
+
 #: cps/templates/layout.html:138
 msgid "Your Shelves"
 msgstr "Ваши полки"
@@ -1928,6 +1901,10 @@ msgstr "О программе"
 #: cps/templates/layout.html:158
 msgid "Previous"
 msgstr "Предыдущий"
+
+#: cps/templates/layout.html:173
+msgid "Next"
+msgstr "Далее"
 
 #: cps/templates/layout.html:185
 msgid "Book Details"
@@ -1988,7 +1965,9 @@ msgstr "Выбрать разрешенные / запрещенные теги 
 
 #: cps/templates/modal_restriction.html:9
 msgid "Select Allowed/Denied Custom Column Values of User"
-msgstr "Выбрать разрешенные / запрещенные значения индивидуальных столбцов пользователя"
+msgstr ""
+"Выбрать разрешенные / запрещенные значения индивидуальных столбцов "
+"пользователя"
 
 #: cps/templates/modal_restriction.html:15
 msgid "Enter Tag"
@@ -2310,6 +2289,10 @@ msgstr "Kobo Sync Token"
 msgid "Create/View"
 msgstr "Создать/Просмотреть"
 
+#: cps/templates/user_edit.html:80
+msgid "Show Random Books"
+msgstr "Показывать Случайные Книги"
+
 #: cps/templates/user_edit.html:84
 msgid "Add allowed/Denied Custom Column Values"
 msgstr "Добавить разрешенные / запрещенные значения индивидуальных столбцов"
@@ -2329,4 +2312,208 @@ msgstr "Создать Kobo Auth URL"
 #: cps/templates/user_edit.html:176
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "Вы действительно хотите удалить Kobo Token ?"
+
+#: vendor/tornado/locale.py:285
+msgid "January"
+msgstr ""
+
+#: vendor/tornado/locale.py:286
+msgid "February"
+msgstr ""
+
+#: vendor/tornado/locale.py:287
+msgid "March"
+msgstr ""
+
+#: vendor/tornado/locale.py:288
+msgid "April"
+msgstr ""
+
+#: vendor/tornado/locale.py:289
+msgid "May"
+msgstr ""
+
+#: vendor/tornado/locale.py:290
+msgid "June"
+msgstr ""
+
+#: vendor/tornado/locale.py:291
+msgid "July"
+msgstr ""
+
+#: vendor/tornado/locale.py:292
+msgid "August"
+msgstr ""
+
+#: vendor/tornado/locale.py:293
+msgid "September"
+msgstr ""
+
+#: vendor/tornado/locale.py:294
+msgid "October"
+msgstr ""
+
+#: vendor/tornado/locale.py:295
+msgid "November"
+msgstr ""
+
+#: vendor/tornado/locale.py:296
+msgid "December"
+msgstr ""
+
+#: vendor/tornado/locale.py:299
+msgid "Monday"
+msgstr ""
+
+#: vendor/tornado/locale.py:300
+msgid "Tuesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:301
+msgid "Wednesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:302
+msgid "Thursday"
+msgstr ""
+
+#: vendor/tornado/locale.py:303
+msgid "Friday"
+msgstr ""
+
+#: vendor/tornado/locale.py:304
+msgid "Saturday"
+msgstr ""
+
+#: vendor/tornado/locale.py:305
+msgid "Sunday"
+msgstr ""
+
+#: vendor/tornado/locale.py:368
+msgid "1 second ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:374
+msgid "1 minute ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:379
+msgid "1 hour ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:382
+#, python-format
+msgid "%(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+msgid "yesterday"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+#, python-format
+msgid "yesterday at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:389 vendor/tornado/locale.py:442
+#, python-format
+msgid "%(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:391
+#, python-format
+msgid "%(month_name)s %(day)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:396
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:398
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:436
+#, python-format
+msgid "%(weekday)s, %(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:459
+#, python-format
+msgid "%(commas)s and %(last)s"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:68
+msgctxt "law"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:69
+msgctxt "good"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:71 vendor/tornado/test/locale_test.py:74
+msgctxt "organization"
+msgid "club"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:76 vendor/tornado/test/locale_test.py:77
+msgctxt "stick"
+msgid "club"
+msgstr ""
+
+#~ msgid "Start"
+#~ msgstr "Старт"
+
+#~ msgid "Popular publications from this catalog based on Downloads."
+#~ msgstr "Популярные книги в этом каталоге, на основе количества Скачиваний"
+
+#~ msgid "Popular publications from this catalog based on Rating."
+#~ msgstr "Популярные книги из этого каталога на основании Рейтинга"
+
+#~ msgid "Recently added Books"
+#~ msgstr "Недавно добавленные книги"
+
+#~ msgid "The latest Books"
+#~ msgstr "Последние Книги"
+
+#~ msgid "Random Books"
+#~ msgstr "Случайный выбор"
+
+#~ msgid "Books ordered by Author"
+#~ msgstr "Книги, отсортированные по Автору"
+
+#~ msgid "Books ordered by publisher"
+#~ msgstr "Книги, отсортированные по издателю"
+
+#~ msgid "Books ordered by category"
+#~ msgstr "Книги, отсортированные по категории"
+
+#~ msgid "Books ordered by series"
+#~ msgstr "Книги, отсортированные по серии"
+
+#~ msgid "Books ordered by Languages"
+#~ msgstr "Книги отсортированы по языкам"
+
+#~ msgid "Books ordered by Rating"
+#~ msgstr ""
+
+#~ msgid "Books ordered by file formats"
+#~ msgstr "Книги отсортированы по формату файла"
+
+#~ msgid "Books organized in shelves"
+#~ msgstr ""
 

--- a/cps/translations/sv/LC_MESSAGES/messages.po
+++ b/cps/translations/sv/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Calibre-Web\n"
 "Report-Msgid-Bugs-To: https://github.com/janeczku/Calibre-Web\n"
-"POT-Creation-Date: 2020-04-03 19:49+0200\n"
+"POT-Creation-Date: 2020-04-08 23:10+0800\n"
 "PO-Revision-Date: 2020-03-14 09:30+0100\n"
 "Last-Translator: Jonatan Nyberg <jonatan.nyberg.karl@gmail.com>\n"
 "Language: sv\n"
@@ -220,7 +220,9 @@ msgstr "inte konfigurerad"
 
 #: cps/editbooks.py:214 cps/editbooks.py:396
 msgid "Error opening eBook. File does not exist or file is not accessible"
-msgstr "Det gick inte att öppna e-boken. Filen finns inte eller filen är inte tillgänglig"
+msgstr ""
+"Det gick inte att öppna e-boken. Filen finns inte eller filen är inte "
+"tillgänglig"
 
 #: cps/editbooks.py:242
 msgid "edit metadata"
@@ -265,7 +267,9 @@ msgstr "Metadata uppdaterades"
 
 #: cps/editbooks.py:534
 msgid "Error editing book, please check logfile for details"
-msgstr "Det gick inte att redigera boken, kontrollera loggfilen för mer information"
+msgstr ""
+"Det gick inte att redigera boken, kontrollera loggfilen för mer "
+"information"
 
 #: cps/editbooks.py:581
 #, python-format
@@ -273,8 +277,12 @@ msgid "File %(filename)s could not saved to temp dir"
 msgstr "Filen %(filename)s kunde inte sparas i temp dir"
 
 #: cps/editbooks.py:598
-msgid "Uploaded book probably exists in the library, consider to change before upload new: "
-msgstr "Uppladdad bok finns förmodligen i biblioteket, överväg att ändra innan du laddar upp nya: "
+msgid ""
+"Uploaded book probably exists in the library, consider to change before "
+"upload new: "
+msgstr ""
+"Uppladdad bok finns förmodligen i biblioteket, överväg att ändra innan du"
+" laddar upp nya: "
 
 #: cps/editbooks.py:613
 #, python-format
@@ -306,12 +314,20 @@ msgid "There was an error converting this book: %(res)s"
 msgstr "Det gick inte att konvertera den här boken: %(res)s"
 
 #: cps/gdrive.py:61
-msgid "Google Drive setup not completed, try to deactivate and activate Google Drive again"
-msgstr "Installationen av Google Drive är inte klar, försök att inaktivera och aktivera Google Drive igen"
+msgid ""
+"Google Drive setup not completed, try to deactivate and activate Google "
+"Drive again"
+msgstr ""
+"Installationen av Google Drive är inte klar, försök att inaktivera och "
+"aktivera Google Drive igen"
 
 #: cps/gdrive.py:103
-msgid "Callback domain is not verified, please follow steps to verify domain in google developer console"
-msgstr "Återuppringningsdomänen är inte verifierad, följ stegen för att verifiera domänen i Google utvecklarkonsol"
+msgid ""
+"Callback domain is not verified, please follow steps to verify domain in "
+"google developer console"
+msgstr ""
+"Återuppringningsdomänen är inte verifierad, följ stegen för att verifiera"
+" domänen i Google utvecklarkonsol"
 
 #: cps/helper.py:80
 #, python-format
@@ -377,17 +393,23 @@ msgstr "Den begärda filen kunde inte läsas. Kanske fel behörigheter?"
 #: cps/helper.py:322
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
-msgstr "Byt namn på titel från: \"%(src)s\" till \"%(dest)s\" misslyckades med fel: %(error)s"
+msgstr ""
+"Byt namn på titel från: \"%(src)s\" till \"%(dest)s\" misslyckades med "
+"fel: %(error)s"
 
 #: cps/helper.py:332
 #, python-format
 msgid "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
-msgstr "Byt namn på författare från: \"%(src)s\" till \"%(dest)s\" misslyckades med fel: %(error)s"
+msgstr ""
+"Byt namn på författare från: \"%(src)s\" till \"%(dest)s\" misslyckades "
+"med fel: %(error)s"
 
 #: cps/helper.py:346
 #, python-format
 msgid "Rename file in path '%(src)s' to '%(dest)s' failed with error: %(error)s"
-msgstr "Byt namn på fil i sökvägen '%(src)s' till '%(dest)s' misslyckades med fel: %(error)s"
+msgstr ""
+"Byt namn på fil i sökvägen '%(src)s' till '%(dest)s' misslyckades med "
+"fel: %(error)s"
 
 #: cps/helper.py:372 cps/helper.py:382 cps/helper.py:390
 #, python-format
@@ -456,8 +478,12 @@ msgid "Unknown Task: "
 msgstr "Okänd uppgift: "
 
 #: cps/kobo_auth.py:127
-msgid "PLease access calibre-web from non localhost to get valid api_endpoint for kobo device"
-msgstr "Vänligen få tillgång till calibre-web från icke localhost för att få giltig api_endpoint för Kobo-enhet"
+msgid ""
+"PLease access calibre-web from non localhost to get valid api_endpoint "
+"for kobo device"
+msgstr ""
+"Vänligen få tillgång till calibre-web från icke localhost för att få "
+"giltig api_endpoint för Kobo-enhet"
 
 #: cps/kobo_auth.py:130 cps/kobo_auth.py:150
 msgid "Kobo Setup"
@@ -622,7 +648,7 @@ msgstr "Nyligen tillagda"
 msgid "Show recent books"
 msgstr "Visa senaste böcker"
 
-#: cps/templates/index.xml:17 cps/ub.py:59
+#: cps/ub.py:59
 msgid "Hot Books"
 msgstr "Heta böcker"
 
@@ -630,7 +656,7 @@ msgstr "Heta böcker"
 msgid "Show Hot Books"
 msgstr "Visa heta böcker"
 
-#: cps/templates/index.xml:24 cps/ub.py:63 cps/web.py:508
+#: cps/ub.py:63 cps/web.py:508
 msgid "Top Rated Books"
 msgstr "Bäst rankade böcker"
 
@@ -638,8 +664,7 @@ msgstr "Bäst rankade böcker"
 msgid "Show Top Rated Books"
 msgstr "Visa böcker med bästa betyg"
 
-#: cps/templates/index.xml:46 cps/templates/index.xml:50 cps/ub.py:66
-#: cps/web.py:1005
+#: cps/ub.py:66 cps/web.py:1005
 msgid "Read Books"
 msgstr "Lästa böcker"
 
@@ -647,8 +672,7 @@ msgstr "Lästa böcker"
 msgid "Show read and unread"
 msgstr "Visa lästa och olästa"
 
-#: cps/templates/index.xml:53 cps/templates/index.xml:57 cps/ub.py:70
-#: cps/web.py:1009
+#: cps/ub.py:70 cps/web.py:1009
 msgid "Unread Books"
 msgstr "Olästa böcker"
 
@@ -664,7 +688,7 @@ msgstr "Upptäck"
 msgid "Show random books"
 msgstr "Visa slumpmässiga böcker"
 
-#: cps/templates/index.xml:75 cps/ub.py:76 cps/web.py:787
+#: cps/ub.py:76 cps/web.py:787
 msgid "Categories"
 msgstr "Kategorier"
 
@@ -672,8 +696,8 @@ msgstr "Kategorier"
 msgid "Show category selection"
 msgstr "Visa kategorival"
 
-#: cps/templates/book_edit.html:69 cps/templates/index.xml:82
-#: cps/templates/search_form.html:53 cps/ub.py:79 cps/web.py:715
+#: cps/templates/book_edit.html:69 cps/templates/search_form.html:53
+#: cps/ub.py:79 cps/web.py:715
 msgid "Series"
 msgstr "Serier"
 
@@ -681,7 +705,7 @@ msgstr "Serier"
 msgid "Show series selection"
 msgstr "Visa serieval"
 
-#: cps/templates/index.xml:61 cps/ub.py:82
+#: cps/ub.py:82
 msgid "Authors"
 msgstr "Författare"
 
@@ -689,7 +713,7 @@ msgstr "Författare"
 msgid "Show author selection"
 msgstr "Visa författarval"
 
-#: cps/templates/index.xml:68 cps/ub.py:86 cps/web.py:699
+#: cps/ub.py:86 cps/web.py:699
 msgid "Publishers"
 msgstr "Förlag"
 
@@ -697,8 +721,7 @@ msgstr "Förlag"
 msgid "Show publisher selection"
 msgstr "Visa urval av förlag"
 
-#: cps/templates/index.xml:89 cps/templates/search_form.html:74 cps/ub.py:89
-#: cps/web.py:770
+#: cps/templates/search_form.html:74 cps/ub.py:89 cps/web.py:770
 msgid "Languages"
 msgstr "Språk"
 
@@ -706,7 +729,7 @@ msgstr "Språk"
 msgid "Show language selection"
 msgstr "Visa språkval"
 
-#: cps/templates/index.xml:96 cps/ub.py:93
+#: cps/ub.py:93
 msgid "Ratings"
 msgstr "Betyg"
 
@@ -714,7 +737,7 @@ msgstr "Betyg"
 msgid "Show ratings selection"
 msgstr "Visa val av betyg"
 
-#: cps/templates/index.xml:104 cps/ub.py:96
+#: cps/ub.py:96
 msgid "File formats"
 msgstr "Filformat"
 
@@ -728,11 +751,17 @@ msgstr "Oväntade data vid läsning av uppdateringsinformation"
 
 #: cps/updater.py:301 cps/updater.py:412
 msgid "No update available. You already have the latest version installed"
-msgstr "Ingen uppdatering tillgänglig. Du har redan den senaste versionen installerad"
+msgstr ""
+"Ingen uppdatering tillgänglig. Du har redan den senaste versionen "
+"installerad"
 
 #: cps/updater.py:333
-msgid "A new update is available. Click on the button below to update to the latest version."
-msgstr "En ny uppdatering är tillgänglig. Klicka på knappen nedan för att uppdatera till den senaste versionen."
+msgid ""
+"A new update is available. Click on the button below to update to the "
+"latest version."
+msgstr ""
+"En ny uppdatering är tillgänglig. Klicka på knappen nedan för att "
+"uppdatera till den senaste versionen."
 
 #: cps/updater.py:385
 msgid "Could not fetch update information"
@@ -744,12 +773,18 @@ msgstr "Ingen versionsinformation tillgänglig"
 
 #: cps/updater.py:456 cps/updater.py:467 cps/updater.py:486
 #, python-format
-msgid "A new update is available. Click on the button below to update to version: %(version)s"
-msgstr "En ny uppdatering är tillgänglig. Klicka på knappen nedan för att uppdatera till version: %(version)s"
+msgid ""
+"A new update is available. Click on the button below to update to "
+"version: %(version)s"
+msgstr ""
+"En ny uppdatering är tillgänglig. Klicka på knappen nedan för att "
+"uppdatera till version: %(version)s"
 
 #: cps/updater.py:477
 msgid "Click on the button below to update to the latest stable version."
-msgstr "Klicka på knappen nedan för att uppdatera till den senaste stabila versionen."
+msgstr ""
+"Klicka på knappen nedan för att uppdatera till den senaste stabila "
+"versionen."
 
 #: cps/web.py:480
 msgid "Recently Added Books"
@@ -768,8 +803,12 @@ msgid "Hot Books (Most Downloaded)"
 msgstr "Heta böcker (mest hämtade)"
 
 #: cps/web.py:580
-msgid "Oops! Selected book title is unavailable. File does not exist or is not accessible"
-msgstr "Hoppsan! Vald boktitel är inte tillgänglig. Filen finns inte eller är inte tillgänglig"
+msgid ""
+"Oops! Selected book title is unavailable. File does not exist or is not "
+"accessible"
+msgstr ""
+"Hoppsan! Vald boktitel är inte tillgänglig. Filen finns inte eller är "
+"inte tillgänglig"
 
 #: cps/web.py:593
 #, python-format
@@ -818,9 +857,9 @@ msgstr "Lista över filformat"
 msgid "Tasks"
 msgstr "Uppgifter"
 
-#: cps/templates/book_edit.html:212 cps/templates/feed.xml:33
-#: cps/templates/layout.html:44 cps/templates/layout.html:47
-#: cps/templates/search_form.html:170 cps/web.py:821 cps/web.py:823
+#: cps/templates/book_edit.html:212 cps/templates/layout.html:44
+#: cps/templates/layout.html:47 cps/templates/search_form.html:170
+#: cps/web.py:821 cps/web.py:823
 msgid "Search"
 msgstr "Sök"
 
@@ -892,7 +931,9 @@ msgstr "du är nu inloggad som: \"%(nickname)s\""
 
 #: cps/web.py:1155
 msgid "Could not login. LDAP server down, please contact your administrator"
-msgstr "Det gick inte att logga in. LDAP-servern är nere, kontakta din administratör"
+msgstr ""
+"Det gick inte att logga in. LDAP-servern är nere, kontakta din "
+"administratör"
 
 #: cps/web.py:1159 cps/web.py:1182
 msgid "Wrong Username or Password"
@@ -938,7 +979,9 @@ msgstr "Profilen uppdaterad"
 
 #: cps/web.py:1384 cps/web.py:1480
 msgid "Error opening eBook. File does not exist or file is not accessible:"
-msgstr "Fel vid öppningen av e-boken. Filen finns inte eller filen är inte tillgänglig:"
+msgstr ""
+"Fel vid öppningen av e-boken. Filen finns inte eller filen är inte "
+"tillgänglig:"
 
 #: cps/web.py:1396 cps/web.py:1399 cps/web.py:1402 cps/web.py:1409
 #: cps/web.py:1414
@@ -947,7 +990,9 @@ msgstr "Läs en bok"
 
 #: cps/web.py:1425
 msgid "Error opening eBook. File does not exist or file is not accessible."
-msgstr "Fel vid öppningen av e-boken. Filen finns inte eller filen är inte tillgänglig."
+msgstr ""
+"Fel vid öppningen av e-boken. Filen finns inte eller filen är inte "
+"tillgänglig."
 
 #: cps/worker.py:335
 #, python-format
@@ -959,189 +1004,189 @@ msgstr "E-bokkonverteraren misslyckades: %(error)s"
 msgid "Kindlegen failed with Error %(error)s. Message: %(message)s"
 msgstr "Kindlegen misslyckades med fel %(error)s. Meddelande: %(message)s"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html:8
 msgid "Users"
 msgstr "Användarlista"
 
-#: cps/templates/admin.html:12 cps/templates/login.html:8
+#: cps/templates/admin.html:11 cps/templates/login.html:8
 #: cps/templates/login.html:9 cps/templates/register.html:7
 #: cps/templates/user_edit.html:8
 msgid "Username"
 msgstr "Smeknamn"
 
-#: cps/templates/admin.html:13 cps/templates/register.html:11
+#: cps/templates/admin.html:12 cps/templates/register.html:11
 #: cps/templates/user_edit.html:13
 msgid "E-mail Address"
 msgstr "E-post"
 
-#: cps/templates/admin.html:14 cps/templates/user_edit.html:26
+#: cps/templates/admin.html:13 cps/templates/user_edit.html:26
 msgid "Send to Kindle E-mail Address"
 msgstr "Kindle"
 
-#: cps/templates/admin.html:15
+#: cps/templates/admin.html:14
 msgid "Downloads"
 msgstr "DLS"
 
-#: cps/templates/admin.html:16 cps/templates/layout.html:76
+#: cps/templates/admin.html:15 cps/templates/layout.html:76
 msgid "Admin"
 msgstr "Administratör"
 
-#: cps/templates/admin.html:17 cps/templates/detail.html:18
+#: cps/templates/admin.html:16 cps/templates/detail.html:18
 #: cps/templates/detail.html:27 cps/templates/shelf.html:6
 #: cps/templates/shelfdown.html:62
 msgid "Download"
 msgstr "Hämta"
 
-#: cps/templates/admin.html:18
+#: cps/templates/admin.html:17
 msgid "View Books"
 msgstr "Visa e-böcker"
 
-#: cps/templates/admin.html:19 cps/templates/layout.html:65
+#: cps/templates/admin.html:18 cps/templates/layout.html:65
 msgid "Upload"
 msgstr "Ladda upp"
 
-#: cps/templates/admin.html:20
+#: cps/templates/admin.html:19
 msgid "Edit"
 msgstr "Redigera"
 
-#: cps/templates/admin.html:38
+#: cps/templates/admin.html:37
 msgid "Add New User"
 msgstr "Lägg till ny användare"
 
-#: cps/templates/admin.html:44
+#: cps/templates/admin.html:43
 msgid "E-mail Server Settings"
 msgstr "Inställningar för SMTP-e-postserver"
 
-#: cps/templates/admin.html:47 cps/templates/email_edit.html:11
+#: cps/templates/admin.html:46 cps/templates/email_edit.html:11
 msgid "SMTP Hostname"
 msgstr "SMTP-värdnamn"
 
-#: cps/templates/admin.html:48 cps/templates/email_edit.html:15
+#: cps/templates/admin.html:47 cps/templates/email_edit.html:15
 msgid "SMTP Port"
 msgstr "SMTP-port"
 
-#: cps/templates/admin.html:49 cps/templates/email_edit.html:19
+#: cps/templates/admin.html:48 cps/templates/email_edit.html:19
 msgid "Encryption"
 msgstr "SSL"
 
-#: cps/templates/admin.html:50 cps/templates/email_edit.html:27
+#: cps/templates/admin.html:49 cps/templates/email_edit.html:27
 msgid "SMTP Login"
 msgstr "SMTP-inloggning"
 
-#: cps/templates/admin.html:51 cps/templates/email_edit.html:35
+#: cps/templates/admin.html:50 cps/templates/email_edit.html:35
 msgid "From E-mail"
 msgstr "Från meddelande"
 
-#: cps/templates/admin.html:61
+#: cps/templates/admin.html:60
 msgid "Edit E-mail Server Settings"
 msgstr "Ändra SMTP-inställningar"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html:66
 msgid "Configuration"
 msgstr "Konfiguration"
 
-#: cps/templates/admin.html:70
+#: cps/templates/admin.html:69
 msgid "Calibre Database Directory"
 msgstr "Calibre DB dir"
 
-#: cps/templates/admin.html:74 cps/templates/config_edit.html:122
+#: cps/templates/admin.html:73 cps/templates/config_edit.html:122
 msgid "Log Level"
 msgstr "Loggnivå"
 
-#: cps/templates/admin.html:78
+#: cps/templates/admin.html:77
 msgid "Port"
 msgstr "Port"
 
-#: cps/templates/admin.html:84 cps/templates/config_view_edit.html:27
+#: cps/templates/admin.html:83 cps/templates/config_view_edit.html:27
 msgid "Books per Page"
 msgstr "Böcker per sida"
 
-#: cps/templates/admin.html:88
+#: cps/templates/admin.html:87
 msgid "Uploads"
 msgstr "Laddar upp"
 
-#: cps/templates/admin.html:92
+#: cps/templates/admin.html:91
 msgid "Anonymous Browsing"
 msgstr "Anonym surfning"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html:95
 msgid "Public Registration"
 msgstr "Publik registrering"
 
-#: cps/templates/admin.html:100
+#: cps/templates/admin.html:99
 msgid "Magic Link Remote Login"
 msgstr "Fjärrinloggning"
 
-#: cps/templates/admin.html:104
+#: cps/templates/admin.html:103
 msgid "Reverse Proxy Login"
 msgstr "Omvänd proxy inloggning"
 
-#: cps/templates/admin.html:109
+#: cps/templates/admin.html:108
 msgid "Reverse proxy header name"
 msgstr "Omvänt proxy rubriknamn"
 
-#: cps/templates/admin.html:114
+#: cps/templates/admin.html:113
 msgid "Edit Basic Configuration"
 msgstr "Redigera grundläggande konfiguration"
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html:114
 msgid "Edit UI Configuration"
 msgstr "Redigera UI-konfiguration"
 
-#: cps/templates/admin.html:121
+#: cps/templates/admin.html:120
 msgid "Administration"
 msgstr "Administration"
 
-#: cps/templates/admin.html:122
+#: cps/templates/admin.html:121
 msgid "View Logs"
 msgstr "Visa loggfiler"
 
-#: cps/templates/admin.html:123
+#: cps/templates/admin.html:122
 msgid "Reconnect Calibre Database"
 msgstr "Anslut till Calibre DB igen"
 
-#: cps/templates/admin.html:124
+#: cps/templates/admin.html:123
 msgid "Restart"
 msgstr "Starta om Calibre-Web"
 
-#: cps/templates/admin.html:125
+#: cps/templates/admin.html:124
 msgid "Shutdown"
 msgstr "Stoppa Calibre-Web"
 
-#: cps/templates/admin.html:131
+#: cps/templates/admin.html:130
 msgid "Update"
 msgstr "Uppdatera"
 
-#: cps/templates/admin.html:135
+#: cps/templates/admin.html:134
 msgid "Version"
 msgstr "Version"
 
-#: cps/templates/admin.html:136
+#: cps/templates/admin.html:135
 msgid "Details"
 msgstr "Detaljer"
 
-#: cps/templates/admin.html:142
+#: cps/templates/admin.html:141
 msgid "Current version"
 msgstr "Aktuell version"
 
-#: cps/templates/admin.html:148
+#: cps/templates/admin.html:147
 msgid "Check for Update"
 msgstr "Sök efter uppdatering"
 
-#: cps/templates/admin.html:149
+#: cps/templates/admin.html:148
 msgid "Perform Update"
 msgstr "Utför uppdatering"
 
-#: cps/templates/admin.html:161
+#: cps/templates/admin.html:160
 msgid "Are you sure you want to restart?"
 msgstr "Är du säker på att du vill starta om Calibre-Web?"
 
-#: cps/templates/admin.html:166 cps/templates/admin.html:180
-#: cps/templates/admin.html:200 cps/templates/shelf.html:72
+#: cps/templates/admin.html:165 cps/templates/admin.html:179
+#: cps/templates/admin.html:199 cps/templates/shelf.html:72
 msgid "OK"
 msgstr "Ok"
 
-#: cps/templates/admin.html:167 cps/templates/admin.html:181
+#: cps/templates/admin.html:166 cps/templates/admin.html:180
 #: cps/templates/book_edit.html:172 cps/templates/book_edit.html:194
 #: cps/templates/config_edit.html:346 cps/templates/config_view_edit.html:151
 #: cps/templates/email_edit.html:40 cps/templates/email_edit.html:92
@@ -1150,11 +1195,11 @@ msgstr "Ok"
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: cps/templates/admin.html:179
+#: cps/templates/admin.html:178
 msgid "Are you sure you want to shutdown?"
 msgstr "Är du säker på att du vill stoppa Calibre-Web?"
 
-#: cps/templates/admin.html:191
+#: cps/templates/admin.html:190
 msgid "Updating, please do not reload this page"
 msgstr "Uppdaterar, vänligen uppdatera inte sidan"
 
@@ -1243,8 +1288,12 @@ msgid "Rating"
 msgstr "Betyg"
 
 #: cps/templates/book_edit.html:81
-msgid "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
-msgstr "Omslagswebbadress (jpg, omslag hämtas och lagras i databasen, fältet är efteråt tomt igen)"
+msgid ""
+"Fetch Cover from URL (JPEG - Image will be downloaded and stored in "
+"database)"
+msgstr ""
+"Omslagswebbadress (jpg, omslag hämtas och lagras i databasen, fältet är "
+"efteråt tomt igen)"
 
 #: cps/templates/book_edit.html:85
 msgid "Upload Cover from Local Disk"
@@ -1777,18 +1826,11 @@ msgstr "Nekade domäner för registrering"
 msgid "Are you sure you want to delete this domain?"
 msgstr "Är du säker på att du vill ta bort den här domänregeln?"
 
-#: cps/templates/feed.xml:21 cps/templates/layout.html:173
-msgid "Next"
-msgstr "Nästa"
-
-#: cps/templates/feed.xml:79 cps/templates/layout.html:136
-#: cps/templates/layout.html:140
-msgid "(Public)"
-msgstr ""
-
 #: cps/templates/generate_kobo_auth_url.html:5
 msgid "Open the .kobo/Kobo eReader.conf file in a text editor and add (or edit):"
-msgstr "Öppna filen .kobo/Kobo eReader.conf i en textredigerare och lägg till (eller redigera):"
+msgstr ""
+"Öppna filen .kobo/Kobo eReader.conf i en textredigerare och lägg till "
+"(eller redigera):"
 
 #: cps/templates/http_error.html:38
 msgid "Create Issue"
@@ -1801,70 +1843,6 @@ msgstr "Tillbaka till hemmet"
 #: cps/templates/index.html:64
 msgid "Group by series"
 msgstr "Gruppera efter serie"
-
-#: cps/templates/index.xml:6
-msgid "Start"
-msgstr "Starta"
-
-#: cps/templates/index.xml:21
-msgid "Popular publications from this catalog based on Downloads."
-msgstr "Populära publikationer från den här katalogen baserad på hämtningar."
-
-#: cps/templates/index.xml:28
-msgid "Popular publications from this catalog based on Rating."
-msgstr "Populära publikationer från den här katalogen baserad på betyg."
-
-#: cps/templates/index.xml:31
-msgid "Recently added Books"
-msgstr "Senaste tillagda böcker"
-
-#: cps/templates/index.xml:35
-msgid "The latest Books"
-msgstr "De senaste böckerna"
-
-#: cps/templates/index.xml:38
-msgid "Random Books"
-msgstr "Slumpmässiga böcker"
-
-#: cps/templates/index.xml:42 cps/templates/user_edit.html:80
-msgid "Show Random Books"
-msgstr "Visa slumpmässiga böcker"
-
-#: cps/templates/index.xml:65
-msgid "Books ordered by Author"
-msgstr "Böcker ordnade efter författare"
-
-#: cps/templates/index.xml:72
-msgid "Books ordered by publisher"
-msgstr "Böcker ordnade efter förlag"
-
-#: cps/templates/index.xml:79
-msgid "Books ordered by category"
-msgstr "Böcker ordnade efter kategori"
-
-#: cps/templates/index.xml:86
-msgid "Books ordered by series"
-msgstr "Böcker ordnade efter serier"
-
-#: cps/templates/index.xml:93
-msgid "Books ordered by Languages"
-msgstr "Böcker ordnade efter språk"
-
-#: cps/templates/index.xml:100
-msgid "Books ordered by Rating"
-msgstr "Böcker sorterade efter Betyg"
-
-#: cps/templates/index.xml:108
-msgid "Books ordered by file formats"
-msgstr "Böcker ordnade av filformat"
-
-#: cps/templates/index.xml:111 cps/templates/layout.html:134
-msgid "Shelves"
-msgstr ""
-
-#: cps/templates/index.xml:115
-msgid "Books organized in shelves"
-msgstr ""
 
 #: cps/templates/layout.html:28
 msgid "Home"
@@ -1916,6 +1894,14 @@ msgstr "Vänligen uppdatera inte sidan"
 msgid "Browse"
 msgstr "Bläddra"
 
+#: cps/templates/layout.html:134
+msgid "Shelves"
+msgstr ""
+
+#: cps/templates/layout.html:136 cps/templates/layout.html:140
+msgid "(Public)"
+msgstr ""
+
 #: cps/templates/layout.html:138
 msgid "Your Shelves"
 msgstr "Dina hyllor"
@@ -1927,6 +1913,10 @@ msgstr "Om"
 #: cps/templates/layout.html:158
 msgid "Previous"
 msgstr "Föregående"
+
+#: cps/templates/layout.html:173
+msgid "Next"
+msgstr "Nästa"
 
 #: cps/templates/layout.html:185
 msgid "Book Details"
@@ -2309,6 +2299,10 @@ msgstr "Kobo Sync Token"
 msgid "Create/View"
 msgstr "Skapa/Visa"
 
+#: cps/templates/user_edit.html:80
+msgid "Show Random Books"
+msgstr "Visa slumpmässiga böcker"
+
 #: cps/templates/user_edit.html:84
 msgid "Add allowed/Denied Custom Column Values"
 msgstr "Lägg till tillåtna/avvisade anpassade kolumnvärden"
@@ -2328,4 +2322,208 @@ msgstr "Skapa Kobo Auth URL"
 #: cps/templates/user_edit.html:176
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "Vill du verkligen ta bort Kobo-token?"
+
+#: vendor/tornado/locale.py:285
+msgid "January"
+msgstr ""
+
+#: vendor/tornado/locale.py:286
+msgid "February"
+msgstr ""
+
+#: vendor/tornado/locale.py:287
+msgid "March"
+msgstr ""
+
+#: vendor/tornado/locale.py:288
+msgid "April"
+msgstr ""
+
+#: vendor/tornado/locale.py:289
+msgid "May"
+msgstr ""
+
+#: vendor/tornado/locale.py:290
+msgid "June"
+msgstr ""
+
+#: vendor/tornado/locale.py:291
+msgid "July"
+msgstr ""
+
+#: vendor/tornado/locale.py:292
+msgid "August"
+msgstr ""
+
+#: vendor/tornado/locale.py:293
+msgid "September"
+msgstr ""
+
+#: vendor/tornado/locale.py:294
+msgid "October"
+msgstr ""
+
+#: vendor/tornado/locale.py:295
+msgid "November"
+msgstr ""
+
+#: vendor/tornado/locale.py:296
+msgid "December"
+msgstr ""
+
+#: vendor/tornado/locale.py:299
+msgid "Monday"
+msgstr ""
+
+#: vendor/tornado/locale.py:300
+msgid "Tuesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:301
+msgid "Wednesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:302
+msgid "Thursday"
+msgstr ""
+
+#: vendor/tornado/locale.py:303
+msgid "Friday"
+msgstr ""
+
+#: vendor/tornado/locale.py:304
+msgid "Saturday"
+msgstr ""
+
+#: vendor/tornado/locale.py:305
+msgid "Sunday"
+msgstr ""
+
+#: vendor/tornado/locale.py:368
+msgid "1 second ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:374
+msgid "1 minute ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:379
+msgid "1 hour ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:382
+#, python-format
+msgid "%(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+msgid "yesterday"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+#, python-format
+msgid "yesterday at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:389 vendor/tornado/locale.py:442
+#, python-format
+msgid "%(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:391
+#, python-format
+msgid "%(month_name)s %(day)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:396
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:398
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:436
+#, python-format
+msgid "%(weekday)s, %(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:459
+#, python-format
+msgid "%(commas)s and %(last)s"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:68
+msgctxt "law"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:69
+msgctxt "good"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:71 vendor/tornado/test/locale_test.py:74
+msgctxt "organization"
+msgid "club"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:76 vendor/tornado/test/locale_test.py:77
+msgctxt "stick"
+msgid "club"
+msgstr ""
+
+#~ msgid "Start"
+#~ msgstr "Starta"
+
+#~ msgid "Popular publications from this catalog based on Downloads."
+#~ msgstr "Populära publikationer från den här katalogen baserad på hämtningar."
+
+#~ msgid "Popular publications from this catalog based on Rating."
+#~ msgstr "Populära publikationer från den här katalogen baserad på betyg."
+
+#~ msgid "Recently added Books"
+#~ msgstr "Senaste tillagda böcker"
+
+#~ msgid "The latest Books"
+#~ msgstr "De senaste böckerna"
+
+#~ msgid "Random Books"
+#~ msgstr "Slumpmässiga böcker"
+
+#~ msgid "Books ordered by Author"
+#~ msgstr "Böcker ordnade efter författare"
+
+#~ msgid "Books ordered by publisher"
+#~ msgstr "Böcker ordnade efter förlag"
+
+#~ msgid "Books ordered by category"
+#~ msgstr "Böcker ordnade efter kategori"
+
+#~ msgid "Books ordered by series"
+#~ msgstr "Böcker ordnade efter serier"
+
+#~ msgid "Books ordered by Languages"
+#~ msgstr "Böcker ordnade efter språk"
+
+#~ msgid "Books ordered by Rating"
+#~ msgstr "Böcker sorterade efter Betyg"
+
+#~ msgid "Books ordered by file formats"
+#~ msgstr "Böcker ordnade av filformat"
+
+#~ msgid "Books organized in shelves"
+#~ msgstr ""
 

--- a/cps/translations/uk/LC_MESSAGES/messages.po
+++ b/cps/translations/uk/LC_MESSAGES/messages.po
@@ -6,12 +6,13 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Calibre-web\n"
 "Report-Msgid-Bugs-To: https://github.com/janeczku/calibre-web\n"
-"POT-Creation-Date: 2020-04-03 19:49+0200\n"
+"POT-Creation-Date: 2020-04-08 23:10+0800\n"
 "PO-Revision-Date: 2017-04-30 00:47+0300\n"
 "Last-Translator: ABIS Team <biblio.if.abis@gmail.com>\n"
 "Language: uk\n"
 "Language-Team: \n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -219,7 +220,9 @@ msgstr ""
 
 #: cps/editbooks.py:214 cps/editbooks.py:396
 msgid "Error opening eBook. File does not exist or file is not accessible"
-msgstr "Сталась помилка при відкриванні eBook. Файл не існує або відсутній доступ до нього"
+msgstr ""
+"Сталась помилка при відкриванні eBook. Файл не існує або відсутній доступ"
+" до нього"
 
 #: cps/editbooks.py:242
 msgid "edit metadata"
@@ -264,7 +267,9 @@ msgstr ""
 
 #: cps/editbooks.py:534
 msgid "Error editing book, please check logfile for details"
-msgstr "Сталась помилка при редагуванні книги. Будь-ласка, перевірте лог-файл для деталей"
+msgstr ""
+"Сталась помилка при редагуванні книги. Будь-ласка, перевірте лог-файл для"
+" деталей"
 
 #: cps/editbooks.py:581
 #, python-format
@@ -272,7 +277,9 @@ msgid "File %(filename)s could not saved to temp dir"
 msgstr ""
 
 #: cps/editbooks.py:598
-msgid "Uploaded book probably exists in the library, consider to change before upload new: "
+msgid ""
+"Uploaded book probably exists in the library, consider to change before "
+"upload new: "
 msgstr ""
 
 #: cps/editbooks.py:613
@@ -305,12 +312,18 @@ msgid "There was an error converting this book: %(res)s"
 msgstr ""
 
 #: cps/gdrive.py:61
-msgid "Google Drive setup not completed, try to deactivate and activate Google Drive again"
+msgid ""
+"Google Drive setup not completed, try to deactivate and activate Google "
+"Drive again"
 msgstr ""
 
 #: cps/gdrive.py:103
-msgid "Callback domain is not verified, please follow steps to verify domain in google developer console"
-msgstr "Домен зворотнього зв'язку не підтверджено. Виконайте дії для підтвердження домену, будь-ласка"
+msgid ""
+"Callback domain is not verified, please follow steps to verify domain in "
+"google developer console"
+msgstr ""
+"Домен зворотнього зв'язку не підтверджено. Виконайте дії для "
+"підтвердження домену, будь-ласка"
 
 #: cps/helper.py:80
 #, python-format
@@ -455,7 +468,9 @@ msgid "Unknown Task: "
 msgstr ""
 
 #: cps/kobo_auth.py:127
-msgid "PLease access calibre-web from non localhost to get valid api_endpoint for kobo device"
+msgid ""
+"PLease access calibre-web from non localhost to get valid api_endpoint "
+"for kobo device"
 msgstr ""
 
 #: cps/kobo_auth.py:130 cps/kobo_auth.py:150
@@ -602,7 +617,9 @@ msgstr "Книжкова полиця: '%(name)s'"
 
 #: cps/shelf.py:330
 msgid "Error opening shelf. Shelf does not exist or is not accessible"
-msgstr "Помилка при відкриванні полиці. Полиця не існує або до неї відсутній доступ"
+msgstr ""
+"Помилка при відкриванні полиці. Полиця не існує або до неї відсутній "
+"доступ"
 
 #: cps/shelf.py:368
 msgid "Hidden Book"
@@ -621,7 +638,7 @@ msgstr "Останні додані"
 msgid "Show recent books"
 msgstr "Показувати останні книги"
 
-#: cps/templates/index.xml:17 cps/ub.py:59
+#: cps/ub.py:59
 msgid "Hot Books"
 msgstr "Популярні книги"
 
@@ -629,7 +646,7 @@ msgstr "Популярні книги"
 msgid "Show Hot Books"
 msgstr "Показувати популярні книги"
 
-#: cps/templates/index.xml:24 cps/ub.py:63 cps/web.py:508
+#: cps/ub.py:63 cps/web.py:508
 msgid "Top Rated Books"
 msgstr "Книги з найкращим рейтингом"
 
@@ -637,8 +654,7 @@ msgstr "Книги з найкращим рейтингом"
 msgid "Show Top Rated Books"
 msgstr "Показувати книги з найвищим рейтингом"
 
-#: cps/templates/index.xml:46 cps/templates/index.xml:50 cps/ub.py:66
-#: cps/web.py:1005
+#: cps/ub.py:66 cps/web.py:1005
 msgid "Read Books"
 msgstr "Прочитані книги"
 
@@ -646,8 +662,7 @@ msgstr "Прочитані книги"
 msgid "Show read and unread"
 msgstr "Показувати прочитані та непрочитані книги"
 
-#: cps/templates/index.xml:53 cps/templates/index.xml:57 cps/ub.py:70
-#: cps/web.py:1009
+#: cps/ub.py:70 cps/web.py:1009
 msgid "Unread Books"
 msgstr "Непрочитані книги"
 
@@ -663,7 +678,7 @@ msgstr "Огляд"
 msgid "Show random books"
 msgstr "Показувати випадкові книги"
 
-#: cps/templates/index.xml:75 cps/ub.py:76 cps/web.py:787
+#: cps/ub.py:76 cps/web.py:787
 msgid "Categories"
 msgstr "Категорії"
 
@@ -671,8 +686,8 @@ msgstr "Категорії"
 msgid "Show category selection"
 msgstr "Показувати вибір категорії"
 
-#: cps/templates/book_edit.html:69 cps/templates/index.xml:82
-#: cps/templates/search_form.html:53 cps/ub.py:79 cps/web.py:715
+#: cps/templates/book_edit.html:69 cps/templates/search_form.html:53
+#: cps/ub.py:79 cps/web.py:715
 msgid "Series"
 msgstr "Серії"
 
@@ -680,7 +695,7 @@ msgstr "Серії"
 msgid "Show series selection"
 msgstr "Показувати вибір серії"
 
-#: cps/templates/index.xml:61 cps/ub.py:82
+#: cps/ub.py:82
 msgid "Authors"
 msgstr "Автори"
 
@@ -688,7 +703,7 @@ msgstr "Автори"
 msgid "Show author selection"
 msgstr "Показувати вибір автора"
 
-#: cps/templates/index.xml:68 cps/ub.py:86 cps/web.py:699
+#: cps/ub.py:86 cps/web.py:699
 msgid "Publishers"
 msgstr ""
 
@@ -696,8 +711,7 @@ msgstr ""
 msgid "Show publisher selection"
 msgstr ""
 
-#: cps/templates/index.xml:89 cps/templates/search_form.html:74 cps/ub.py:89
-#: cps/web.py:770
+#: cps/templates/search_form.html:74 cps/ub.py:89 cps/web.py:770
 msgid "Languages"
 msgstr "Мови"
 
@@ -705,7 +719,7 @@ msgstr "Мови"
 msgid "Show language selection"
 msgstr "Показувати вибір мови"
 
-#: cps/templates/index.xml:96 cps/ub.py:93
+#: cps/ub.py:93
 msgid "Ratings"
 msgstr ""
 
@@ -713,7 +727,7 @@ msgstr ""
 msgid "Show ratings selection"
 msgstr ""
 
-#: cps/templates/index.xml:104 cps/ub.py:96
+#: cps/ub.py:96
 msgid "File formats"
 msgstr ""
 
@@ -730,7 +744,9 @@ msgid "No update available. You already have the latest version installed"
 msgstr ""
 
 #: cps/updater.py:333
-msgid "A new update is available. Click on the button below to update to the latest version."
+msgid ""
+"A new update is available. Click on the button below to update to the "
+"latest version."
 msgstr ""
 
 #: cps/updater.py:385
@@ -743,7 +759,9 @@ msgstr ""
 
 #: cps/updater.py:456 cps/updater.py:467 cps/updater.py:486
 #, python-format
-msgid "A new update is available. Click on the button below to update to version: %(version)s"
+msgid ""
+"A new update is available. Click on the button below to update to "
+"version: %(version)s"
 msgstr ""
 
 #: cps/updater.py:477
@@ -767,7 +785,9 @@ msgid "Hot Books (Most Downloaded)"
 msgstr "Популярні книги (найбільш завантажувані)"
 
 #: cps/web.py:580
-msgid "Oops! Selected book title is unavailable. File does not exist or is not accessible"
+msgid ""
+"Oops! Selected book title is unavailable. File does not exist or is not "
+"accessible"
 msgstr "Неможливо відкрити книгу. Файл не існує або немає доступу."
 
 #: cps/web.py:593
@@ -817,9 +837,9 @@ msgstr ""
 msgid "Tasks"
 msgstr ""
 
-#: cps/templates/book_edit.html:212 cps/templates/feed.xml:33
-#: cps/templates/layout.html:44 cps/templates/layout.html:47
-#: cps/templates/search_form.html:170 cps/web.py:821 cps/web.py:823
+#: cps/templates/book_edit.html:212 cps/templates/layout.html:44
+#: cps/templates/layout.html:47 cps/templates/search_form.html:170
+#: cps/web.py:821 cps/web.py:823
 msgid "Search"
 msgstr "Пошук"
 
@@ -958,189 +978,189 @@ msgstr ""
 msgid "Kindlegen failed with Error %(error)s. Message: %(message)s"
 msgstr "Kindlegen відхилено з помилкою %(error)s. Повідомлення: %(message)s "
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html:8
 msgid "Users"
 msgstr "Список користувачів"
 
-#: cps/templates/admin.html:12 cps/templates/login.html:8
+#: cps/templates/admin.html:11 cps/templates/login.html:8
 #: cps/templates/login.html:9 cps/templates/register.html:7
 #: cps/templates/user_edit.html:8
 msgid "Username"
 msgstr "Ім'я користувача"
 
-#: cps/templates/admin.html:13 cps/templates/register.html:11
+#: cps/templates/admin.html:12 cps/templates/register.html:11
 #: cps/templates/user_edit.html:13
 msgid "E-mail Address"
 msgstr ""
 
-#: cps/templates/admin.html:14 cps/templates/user_edit.html:26
+#: cps/templates/admin.html:13 cps/templates/user_edit.html:26
 msgid "Send to Kindle E-mail Address"
 msgstr "Kindle"
 
-#: cps/templates/admin.html:15
+#: cps/templates/admin.html:14
 msgid "Downloads"
 msgstr "DLS"
 
-#: cps/templates/admin.html:16 cps/templates/layout.html:76
+#: cps/templates/admin.html:15 cps/templates/layout.html:76
 msgid "Admin"
 msgstr "Адмін"
 
-#: cps/templates/admin.html:17 cps/templates/detail.html:18
+#: cps/templates/admin.html:16 cps/templates/detail.html:18
 #: cps/templates/detail.html:27 cps/templates/shelf.html:6
 #: cps/templates/shelfdown.html:62
 msgid "Download"
 msgstr "Завантажити"
 
-#: cps/templates/admin.html:18
+#: cps/templates/admin.html:17
 msgid "View Books"
 msgstr ""
 
-#: cps/templates/admin.html:19 cps/templates/layout.html:65
+#: cps/templates/admin.html:18 cps/templates/layout.html:65
 msgid "Upload"
 msgstr "Додати нову книгу"
 
-#: cps/templates/admin.html:20
+#: cps/templates/admin.html:19
 msgid "Edit"
 msgstr "Редагувати"
 
-#: cps/templates/admin.html:38
+#: cps/templates/admin.html:37
 msgid "Add New User"
 msgstr ""
 
-#: cps/templates/admin.html:44
+#: cps/templates/admin.html:43
 msgid "E-mail Server Settings"
 msgstr ""
 
-#: cps/templates/admin.html:47 cps/templates/email_edit.html:11
+#: cps/templates/admin.html:46 cps/templates/email_edit.html:11
 msgid "SMTP Hostname"
 msgstr "SMTP-сервер"
 
-#: cps/templates/admin.html:48 cps/templates/email_edit.html:15
+#: cps/templates/admin.html:47 cps/templates/email_edit.html:15
 msgid "SMTP Port"
 msgstr "SMTP-порт"
 
-#: cps/templates/admin.html:49 cps/templates/email_edit.html:19
+#: cps/templates/admin.html:48 cps/templates/email_edit.html:19
 msgid "Encryption"
 msgstr "SSL"
 
-#: cps/templates/admin.html:50 cps/templates/email_edit.html:27
+#: cps/templates/admin.html:49 cps/templates/email_edit.html:27
 msgid "SMTP Login"
 msgstr "SMTP логін"
 
-#: cps/templates/admin.html:51 cps/templates/email_edit.html:35
+#: cps/templates/admin.html:50 cps/templates/email_edit.html:35
 msgid "From E-mail"
 msgstr "Відправник"
 
-#: cps/templates/admin.html:61
+#: cps/templates/admin.html:60
 msgid "Edit E-mail Server Settings"
 msgstr "Змінити налаштування SMTP"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html:66
 msgid "Configuration"
 msgstr "Налаштування сервера"
 
-#: cps/templates/admin.html:70
+#: cps/templates/admin.html:69
 msgid "Calibre Database Directory"
 msgstr "Папка Calibre DB"
 
-#: cps/templates/admin.html:74 cps/templates/config_edit.html:122
+#: cps/templates/admin.html:73 cps/templates/config_edit.html:122
 msgid "Log Level"
 msgstr ""
 
-#: cps/templates/admin.html:78
+#: cps/templates/admin.html:77
 msgid "Port"
 msgstr "Порт"
 
-#: cps/templates/admin.html:84 cps/templates/config_view_edit.html:27
+#: cps/templates/admin.html:83 cps/templates/config_view_edit.html:27
 msgid "Books per Page"
 msgstr "Кількість книг на сторінці"
 
-#: cps/templates/admin.html:88
+#: cps/templates/admin.html:87
 msgid "Uploads"
 msgstr "Загрузка на сервер"
 
-#: cps/templates/admin.html:92
+#: cps/templates/admin.html:91
 msgid "Anonymous Browsing"
 msgstr "Анонімний перегляд"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html:95
 msgid "Public Registration"
 msgstr "Публічна реєстрація"
 
-#: cps/templates/admin.html:100
+#: cps/templates/admin.html:99
 msgid "Magic Link Remote Login"
 msgstr ""
 
-#: cps/templates/admin.html:104
+#: cps/templates/admin.html:103
 msgid "Reverse Proxy Login"
 msgstr ""
 
-#: cps/templates/admin.html:109
+#: cps/templates/admin.html:108
 msgid "Reverse proxy header name"
 msgstr ""
 
-#: cps/templates/admin.html:114
+#: cps/templates/admin.html:113
 msgid "Edit Basic Configuration"
 msgstr ""
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html:114
 msgid "Edit UI Configuration"
 msgstr ""
 
-#: cps/templates/admin.html:121
+#: cps/templates/admin.html:120
 msgid "Administration"
 msgstr "Адміністрування"
 
-#: cps/templates/admin.html:122
+#: cps/templates/admin.html:121
 msgid "View Logs"
 msgstr ""
 
-#: cps/templates/admin.html:123
+#: cps/templates/admin.html:122
 msgid "Reconnect Calibre Database"
 msgstr "Повторне підключення до БД Calibre"
 
-#: cps/templates/admin.html:124
+#: cps/templates/admin.html:123
 msgid "Restart"
 msgstr ""
 
-#: cps/templates/admin.html:125
+#: cps/templates/admin.html:124
 msgid "Shutdown"
 msgstr ""
 
-#: cps/templates/admin.html:131
+#: cps/templates/admin.html:130
 msgid "Update"
 msgstr ""
 
-#: cps/templates/admin.html:135
+#: cps/templates/admin.html:134
 msgid "Version"
 msgstr ""
 
-#: cps/templates/admin.html:136
+#: cps/templates/admin.html:135
 msgid "Details"
 msgstr ""
 
-#: cps/templates/admin.html:142
+#: cps/templates/admin.html:141
 msgid "Current version"
 msgstr ""
 
-#: cps/templates/admin.html:148
+#: cps/templates/admin.html:147
 msgid "Check for Update"
 msgstr "Перевірка оновлень"
 
-#: cps/templates/admin.html:149
+#: cps/templates/admin.html:148
 msgid "Perform Update"
 msgstr "Встановити оновлення"
 
-#: cps/templates/admin.html:161
+#: cps/templates/admin.html:160
 msgid "Are you sure you want to restart?"
 msgstr ""
 
-#: cps/templates/admin.html:166 cps/templates/admin.html:180
-#: cps/templates/admin.html:200 cps/templates/shelf.html:72
+#: cps/templates/admin.html:165 cps/templates/admin.html:179
+#: cps/templates/admin.html:199 cps/templates/shelf.html:72
 msgid "OK"
 msgstr "Ok"
 
-#: cps/templates/admin.html:167 cps/templates/admin.html:181
+#: cps/templates/admin.html:166 cps/templates/admin.html:180
 #: cps/templates/book_edit.html:172 cps/templates/book_edit.html:194
 #: cps/templates/config_edit.html:346 cps/templates/config_view_edit.html:151
 #: cps/templates/email_edit.html:40 cps/templates/email_edit.html:92
@@ -1149,11 +1169,11 @@ msgstr "Ok"
 msgid "Cancel"
 msgstr ""
 
-#: cps/templates/admin.html:179
+#: cps/templates/admin.html:178
 msgid "Are you sure you want to shutdown?"
 msgstr ""
 
-#: cps/templates/admin.html:191
+#: cps/templates/admin.html:190
 msgid "Updating, please do not reload this page"
 msgstr "Встановлення оновлень, будь-ласка, не оновлюйте сторінку"
 
@@ -1242,7 +1262,9 @@ msgid "Rating"
 msgstr "Рейтинг"
 
 #: cps/templates/book_edit.html:81
-msgid "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
+msgid ""
+"Fetch Cover from URL (JPEG - Image will be downloaded and stored in "
+"database)"
 msgstr ""
 
 #: cps/templates/book_edit.html:85
@@ -1386,11 +1408,15 @@ msgstr "Порт сервера"
 
 #: cps/templates/config_edit.html:91
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
-msgstr "Розташування сертифіката SSL (залиште його порожнім для серверів, які не використовують SSL)"
+msgstr ""
+"Розташування сертифіката SSL (залиште його порожнім для серверів, які не "
+"використовують SSL)"
 
 #: cps/templates/config_edit.html:95
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
-msgstr "Розташування ключових слів SSL (залиште його порожнім для серверів, які не використовують SSL)"
+msgstr ""
+"Розташування ключових слів SSL (залиште його порожнім для серверів, які "
+"не використовують SSL)"
 
 #: cps/templates/config_edit.html:99
 msgid "Update Channel"
@@ -1776,15 +1802,6 @@ msgstr ""
 msgid "Are you sure you want to delete this domain?"
 msgstr ""
 
-#: cps/templates/feed.xml:21 cps/templates/layout.html:173
-msgid "Next"
-msgstr "Далі"
-
-#: cps/templates/feed.xml:79 cps/templates/layout.html:136
-#: cps/templates/layout.html:140
-msgid "(Public)"
-msgstr ""
-
 #: cps/templates/generate_kobo_auth_url.html:5
 msgid "Open the .kobo/Kobo eReader.conf file in a text editor and add (or edit):"
 msgstr ""
@@ -1799,70 +1816,6 @@ msgstr ""
 
 #: cps/templates/index.html:64
 msgid "Group by series"
-msgstr ""
-
-#: cps/templates/index.xml:6
-msgid "Start"
-msgstr "Старт"
-
-#: cps/templates/index.xml:21
-msgid "Popular publications from this catalog based on Downloads."
-msgstr "Популярні книги в цьому каталозі, на основі кількості завантажень"
-
-#: cps/templates/index.xml:28
-msgid "Popular publications from this catalog based on Rating."
-msgstr "Популярні книги з цього каталогу на основі рейтингу"
-
-#: cps/templates/index.xml:31
-msgid "Recently added Books"
-msgstr ""
-
-#: cps/templates/index.xml:35
-msgid "The latest Books"
-msgstr "Останні книги"
-
-#: cps/templates/index.xml:38
-msgid "Random Books"
-msgstr "Випадковий список книг"
-
-#: cps/templates/index.xml:42 cps/templates/user_edit.html:80
-msgid "Show Random Books"
-msgstr "Показувати випадкові книги"
-
-#: cps/templates/index.xml:65
-msgid "Books ordered by Author"
-msgstr "Книги відсортовані за автором"
-
-#: cps/templates/index.xml:72
-msgid "Books ordered by publisher"
-msgstr ""
-
-#: cps/templates/index.xml:79
-msgid "Books ordered by category"
-msgstr "Книги відсортовані за категоріями"
-
-#: cps/templates/index.xml:86
-msgid "Books ordered by series"
-msgstr "Книги відсортовані за серією"
-
-#: cps/templates/index.xml:93
-msgid "Books ordered by Languages"
-msgstr ""
-
-#: cps/templates/index.xml:100
-msgid "Books ordered by Rating"
-msgstr ""
-
-#: cps/templates/index.xml:108
-msgid "Books ordered by file formats"
-msgstr ""
-
-#: cps/templates/index.xml:111 cps/templates/layout.html:134
-msgid "Shelves"
-msgstr ""
-
-#: cps/templates/index.xml:115
-msgid "Books organized in shelves"
 msgstr ""
 
 #: cps/templates/layout.html:28
@@ -1915,6 +1868,14 @@ msgstr ""
 msgid "Browse"
 msgstr "Перегляд"
 
+#: cps/templates/layout.html:134
+msgid "Shelves"
+msgstr ""
+
+#: cps/templates/layout.html:136 cps/templates/layout.html:140
+msgid "(Public)"
+msgstr ""
+
 #: cps/templates/layout.html:138
 msgid "Your Shelves"
 msgstr "Ваші книжкові полиці"
@@ -1926,6 +1887,10 @@ msgstr "Про програму"
 #: cps/templates/layout.html:158
 msgid "Previous"
 msgstr "Попередній перегляд"
+
+#: cps/templates/layout.html:173
+msgid "Next"
+msgstr "Далі"
 
 #: cps/templates/layout.html:185
 msgid "Book Details"
@@ -2308,6 +2273,10 @@ msgstr ""
 msgid "Create/View"
 msgstr ""
 
+#: cps/templates/user_edit.html:80
+msgid "Show Random Books"
+msgstr "Показувати випадкові книги"
+
 #: cps/templates/user_edit.html:84
 msgid "Add allowed/Denied Custom Column Values"
 msgstr ""
@@ -2327,4 +2296,208 @@ msgstr ""
 #: cps/templates/user_edit.html:176
 msgid "Do you really want to delete the Kobo Token?"
 msgstr ""
+
+#: vendor/tornado/locale.py:285
+msgid "January"
+msgstr ""
+
+#: vendor/tornado/locale.py:286
+msgid "February"
+msgstr ""
+
+#: vendor/tornado/locale.py:287
+msgid "March"
+msgstr ""
+
+#: vendor/tornado/locale.py:288
+msgid "April"
+msgstr ""
+
+#: vendor/tornado/locale.py:289
+msgid "May"
+msgstr ""
+
+#: vendor/tornado/locale.py:290
+msgid "June"
+msgstr ""
+
+#: vendor/tornado/locale.py:291
+msgid "July"
+msgstr ""
+
+#: vendor/tornado/locale.py:292
+msgid "August"
+msgstr ""
+
+#: vendor/tornado/locale.py:293
+msgid "September"
+msgstr ""
+
+#: vendor/tornado/locale.py:294
+msgid "October"
+msgstr ""
+
+#: vendor/tornado/locale.py:295
+msgid "November"
+msgstr ""
+
+#: vendor/tornado/locale.py:296
+msgid "December"
+msgstr ""
+
+#: vendor/tornado/locale.py:299
+msgid "Monday"
+msgstr ""
+
+#: vendor/tornado/locale.py:300
+msgid "Tuesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:301
+msgid "Wednesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:302
+msgid "Thursday"
+msgstr ""
+
+#: vendor/tornado/locale.py:303
+msgid "Friday"
+msgstr ""
+
+#: vendor/tornado/locale.py:304
+msgid "Saturday"
+msgstr ""
+
+#: vendor/tornado/locale.py:305
+msgid "Sunday"
+msgstr ""
+
+#: vendor/tornado/locale.py:368
+msgid "1 second ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:374
+msgid "1 minute ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:379
+msgid "1 hour ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:382
+#, python-format
+msgid "%(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+msgid "yesterday"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+#, python-format
+msgid "yesterday at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:389 vendor/tornado/locale.py:442
+#, python-format
+msgid "%(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:391
+#, python-format
+msgid "%(month_name)s %(day)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:396
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:398
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:436
+#, python-format
+msgid "%(weekday)s, %(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:459
+#, python-format
+msgid "%(commas)s and %(last)s"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:68
+msgctxt "law"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:69
+msgctxt "good"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:71 vendor/tornado/test/locale_test.py:74
+msgctxt "organization"
+msgid "club"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:76 vendor/tornado/test/locale_test.py:77
+msgctxt "stick"
+msgid "club"
+msgstr ""
+
+#~ msgid "Start"
+#~ msgstr "Старт"
+
+#~ msgid "Popular publications from this catalog based on Downloads."
+#~ msgstr "Популярні книги в цьому каталозі, на основі кількості завантажень"
+
+#~ msgid "Popular publications from this catalog based on Rating."
+#~ msgstr "Популярні книги з цього каталогу на основі рейтингу"
+
+#~ msgid "Recently added Books"
+#~ msgstr ""
+
+#~ msgid "The latest Books"
+#~ msgstr "Останні книги"
+
+#~ msgid "Random Books"
+#~ msgstr "Випадковий список книг"
+
+#~ msgid "Books ordered by Author"
+#~ msgstr "Книги відсортовані за автором"
+
+#~ msgid "Books ordered by publisher"
+#~ msgstr ""
+
+#~ msgid "Books ordered by category"
+#~ msgstr "Книги відсортовані за категоріями"
+
+#~ msgid "Books ordered by series"
+#~ msgstr "Книги відсортовані за серією"
+
+#~ msgid "Books ordered by Languages"
+#~ msgstr ""
+
+#~ msgid "Books ordered by Rating"
+#~ msgstr ""
+
+#~ msgid "Books ordered by file formats"
+#~ msgstr ""
+
+#~ msgid "Books organized in shelves"
+#~ msgstr ""
 

--- a/cps/translations/zh_Hans_CN/LC_MESSAGES/messages.po
+++ b/cps/translations/zh_Hans_CN/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Calibre-Web\n"
 "Report-Msgid-Bugs-To: https://github.com/janeczku/Calibre-Web\n"
-"POT-Creation-Date: 2020-04-03 19:49+0200\n"
+"POT-Creation-Date: 2020-04-08 23:10+0800\n"
 "PO-Revision-Date: 2017-01-06 17:00+0000\n"
 "Last-Translator: dalin <dalin.lin@gmail.com>\n"
 "Language: zh_Hans_CN\n"
@@ -273,7 +273,9 @@ msgid "File %(filename)s could not saved to temp dir"
 msgstr "文件 %(filename)s 无法保存到临时目录"
 
 #: cps/editbooks.py:598
-msgid "Uploaded book probably exists in the library, consider to change before upload new: "
+msgid ""
+"Uploaded book probably exists in the library, consider to change before "
+"upload new: "
 msgstr "上传的书籍可能已经存在，建议修改后重新上传："
 
 #: cps/editbooks.py:613
@@ -306,11 +308,15 @@ msgid "There was an error converting this book: %(res)s"
 msgstr "转换此书时出现错误： %(res)s"
 
 #: cps/gdrive.py:61
-msgid "Google Drive setup not completed, try to deactivate and activate Google Drive again"
+msgid ""
+"Google Drive setup not completed, try to deactivate and activate Google "
+"Drive again"
 msgstr "Google Drive 没有完成，试试重新关闭Google Drive再开启"
 
 #: cps/gdrive.py:103
-msgid "Callback domain is not verified, please follow steps to verify domain in google developer console"
+msgid ""
+"Callback domain is not verified, please follow steps to verify domain in "
+"google developer console"
 msgstr "回调域名尚未被校验，请在google开发者控制台按步骤校验域名"
 
 #: cps/helper.py:80
@@ -456,7 +462,9 @@ msgid "Unknown Task: "
 msgstr "未知任务："
 
 #: cps/kobo_auth.py:127
-msgid "PLease access calibre-web from non localhost to get valid api_endpoint for kobo device"
+msgid ""
+"PLease access calibre-web from non localhost to get valid api_endpoint "
+"for kobo device"
 msgstr "请不要使用localhost访问calibre-web，以便kobo设备能获取有效的api_endpoint"
 
 #: cps/kobo_auth.py:130 cps/kobo_auth.py:150
@@ -622,7 +630,7 @@ msgstr "最近添加"
 msgid "Show recent books"
 msgstr "显示最近书籍"
 
-#: cps/templates/index.xml:17 cps/ub.py:59
+#: cps/ub.py:59
 msgid "Hot Books"
 msgstr "热门书籍"
 
@@ -630,7 +638,7 @@ msgstr "热门书籍"
 msgid "Show Hot Books"
 msgstr "显示热门书籍"
 
-#: cps/templates/index.xml:24 cps/ub.py:63 cps/web.py:508
+#: cps/ub.py:63 cps/web.py:508
 msgid "Top Rated Books"
 msgstr "最高评分书籍"
 
@@ -638,8 +646,7 @@ msgstr "最高评分书籍"
 msgid "Show Top Rated Books"
 msgstr "显示最高评分书籍"
 
-#: cps/templates/index.xml:46 cps/templates/index.xml:50 cps/ub.py:66
-#: cps/web.py:1005
+#: cps/ub.py:66 cps/web.py:1005
 msgid "Read Books"
 msgstr "已读书籍"
 
@@ -647,8 +654,7 @@ msgstr "已读书籍"
 msgid "Show read and unread"
 msgstr "显示已读和未读"
 
-#: cps/templates/index.xml:53 cps/templates/index.xml:57 cps/ub.py:70
-#: cps/web.py:1009
+#: cps/ub.py:70 cps/web.py:1009
 msgid "Unread Books"
 msgstr "未读书籍"
 
@@ -664,7 +670,7 @@ msgstr "发现"
 msgid "Show random books"
 msgstr "显示随机书籍"
 
-#: cps/templates/index.xml:75 cps/ub.py:76 cps/web.py:787
+#: cps/ub.py:76 cps/web.py:787
 msgid "Categories"
 msgstr "分类"
 
@@ -672,8 +678,8 @@ msgstr "分类"
 msgid "Show category selection"
 msgstr "显示分类选择"
 
-#: cps/templates/book_edit.html:69 cps/templates/index.xml:82
-#: cps/templates/search_form.html:53 cps/ub.py:79 cps/web.py:715
+#: cps/templates/book_edit.html:69 cps/templates/search_form.html:53
+#: cps/ub.py:79 cps/web.py:715
 msgid "Series"
 msgstr "丛书"
 
@@ -681,7 +687,7 @@ msgstr "丛书"
 msgid "Show series selection"
 msgstr "显示丛书选择"
 
-#: cps/templates/index.xml:61 cps/ub.py:82
+#: cps/ub.py:82
 msgid "Authors"
 msgstr "作者"
 
@@ -689,7 +695,7 @@ msgstr "作者"
 msgid "Show author selection"
 msgstr "显示作者选择"
 
-#: cps/templates/index.xml:68 cps/ub.py:86 cps/web.py:699
+#: cps/ub.py:86 cps/web.py:699
 msgid "Publishers"
 msgstr "出版社"
 
@@ -697,8 +703,7 @@ msgstr "出版社"
 msgid "Show publisher selection"
 msgstr "显示出版社选择"
 
-#: cps/templates/index.xml:89 cps/templates/search_form.html:74 cps/ub.py:89
-#: cps/web.py:770
+#: cps/templates/search_form.html:74 cps/ub.py:89 cps/web.py:770
 msgid "Languages"
 msgstr "语言"
 
@@ -706,7 +711,7 @@ msgstr "语言"
 msgid "Show language selection"
 msgstr "显示语言选择"
 
-#: cps/templates/index.xml:96 cps/ub.py:93
+#: cps/ub.py:93
 msgid "Ratings"
 msgstr "评分"
 
@@ -714,7 +719,7 @@ msgstr "评分"
 msgid "Show ratings selection"
 msgstr "显示评分选择"
 
-#: cps/templates/index.xml:104 cps/ub.py:96
+#: cps/ub.py:96
 msgid "File formats"
 msgstr "文件格式"
 
@@ -731,7 +736,9 @@ msgid "No update available. You already have the latest version installed"
 msgstr "没有可用更新。您已经安装了最新版本"
 
 #: cps/updater.py:333
-msgid "A new update is available. Click on the button below to update to the latest version."
+msgid ""
+"A new update is available. Click on the button below to update to the "
+"latest version."
 msgstr "有一个更新可用。点击正文按钮更新到最新版本。"
 
 #: cps/updater.py:385
@@ -744,7 +751,9 @@ msgstr "没有可用发布信息"
 
 #: cps/updater.py:456 cps/updater.py:467 cps/updater.py:486
 #, python-format
-msgid "A new update is available. Click on the button below to update to version: %(version)s"
+msgid ""
+"A new update is available. Click on the button below to update to "
+"version: %(version)s"
 msgstr "一个新的更新可用。点击下面按钮更新到版本: %(version)s"
 
 #: cps/updater.py:477
@@ -768,7 +777,9 @@ msgid "Hot Books (Most Downloaded)"
 msgstr "热门书籍（最多下载）"
 
 #: cps/web.py:580
-msgid "Oops! Selected book title is unavailable. File does not exist or is not accessible"
+msgid ""
+"Oops! Selected book title is unavailable. File does not exist or is not "
+"accessible"
 msgstr "无法打开电子书。 文件不存在或者文件不可访问:"
 
 #: cps/web.py:593
@@ -818,9 +829,9 @@ msgstr "文件格式列表"
 msgid "Tasks"
 msgstr "任务"
 
-#: cps/templates/book_edit.html:212 cps/templates/feed.xml:33
-#: cps/templates/layout.html:44 cps/templates/layout.html:47
-#: cps/templates/search_form.html:170 cps/web.py:821 cps/web.py:823
+#: cps/templates/book_edit.html:212 cps/templates/layout.html:44
+#: cps/templates/layout.html:47 cps/templates/search_form.html:170
+#: cps/web.py:821 cps/web.py:823
 msgid "Search"
 msgstr "搜索"
 
@@ -959,189 +970,189 @@ msgstr "电子书转换器失败： %(error)s"
 msgid "Kindlegen failed with Error %(error)s. Message: %(message)s"
 msgstr "Kindlegen 因为错误 %(error)s 失败。消息： %(message)s"
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html:8
 msgid "Users"
 msgstr "用户列表"
 
-#: cps/templates/admin.html:12 cps/templates/login.html:8
+#: cps/templates/admin.html:11 cps/templates/login.html:8
 #: cps/templates/login.html:9 cps/templates/register.html:7
 #: cps/templates/user_edit.html:8
 msgid "Username"
 msgstr "昵称"
 
-#: cps/templates/admin.html:13 cps/templates/register.html:11
+#: cps/templates/admin.html:12 cps/templates/register.html:11
 #: cps/templates/user_edit.html:13
 msgid "E-mail Address"
 msgstr "邮箱"
 
-#: cps/templates/admin.html:14 cps/templates/user_edit.html:26
+#: cps/templates/admin.html:13 cps/templates/user_edit.html:26
 msgid "Send to Kindle E-mail Address"
 msgstr "Send to Kindle邮箱"
 
-#: cps/templates/admin.html:15
+#: cps/templates/admin.html:14
 msgid "Downloads"
 msgstr "下载量"
 
-#: cps/templates/admin.html:16 cps/templates/layout.html:76
+#: cps/templates/admin.html:15 cps/templates/layout.html:76
 msgid "Admin"
 msgstr "管理"
 
-#: cps/templates/admin.html:17 cps/templates/detail.html:18
+#: cps/templates/admin.html:16 cps/templates/detail.html:18
 #: cps/templates/detail.html:27 cps/templates/shelf.html:6
 #: cps/templates/shelfdown.html:62
 msgid "Download"
 msgstr "下载"
 
-#: cps/templates/admin.html:18
+#: cps/templates/admin.html:17
 msgid "View Books"
 msgstr "查看电子书"
 
-#: cps/templates/admin.html:19 cps/templates/layout.html:65
+#: cps/templates/admin.html:18 cps/templates/layout.html:65
 msgid "Upload"
 msgstr "上传"
 
-#: cps/templates/admin.html:20
+#: cps/templates/admin.html:19
 msgid "Edit"
 msgstr "编辑"
 
-#: cps/templates/admin.html:38
+#: cps/templates/admin.html:37
 msgid "Add New User"
 msgstr "新建用户"
 
-#: cps/templates/admin.html:44
+#: cps/templates/admin.html:43
 msgid "E-mail Server Settings"
 msgstr "SMTP邮件服务器设置"
 
-#: cps/templates/admin.html:47 cps/templates/email_edit.html:11
+#: cps/templates/admin.html:46 cps/templates/email_edit.html:11
 msgid "SMTP Hostname"
 msgstr "SMTP地址"
 
-#: cps/templates/admin.html:48 cps/templates/email_edit.html:15
+#: cps/templates/admin.html:47 cps/templates/email_edit.html:15
 msgid "SMTP Port"
 msgstr "SMTP端口"
 
-#: cps/templates/admin.html:49 cps/templates/email_edit.html:19
+#: cps/templates/admin.html:48 cps/templates/email_edit.html:19
 msgid "Encryption"
 msgstr "加密"
 
-#: cps/templates/admin.html:50 cps/templates/email_edit.html:27
+#: cps/templates/admin.html:49 cps/templates/email_edit.html:27
 msgid "SMTP Login"
 msgstr "SMTP用户名"
 
-#: cps/templates/admin.html:51 cps/templates/email_edit.html:35
+#: cps/templates/admin.html:50 cps/templates/email_edit.html:35
 msgid "From E-mail"
 msgstr "来自邮箱"
 
-#: cps/templates/admin.html:61
+#: cps/templates/admin.html:60
 msgid "Edit E-mail Server Settings"
 msgstr "修改SMTP设置"
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html:66
 msgid "Configuration"
 msgstr "配置"
 
-#: cps/templates/admin.html:70
+#: cps/templates/admin.html:69
 msgid "Calibre Database Directory"
 msgstr "Calibre DB目录"
 
-#: cps/templates/admin.html:74 cps/templates/config_edit.html:122
+#: cps/templates/admin.html:73 cps/templates/config_edit.html:122
 msgid "Log Level"
 msgstr "日志级别"
 
-#: cps/templates/admin.html:78
+#: cps/templates/admin.html:77
 msgid "Port"
 msgstr "端口"
 
-#: cps/templates/admin.html:84 cps/templates/config_view_edit.html:27
+#: cps/templates/admin.html:83 cps/templates/config_view_edit.html:27
 msgid "Books per Page"
 msgstr "每页书籍数"
 
-#: cps/templates/admin.html:88
+#: cps/templates/admin.html:87
 msgid "Uploads"
 msgstr "上传"
 
-#: cps/templates/admin.html:92
+#: cps/templates/admin.html:91
 msgid "Anonymous Browsing"
 msgstr "匿名浏览"
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html:95
 msgid "Public Registration"
 msgstr "开放注册"
 
-#: cps/templates/admin.html:100
+#: cps/templates/admin.html:99
 msgid "Magic Link Remote Login"
 msgstr "远程登录"
 
-#: cps/templates/admin.html:104
+#: cps/templates/admin.html:103
 msgid "Reverse Proxy Login"
 msgstr "反向代理登录"
 
-#: cps/templates/admin.html:109
+#: cps/templates/admin.html:108
 msgid "Reverse proxy header name"
 msgstr "反向代理header name"
 
-#: cps/templates/admin.html:114
+#: cps/templates/admin.html:113
 msgid "Edit Basic Configuration"
 msgstr "修改基本配置"
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html:114
 msgid "Edit UI Configuration"
 msgstr "修改界面配置"
 
-#: cps/templates/admin.html:121
+#: cps/templates/admin.html:120
 msgid "Administration"
 msgstr "管理"
 
-#: cps/templates/admin.html:122
+#: cps/templates/admin.html:121
 msgid "View Logs"
 msgstr "查看日志文件"
 
-#: cps/templates/admin.html:123
+#: cps/templates/admin.html:122
 msgid "Reconnect Calibre Database"
 msgstr "重新连接到Calibre数据库"
 
-#: cps/templates/admin.html:124
+#: cps/templates/admin.html:123
 msgid "Restart"
 msgstr "重启 Calibre-Web"
 
-#: cps/templates/admin.html:125
+#: cps/templates/admin.html:124
 msgid "Shutdown"
 msgstr "停止 Calibre-Web"
 
-#: cps/templates/admin.html:131
+#: cps/templates/admin.html:130
 msgid "Update"
 msgstr "更新"
 
-#: cps/templates/admin.html:135
+#: cps/templates/admin.html:134
 msgid "Version"
 msgstr "版本"
 
-#: cps/templates/admin.html:136
+#: cps/templates/admin.html:135
 msgid "Details"
 msgstr "详情"
 
-#: cps/templates/admin.html:142
+#: cps/templates/admin.html:141
 msgid "Current version"
 msgstr "当前版本"
 
-#: cps/templates/admin.html:148
+#: cps/templates/admin.html:147
 msgid "Check for Update"
 msgstr "检查更新"
 
-#: cps/templates/admin.html:149
+#: cps/templates/admin.html:148
 msgid "Perform Update"
 msgstr "执行更新"
 
-#: cps/templates/admin.html:161
+#: cps/templates/admin.html:160
 msgid "Are you sure you want to restart?"
 msgstr "您确定要重启 Calibre-Web 吗？"
 
-#: cps/templates/admin.html:166 cps/templates/admin.html:180
-#: cps/templates/admin.html:200 cps/templates/shelf.html:72
+#: cps/templates/admin.html:165 cps/templates/admin.html:179
+#: cps/templates/admin.html:199 cps/templates/shelf.html:72
 msgid "OK"
 msgstr "确定"
 
-#: cps/templates/admin.html:167 cps/templates/admin.html:181
+#: cps/templates/admin.html:166 cps/templates/admin.html:180
 #: cps/templates/book_edit.html:172 cps/templates/book_edit.html:194
 #: cps/templates/config_edit.html:346 cps/templates/config_view_edit.html:151
 #: cps/templates/email_edit.html:40 cps/templates/email_edit.html:92
@@ -1150,11 +1161,11 @@ msgstr "确定"
 msgid "Cancel"
 msgstr "取消"
 
-#: cps/templates/admin.html:179
+#: cps/templates/admin.html:178
 msgid "Are you sure you want to shutdown?"
 msgstr "您确定要关闭 Calibre-Web 吗？"
 
-#: cps/templates/admin.html:191
+#: cps/templates/admin.html:190
 msgid "Updating, please do not reload this page"
 msgstr "正在更新，请不要刷新页面"
 
@@ -1243,7 +1254,9 @@ msgid "Rating"
 msgstr "评分"
 
 #: cps/templates/book_edit.html:81
-msgid "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
+msgid ""
+"Fetch Cover from URL (JPEG - Image will be downloaded and stored in "
+"database)"
 msgstr "封面URL(jpg,封面会被下载被保存在数据库中，然后字段会被重新清空)"
 
 #: cps/templates/book_edit.html:85
@@ -1777,15 +1790,6 @@ msgstr "禁用的域名（黑名单）"
 msgid "Are you sure you want to delete this domain?"
 msgstr "您确定要删除这条域名规则吗？"
 
-#: cps/templates/feed.xml:21 cps/templates/layout.html:173
-msgid "Next"
-msgstr "下一个"
-
-#: cps/templates/feed.xml:79 cps/templates/layout.html:136
-#: cps/templates/layout.html:140
-msgid "(Public)"
-msgstr ""
-
 #: cps/templates/generate_kobo_auth_url.html:5
 msgid "Open the .kobo/Kobo eReader.conf file in a text editor and add (or edit):"
 msgstr "在文本编辑器中打开.kobo/Kobo eReader.conf，增加（修改为）:"
@@ -1801,70 +1805,6 @@ msgstr "回到首页"
 #: cps/templates/index.html:64
 msgid "Group by series"
 msgstr "根据系列分组"
-
-#: cps/templates/index.xml:6
-msgid "Start"
-msgstr "开始"
-
-#: cps/templates/index.xml:21
-msgid "Popular publications from this catalog based on Downloads."
-msgstr "基于下载数的热门书籍"
-
-#: cps/templates/index.xml:28
-msgid "Popular publications from this catalog based on Rating."
-msgstr "基于评分的热门书籍"
-
-#: cps/templates/index.xml:31
-msgid "Recently added Books"
-msgstr "最近添加的书籍"
-
-#: cps/templates/index.xml:35
-msgid "The latest Books"
-msgstr "最新书籍"
-
-#: cps/templates/index.xml:38
-msgid "Random Books"
-msgstr "随机书籍"
-
-#: cps/templates/index.xml:42 cps/templates/user_edit.html:80
-msgid "Show Random Books"
-msgstr "显示随机书籍"
-
-#: cps/templates/index.xml:65
-msgid "Books ordered by Author"
-msgstr "书籍按作者排序"
-
-#: cps/templates/index.xml:72
-msgid "Books ordered by publisher"
-msgstr "书籍按出版社排版"
-
-#: cps/templates/index.xml:79
-msgid "Books ordered by category"
-msgstr "书籍按分类排序"
-
-#: cps/templates/index.xml:86
-msgid "Books ordered by series"
-msgstr "书籍按丛书排序"
-
-#: cps/templates/index.xml:93
-msgid "Books ordered by Languages"
-msgstr "根据语言排序书籍"
-
-#: cps/templates/index.xml:100
-msgid "Books ordered by Rating"
-msgstr ""
-
-#: cps/templates/index.xml:108
-msgid "Books ordered by file formats"
-msgstr "根据文件类型排序书籍"
-
-#: cps/templates/index.xml:111 cps/templates/layout.html:134
-msgid "Shelves"
-msgstr ""
-
-#: cps/templates/index.xml:115
-msgid "Books organized in shelves"
-msgstr ""
 
 #: cps/templates/layout.html:28
 msgid "Home"
@@ -1916,6 +1856,14 @@ msgstr "请不要刷新页面"
 msgid "Browse"
 msgstr "浏览"
 
+#: cps/templates/layout.html:134
+msgid "Shelves"
+msgstr ""
+
+#: cps/templates/layout.html:136 cps/templates/layout.html:140
+msgid "(Public)"
+msgstr ""
+
 #: cps/templates/layout.html:138
 msgid "Your Shelves"
 msgstr "您的书架"
@@ -1927,6 +1875,10 @@ msgstr "关于"
 #: cps/templates/layout.html:158
 msgid "Previous"
 msgstr "上一个"
+
+#: cps/templates/layout.html:173
+msgid "Next"
+msgstr "下一个"
 
 #: cps/templates/layout.html:185
 msgid "Book Details"
@@ -2309,6 +2261,10 @@ msgstr ""
 msgid "Create/View"
 msgstr "新建/查看"
 
+#: cps/templates/user_edit.html:80
+msgid "Show Random Books"
+msgstr "显示随机书籍"
+
 #: cps/templates/user_edit.html:84
 msgid "Add allowed/Denied Custom Column Values"
 msgstr "添加（允许/禁止）自定义栏值"
@@ -2328,4 +2284,208 @@ msgstr "生成Kobo Auth URL"
 #: cps/templates/user_edit.html:176
 msgid "Do you really want to delete the Kobo Token?"
 msgstr "您确定删除Kobo Token吗？"
+
+#: vendor/tornado/locale.py:285
+msgid "January"
+msgstr ""
+
+#: vendor/tornado/locale.py:286
+msgid "February"
+msgstr ""
+
+#: vendor/tornado/locale.py:287
+msgid "March"
+msgstr ""
+
+#: vendor/tornado/locale.py:288
+msgid "April"
+msgstr ""
+
+#: vendor/tornado/locale.py:289
+msgid "May"
+msgstr ""
+
+#: vendor/tornado/locale.py:290
+msgid "June"
+msgstr ""
+
+#: vendor/tornado/locale.py:291
+msgid "July"
+msgstr ""
+
+#: vendor/tornado/locale.py:292
+msgid "August"
+msgstr ""
+
+#: vendor/tornado/locale.py:293
+msgid "September"
+msgstr ""
+
+#: vendor/tornado/locale.py:294
+msgid "October"
+msgstr ""
+
+#: vendor/tornado/locale.py:295
+msgid "November"
+msgstr ""
+
+#: vendor/tornado/locale.py:296
+msgid "December"
+msgstr ""
+
+#: vendor/tornado/locale.py:299
+msgid "Monday"
+msgstr ""
+
+#: vendor/tornado/locale.py:300
+msgid "Tuesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:301
+msgid "Wednesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:302
+msgid "Thursday"
+msgstr ""
+
+#: vendor/tornado/locale.py:303
+msgid "Friday"
+msgstr ""
+
+#: vendor/tornado/locale.py:304
+msgid "Saturday"
+msgstr ""
+
+#: vendor/tornado/locale.py:305
+msgid "Sunday"
+msgstr ""
+
+#: vendor/tornado/locale.py:368
+msgid "1 second ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:374
+msgid "1 minute ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:379
+msgid "1 hour ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:382
+#, python-format
+msgid "%(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+msgid "yesterday"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+#, python-format
+msgid "yesterday at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:389 vendor/tornado/locale.py:442
+#, python-format
+msgid "%(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:391
+#, python-format
+msgid "%(month_name)s %(day)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:396
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:398
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:436
+#, python-format
+msgid "%(weekday)s, %(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:459
+#, python-format
+msgid "%(commas)s and %(last)s"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:68
+msgctxt "law"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:69
+msgctxt "good"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:71 vendor/tornado/test/locale_test.py:74
+msgctxt "organization"
+msgid "club"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:76 vendor/tornado/test/locale_test.py:77
+msgctxt "stick"
+msgid "club"
+msgstr ""
+
+#~ msgid "Start"
+#~ msgstr "开始"
+
+#~ msgid "Popular publications from this catalog based on Downloads."
+#~ msgstr "基于下载数的热门书籍"
+
+#~ msgid "Popular publications from this catalog based on Rating."
+#~ msgstr "基于评分的热门书籍"
+
+#~ msgid "Recently added Books"
+#~ msgstr "最近添加的书籍"
+
+#~ msgid "The latest Books"
+#~ msgstr "最新书籍"
+
+#~ msgid "Random Books"
+#~ msgstr "随机书籍"
+
+#~ msgid "Books ordered by Author"
+#~ msgstr "书籍按作者排序"
+
+#~ msgid "Books ordered by publisher"
+#~ msgstr "书籍按出版社排版"
+
+#~ msgid "Books ordered by category"
+#~ msgstr "书籍按分类排序"
+
+#~ msgid "Books ordered by series"
+#~ msgstr "书籍按丛书排序"
+
+#~ msgid "Books ordered by Languages"
+#~ msgstr "根据语言排序书籍"
+
+#~ msgid "Books ordered by Rating"
+#~ msgstr ""
+
+#~ msgid "Books ordered by file formats"
+#~ msgstr "根据文件类型排序书籍"
+
+#~ msgid "Books organized in shelves"
+#~ msgstr ""
 

--- a/messages.pot
+++ b/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-04-03 19:49+0200\n"
+"POT-Creation-Date: 2020-04-08 23:10+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -272,7 +272,9 @@ msgid "File %(filename)s could not saved to temp dir"
 msgstr ""
 
 #: cps/editbooks.py:598
-msgid "Uploaded book probably exists in the library, consider to change before upload new: "
+msgid ""
+"Uploaded book probably exists in the library, consider to change before "
+"upload new: "
 msgstr ""
 
 #: cps/editbooks.py:613
@@ -305,11 +307,15 @@ msgid "There was an error converting this book: %(res)s"
 msgstr ""
 
 #: cps/gdrive.py:61
-msgid "Google Drive setup not completed, try to deactivate and activate Google Drive again"
+msgid ""
+"Google Drive setup not completed, try to deactivate and activate Google "
+"Drive again"
 msgstr ""
 
 #: cps/gdrive.py:103
-msgid "Callback domain is not verified, please follow steps to verify domain in google developer console"
+msgid ""
+"Callback domain is not verified, please follow steps to verify domain in "
+"google developer console"
 msgstr ""
 
 #: cps/helper.py:80
@@ -455,7 +461,9 @@ msgid "Unknown Task: "
 msgstr ""
 
 #: cps/kobo_auth.py:127
-msgid "PLease access calibre-web from non localhost to get valid api_endpoint for kobo device"
+msgid ""
+"PLease access calibre-web from non localhost to get valid api_endpoint "
+"for kobo device"
 msgstr ""
 
 #: cps/kobo_auth.py:130 cps/kobo_auth.py:150
@@ -621,7 +629,7 @@ msgstr ""
 msgid "Show recent books"
 msgstr ""
 
-#: cps/templates/index.xml:17 cps/ub.py:59
+#: cps/ub.py:59
 msgid "Hot Books"
 msgstr ""
 
@@ -629,7 +637,7 @@ msgstr ""
 msgid "Show Hot Books"
 msgstr ""
 
-#: cps/templates/index.xml:24 cps/ub.py:63 cps/web.py:508
+#: cps/ub.py:63 cps/web.py:508
 msgid "Top Rated Books"
 msgstr ""
 
@@ -637,8 +645,7 @@ msgstr ""
 msgid "Show Top Rated Books"
 msgstr ""
 
-#: cps/templates/index.xml:46 cps/templates/index.xml:50 cps/ub.py:66
-#: cps/web.py:1005
+#: cps/ub.py:66 cps/web.py:1005
 msgid "Read Books"
 msgstr ""
 
@@ -646,8 +653,7 @@ msgstr ""
 msgid "Show read and unread"
 msgstr ""
 
-#: cps/templates/index.xml:53 cps/templates/index.xml:57 cps/ub.py:70
-#: cps/web.py:1009
+#: cps/ub.py:70 cps/web.py:1009
 msgid "Unread Books"
 msgstr ""
 
@@ -663,7 +669,7 @@ msgstr ""
 msgid "Show random books"
 msgstr ""
 
-#: cps/templates/index.xml:75 cps/ub.py:76 cps/web.py:787
+#: cps/ub.py:76 cps/web.py:787
 msgid "Categories"
 msgstr ""
 
@@ -671,8 +677,8 @@ msgstr ""
 msgid "Show category selection"
 msgstr ""
 
-#: cps/templates/book_edit.html:69 cps/templates/index.xml:82
-#: cps/templates/search_form.html:53 cps/ub.py:79 cps/web.py:715
+#: cps/templates/book_edit.html:69 cps/templates/search_form.html:53
+#: cps/ub.py:79 cps/web.py:715
 msgid "Series"
 msgstr ""
 
@@ -680,7 +686,7 @@ msgstr ""
 msgid "Show series selection"
 msgstr ""
 
-#: cps/templates/index.xml:61 cps/ub.py:82
+#: cps/ub.py:82
 msgid "Authors"
 msgstr ""
 
@@ -688,7 +694,7 @@ msgstr ""
 msgid "Show author selection"
 msgstr ""
 
-#: cps/templates/index.xml:68 cps/ub.py:86 cps/web.py:699
+#: cps/ub.py:86 cps/web.py:699
 msgid "Publishers"
 msgstr ""
 
@@ -696,8 +702,7 @@ msgstr ""
 msgid "Show publisher selection"
 msgstr ""
 
-#: cps/templates/index.xml:89 cps/templates/search_form.html:74 cps/ub.py:89
-#: cps/web.py:770
+#: cps/templates/search_form.html:74 cps/ub.py:89 cps/web.py:770
 msgid "Languages"
 msgstr ""
 
@@ -705,7 +710,7 @@ msgstr ""
 msgid "Show language selection"
 msgstr ""
 
-#: cps/templates/index.xml:96 cps/ub.py:93
+#: cps/ub.py:93
 msgid "Ratings"
 msgstr ""
 
@@ -713,7 +718,7 @@ msgstr ""
 msgid "Show ratings selection"
 msgstr ""
 
-#: cps/templates/index.xml:104 cps/ub.py:96
+#: cps/ub.py:96
 msgid "File formats"
 msgstr ""
 
@@ -730,7 +735,9 @@ msgid "No update available. You already have the latest version installed"
 msgstr ""
 
 #: cps/updater.py:333
-msgid "A new update is available. Click on the button below to update to the latest version."
+msgid ""
+"A new update is available. Click on the button below to update to the "
+"latest version."
 msgstr ""
 
 #: cps/updater.py:385
@@ -743,7 +750,9 @@ msgstr ""
 
 #: cps/updater.py:456 cps/updater.py:467 cps/updater.py:486
 #, python-format
-msgid "A new update is available. Click on the button below to update to version: %(version)s"
+msgid ""
+"A new update is available. Click on the button below to update to "
+"version: %(version)s"
 msgstr ""
 
 #: cps/updater.py:477
@@ -767,7 +776,9 @@ msgid "Hot Books (Most Downloaded)"
 msgstr ""
 
 #: cps/web.py:580
-msgid "Oops! Selected book title is unavailable. File does not exist or is not accessible"
+msgid ""
+"Oops! Selected book title is unavailable. File does not exist or is not "
+"accessible"
 msgstr ""
 
 #: cps/web.py:593
@@ -817,9 +828,9 @@ msgstr ""
 msgid "Tasks"
 msgstr ""
 
-#: cps/templates/book_edit.html:212 cps/templates/feed.xml:33
-#: cps/templates/layout.html:44 cps/templates/layout.html:47
-#: cps/templates/search_form.html:170 cps/web.py:821 cps/web.py:823
+#: cps/templates/book_edit.html:212 cps/templates/layout.html:44
+#: cps/templates/layout.html:47 cps/templates/search_form.html:170
+#: cps/web.py:821 cps/web.py:823
 msgid "Search"
 msgstr ""
 
@@ -958,189 +969,189 @@ msgstr ""
 msgid "Kindlegen failed with Error %(error)s. Message: %(message)s"
 msgstr ""
 
-#: cps/templates/admin.html:9
+#: cps/templates/admin.html:8
 msgid "Users"
 msgstr ""
 
-#: cps/templates/admin.html:12 cps/templates/login.html:8
+#: cps/templates/admin.html:11 cps/templates/login.html:8
 #: cps/templates/login.html:9 cps/templates/register.html:7
 #: cps/templates/user_edit.html:8
 msgid "Username"
 msgstr ""
 
-#: cps/templates/admin.html:13 cps/templates/register.html:11
+#: cps/templates/admin.html:12 cps/templates/register.html:11
 #: cps/templates/user_edit.html:13
 msgid "E-mail Address"
 msgstr ""
 
-#: cps/templates/admin.html:14 cps/templates/user_edit.html:26
+#: cps/templates/admin.html:13 cps/templates/user_edit.html:26
 msgid "Send to Kindle E-mail Address"
 msgstr ""
 
-#: cps/templates/admin.html:15
+#: cps/templates/admin.html:14
 msgid "Downloads"
 msgstr ""
 
-#: cps/templates/admin.html:16 cps/templates/layout.html:76
+#: cps/templates/admin.html:15 cps/templates/layout.html:76
 msgid "Admin"
 msgstr ""
 
-#: cps/templates/admin.html:17 cps/templates/detail.html:18
+#: cps/templates/admin.html:16 cps/templates/detail.html:18
 #: cps/templates/detail.html:27 cps/templates/shelf.html:6
 #: cps/templates/shelfdown.html:62
 msgid "Download"
 msgstr ""
 
-#: cps/templates/admin.html:18
+#: cps/templates/admin.html:17
 msgid "View Books"
 msgstr ""
 
-#: cps/templates/admin.html:19 cps/templates/layout.html:65
+#: cps/templates/admin.html:18 cps/templates/layout.html:65
 msgid "Upload"
 msgstr ""
 
-#: cps/templates/admin.html:20
+#: cps/templates/admin.html:19
 msgid "Edit"
 msgstr ""
 
-#: cps/templates/admin.html:38
+#: cps/templates/admin.html:37
 msgid "Add New User"
 msgstr ""
 
-#: cps/templates/admin.html:44
+#: cps/templates/admin.html:43
 msgid "E-mail Server Settings"
 msgstr ""
 
-#: cps/templates/admin.html:47 cps/templates/email_edit.html:11
+#: cps/templates/admin.html:46 cps/templates/email_edit.html:11
 msgid "SMTP Hostname"
 msgstr ""
 
-#: cps/templates/admin.html:48 cps/templates/email_edit.html:15
+#: cps/templates/admin.html:47 cps/templates/email_edit.html:15
 msgid "SMTP Port"
 msgstr ""
 
-#: cps/templates/admin.html:49 cps/templates/email_edit.html:19
+#: cps/templates/admin.html:48 cps/templates/email_edit.html:19
 msgid "Encryption"
 msgstr ""
 
-#: cps/templates/admin.html:50 cps/templates/email_edit.html:27
+#: cps/templates/admin.html:49 cps/templates/email_edit.html:27
 msgid "SMTP Login"
 msgstr ""
 
-#: cps/templates/admin.html:51 cps/templates/email_edit.html:35
+#: cps/templates/admin.html:50 cps/templates/email_edit.html:35
 msgid "From E-mail"
 msgstr ""
 
-#: cps/templates/admin.html:61
+#: cps/templates/admin.html:60
 msgid "Edit E-mail Server Settings"
 msgstr ""
 
-#: cps/templates/admin.html:67
+#: cps/templates/admin.html:66
 msgid "Configuration"
 msgstr ""
 
-#: cps/templates/admin.html:70
+#: cps/templates/admin.html:69
 msgid "Calibre Database Directory"
 msgstr ""
 
-#: cps/templates/admin.html:74 cps/templates/config_edit.html:122
+#: cps/templates/admin.html:73 cps/templates/config_edit.html:122
 msgid "Log Level"
 msgstr ""
 
-#: cps/templates/admin.html:78
+#: cps/templates/admin.html:77
 msgid "Port"
 msgstr ""
 
-#: cps/templates/admin.html:84 cps/templates/config_view_edit.html:27
+#: cps/templates/admin.html:83 cps/templates/config_view_edit.html:27
 msgid "Books per Page"
 msgstr ""
 
-#: cps/templates/admin.html:88
+#: cps/templates/admin.html:87
 msgid "Uploads"
 msgstr ""
 
-#: cps/templates/admin.html:92
+#: cps/templates/admin.html:91
 msgid "Anonymous Browsing"
 msgstr ""
 
-#: cps/templates/admin.html:96
+#: cps/templates/admin.html:95
 msgid "Public Registration"
 msgstr ""
 
-#: cps/templates/admin.html:100
+#: cps/templates/admin.html:99
 msgid "Magic Link Remote Login"
 msgstr ""
 
-#: cps/templates/admin.html:104
+#: cps/templates/admin.html:103
 msgid "Reverse Proxy Login"
 msgstr ""
 
-#: cps/templates/admin.html:109
+#: cps/templates/admin.html:108
 msgid "Reverse proxy header name"
 msgstr ""
 
-#: cps/templates/admin.html:114
+#: cps/templates/admin.html:113
 msgid "Edit Basic Configuration"
 msgstr ""
 
-#: cps/templates/admin.html:115
+#: cps/templates/admin.html:114
 msgid "Edit UI Configuration"
 msgstr ""
 
-#: cps/templates/admin.html:121
+#: cps/templates/admin.html:120
 msgid "Administration"
 msgstr ""
 
-#: cps/templates/admin.html:122
+#: cps/templates/admin.html:121
 msgid "View Logs"
 msgstr ""
 
-#: cps/templates/admin.html:123
+#: cps/templates/admin.html:122
 msgid "Reconnect Calibre Database"
 msgstr ""
 
-#: cps/templates/admin.html:124
+#: cps/templates/admin.html:123
 msgid "Restart"
 msgstr ""
 
-#: cps/templates/admin.html:125
+#: cps/templates/admin.html:124
 msgid "Shutdown"
 msgstr ""
 
-#: cps/templates/admin.html:131
+#: cps/templates/admin.html:130
 msgid "Update"
 msgstr ""
 
-#: cps/templates/admin.html:135
+#: cps/templates/admin.html:134
 msgid "Version"
 msgstr ""
 
-#: cps/templates/admin.html:136
+#: cps/templates/admin.html:135
 msgid "Details"
 msgstr ""
 
-#: cps/templates/admin.html:142
+#: cps/templates/admin.html:141
 msgid "Current version"
 msgstr ""
 
-#: cps/templates/admin.html:148
+#: cps/templates/admin.html:147
 msgid "Check for Update"
 msgstr ""
 
-#: cps/templates/admin.html:149
+#: cps/templates/admin.html:148
 msgid "Perform Update"
 msgstr ""
 
-#: cps/templates/admin.html:161
+#: cps/templates/admin.html:160
 msgid "Are you sure you want to restart?"
 msgstr ""
 
-#: cps/templates/admin.html:166 cps/templates/admin.html:180
-#: cps/templates/admin.html:200 cps/templates/shelf.html:72
+#: cps/templates/admin.html:165 cps/templates/admin.html:179
+#: cps/templates/admin.html:199 cps/templates/shelf.html:72
 msgid "OK"
 msgstr ""
 
-#: cps/templates/admin.html:167 cps/templates/admin.html:181
+#: cps/templates/admin.html:166 cps/templates/admin.html:180
 #: cps/templates/book_edit.html:172 cps/templates/book_edit.html:194
 #: cps/templates/config_edit.html:346 cps/templates/config_view_edit.html:151
 #: cps/templates/email_edit.html:40 cps/templates/email_edit.html:92
@@ -1149,11 +1160,11 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: cps/templates/admin.html:179
+#: cps/templates/admin.html:178
 msgid "Are you sure you want to shutdown?"
 msgstr ""
 
-#: cps/templates/admin.html:191
+#: cps/templates/admin.html:190
 msgid "Updating, please do not reload this page"
 msgstr ""
 
@@ -1242,7 +1253,9 @@ msgid "Rating"
 msgstr ""
 
 #: cps/templates/book_edit.html:81
-msgid "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
+msgid ""
+"Fetch Cover from URL (JPEG - Image will be downloaded and stored in "
+"database)"
 msgstr ""
 
 #: cps/templates/book_edit.html:85
@@ -1776,15 +1789,6 @@ msgstr ""
 msgid "Are you sure you want to delete this domain?"
 msgstr ""
 
-#: cps/templates/feed.xml:21 cps/templates/layout.html:173
-msgid "Next"
-msgstr ""
-
-#: cps/templates/feed.xml:79 cps/templates/layout.html:136
-#: cps/templates/layout.html:140
-msgid "(Public)"
-msgstr ""
-
 #: cps/templates/generate_kobo_auth_url.html:5
 msgid "Open the .kobo/Kobo eReader.conf file in a text editor and add (or edit):"
 msgstr ""
@@ -1799,70 +1803,6 @@ msgstr ""
 
 #: cps/templates/index.html:64
 msgid "Group by series"
-msgstr ""
-
-#: cps/templates/index.xml:6
-msgid "Start"
-msgstr ""
-
-#: cps/templates/index.xml:21
-msgid "Popular publications from this catalog based on Downloads."
-msgstr ""
-
-#: cps/templates/index.xml:28
-msgid "Popular publications from this catalog based on Rating."
-msgstr ""
-
-#: cps/templates/index.xml:31
-msgid "Recently added Books"
-msgstr ""
-
-#: cps/templates/index.xml:35
-msgid "The latest Books"
-msgstr ""
-
-#: cps/templates/index.xml:38
-msgid "Random Books"
-msgstr ""
-
-#: cps/templates/index.xml:42 cps/templates/user_edit.html:80
-msgid "Show Random Books"
-msgstr ""
-
-#: cps/templates/index.xml:65
-msgid "Books ordered by Author"
-msgstr ""
-
-#: cps/templates/index.xml:72
-msgid "Books ordered by publisher"
-msgstr ""
-
-#: cps/templates/index.xml:79
-msgid "Books ordered by category"
-msgstr ""
-
-#: cps/templates/index.xml:86
-msgid "Books ordered by series"
-msgstr ""
-
-#: cps/templates/index.xml:93
-msgid "Books ordered by Languages"
-msgstr ""
-
-#: cps/templates/index.xml:100
-msgid "Books ordered by Rating"
-msgstr ""
-
-#: cps/templates/index.xml:108
-msgid "Books ordered by file formats"
-msgstr ""
-
-#: cps/templates/index.xml:111 cps/templates/layout.html:134
-msgid "Shelves"
-msgstr ""
-
-#: cps/templates/index.xml:115
-msgid "Books organized in shelves"
 msgstr ""
 
 #: cps/templates/layout.html:28
@@ -1915,6 +1855,14 @@ msgstr ""
 msgid "Browse"
 msgstr ""
 
+#: cps/templates/layout.html:134
+msgid "Shelves"
+msgstr ""
+
+#: cps/templates/layout.html:136 cps/templates/layout.html:140
+msgid "(Public)"
+msgstr ""
+
 #: cps/templates/layout.html:138
 msgid "Your Shelves"
 msgstr ""
@@ -1925,6 +1873,10 @@ msgstr ""
 
 #: cps/templates/layout.html:158
 msgid "Previous"
+msgstr ""
+
+#: cps/templates/layout.html:173
+msgid "Next"
 msgstr ""
 
 #: cps/templates/layout.html:185
@@ -2308,6 +2260,10 @@ msgstr ""
 msgid "Create/View"
 msgstr ""
 
+#: cps/templates/user_edit.html:80
+msgid "Show Random Books"
+msgstr ""
+
 #: cps/templates/user_edit.html:84
 msgid "Add allowed/Denied Custom Column Values"
 msgstr ""
@@ -2326,5 +2282,167 @@ msgstr ""
 
 #: cps/templates/user_edit.html:176
 msgid "Do you really want to delete the Kobo Token?"
+msgstr ""
+
+#: vendor/tornado/locale.py:285
+msgid "January"
+msgstr ""
+
+#: vendor/tornado/locale.py:286
+msgid "February"
+msgstr ""
+
+#: vendor/tornado/locale.py:287
+msgid "March"
+msgstr ""
+
+#: vendor/tornado/locale.py:288
+msgid "April"
+msgstr ""
+
+#: vendor/tornado/locale.py:289
+msgid "May"
+msgstr ""
+
+#: vendor/tornado/locale.py:290
+msgid "June"
+msgstr ""
+
+#: vendor/tornado/locale.py:291
+msgid "July"
+msgstr ""
+
+#: vendor/tornado/locale.py:292
+msgid "August"
+msgstr ""
+
+#: vendor/tornado/locale.py:293
+msgid "September"
+msgstr ""
+
+#: vendor/tornado/locale.py:294
+msgid "October"
+msgstr ""
+
+#: vendor/tornado/locale.py:295
+msgid "November"
+msgstr ""
+
+#: vendor/tornado/locale.py:296
+msgid "December"
+msgstr ""
+
+#: vendor/tornado/locale.py:299
+msgid "Monday"
+msgstr ""
+
+#: vendor/tornado/locale.py:300
+msgid "Tuesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:301
+msgid "Wednesday"
+msgstr ""
+
+#: vendor/tornado/locale.py:302
+msgid "Thursday"
+msgstr ""
+
+#: vendor/tornado/locale.py:303
+msgid "Friday"
+msgstr ""
+
+#: vendor/tornado/locale.py:304
+msgid "Saturday"
+msgstr ""
+
+#: vendor/tornado/locale.py:305
+msgid "Sunday"
+msgstr ""
+
+#: vendor/tornado/locale.py:368
+msgid "1 second ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:374
+msgid "1 minute ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:379
+msgid "1 hour ago"
+msgstr ""
+
+#: vendor/tornado/locale.py:382
+#, python-format
+msgid "%(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+msgid "yesterday"
+msgstr ""
+
+#: vendor/tornado/locale.py:384
+#, python-format
+msgid "yesterday at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:386
+#, python-format
+msgid "%(weekday)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:389 vendor/tornado/locale.py:442
+#, python-format
+msgid "%(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:391
+#, python-format
+msgid "%(month_name)s %(day)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:396
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:398
+#, python-format
+msgid "%(month_name)s %(day)s, %(year)s at %(time)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:436
+#, python-format
+msgid "%(weekday)s, %(month_name)s %(day)s"
+msgstr ""
+
+#: vendor/tornado/locale.py:459
+#, python-format
+msgid "%(commas)s and %(last)s"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:68
+msgctxt "law"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:69
+msgctxt "good"
+msgid "right"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:71 vendor/tornado/test/locale_test.py:74
+msgctxt "organization"
+msgid "club"
+msgstr ""
+
+#: vendor/tornado/test/locale_test.py:76 vendor/tornado/test/locale_test.py:77
+msgctxt "stick"
+msgid "club"
 msgstr ""
 


### PR DESCRIPTION
There are several errors in current opds templetes.

* ~~Not using absolute URL~~
* Not specifying `kind` in `type`
* Some titles and contents are identical

This PR fixes all above. Due to string changes, I also regenerated the translation files. If that's not correct, I can remove that commit.