### PR TITLE
Changing ordering logic when showing books from a category

### DIFF
--- a/cps/web.py
+++ b/cps/web.py
@@ -709,7 +709,7 @@ def render_category_books(page, book_id, order):
     name = db.session.query(db.Tags).filter(db.Tags.id == book_id).first()
     if name:
         entries, random, pagination = fill_indexpage(page, db.Books, db.Books.tags.any(db.Tags.id == book_id),
-                                                     [db.Series.name, db.Books.series_index, order[0]],
+                                                     [order[0], db.Series.name, db.Books.series_index],
                                                      db.books_series_link, db.Series)
         return render_title_template('index.html', random=random, entries=entries, pagination=pagination, id=book_id,
                                  title=_(u"Category: %(name)s", name=name.name), page="category")


### PR DESCRIPTION
Hello,

I am trying to use categories as a first proxy to create story arcs, where I mix multiple series in one big story.

To be able to order them, I was currently using the publication date. When I was using it, I was surprised that the books were first ordered by series before the date.

This PR is about ordering first the books by the dates and then using series information if needed.