### PR TITLE
Fix https github oauth

### DIFF
--- a/cps/__init__.py
+++ b/cps/__init__.py
@@ -36,7 +36,7 @@ from flask_principal import Principal
 from . import logger, cache_buster, cli, config_sql, ub, db, services
 from .reverseproxy import ReverseProxied
 from .server import WebServer
-
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 mimetypes.init()
 mimetypes.add_type('application/xhtml+xml', '.xhtml')
@@ -77,7 +77,7 @@ log = logger.create()
 
 
 def create_app():
-    app.wsgi_app = ReverseProxied(app.wsgi_app)
+    app.wsgi_app = ReverseProxied(ProxyFix(app.wsgi_app, x_for=1, x_host=1))
     # For python2 convert path to unicode
     if sys.version_info < (3, 0):
         app.static_folder = app.static_folder.decode('utf-8')


### PR DESCRIPTION
@OzzieIsaacs After spending several hours digging the github oauth problem #1307 , I finally makes it work with https domains.
First, the nginx configuration is needed to properly proxy the real domain and protocol to Flask, following [this example](https://flask.palletsprojects.com/en/1.0.x/deploying/wsgi-standalone/#deploying-proxy-setups).
And pyopenssl model is required: `pip3 install -U pyopenssl`.
Finally, import `ProxyFix` to make flask properly identity https protocols.
Feel free to test here https://calibre.redbux.cn
Some useful links：
https://stackoverflow.com/questions/54278247/flask-dance-and-error-redirect-uri-mismatch
https://flask-dance.readthedocs.io/en/latest/proxies.html
https://github.com/singingwolfboy/flask-dance/issues/188