### PR TITLE
Update web.py to sort Publishers by name

### DIFF
--- a/cps/web.py
+++ b/cps/web.py
@@ -801,7 +801,7 @@ def publisher_list():
     if current_user.check_visibility(constants.SIDEBAR_PUBLISHER):
         entries = db.session.query(db.Publishers, func.count('books_publishers_link.book').label('count')) \
             .join(db.books_publishers_link).join(db.Books).filter(common_filters()) \
-            .group_by(text('books_publishers_link.publisher')).order_by(db.Publishers.sort).all()
+            .group_by(text('books_publishers_link.publisher')).order_by(db.Publishers.name).all()
         charlist = db.session.query(func.upper(func.substr(db.Publishers.name, 1, 1)).label('char')) \
             .join(db.books_publishers_link).join(db.Books).filter(common_filters()) \
             .group_by(func.upper(func.substr(db.Publishers.name, 1, 1))).all()


### PR DESCRIPTION
First time doing this, so apologies if it's not following procedures or protocol. Publishers query attempts to sort on the publishers.sort column, which is empty in the calibre database. Order by publishers.name allows publishers to be sorted alphabetically on the Publishers page.