### PR TITLE
Append .epub extension when downloading .kepub format

### DIFF
--- a/cps/helper.py
+++ b/cps/helper.py
@@ -890,10 +890,11 @@ def get_download_link(book_id, book_format):
         if len(book.authors) > 0:
             file_name = book.authors[0].name + '_' + file_name
         file_name = get_valid_filename(file_name)
+        real_book_format = book_format + '.epub' if book_format == 'kepub' else book_format
         headers = Headers()
         headers["Content-Type"] = mimetypes.types_map.get('.' + book_format, "application/octet-stream")
         headers["Content-Disposition"] = "attachment; filename=%s.%s; filename*=UTF-8''%s.%s" % (
-            quote(file_name.encode('utf-8')), book_format, quote(file_name.encode('utf-8')), book_format)
+            quote(file_name.encode('utf-8')), real_book_format, quote(file_name.encode('utf-8')), real_book_format)
         return do_download_file(book, book_format, data1, headers)
     else:
         abort(404)


### PR DESCRIPTION
This will make that  when an Kepub file is being asked to download an .epub extension is added automatically.
## Motivation
Calibre stores kepub files as .kepub to not messing them with the .epub format.
When calibre sends a kepub file to a kobo device it automatically appends the .epub extension so the name becomes "name_of_the_book.kepub.epub" that is the way kobo devices need to be named.
When a kobo device is using the experimental browser to access calibre-web and try to download a kepub it doesn't have the oportunity to rename the file to use kepub.epub. This pr solve that.
If any other kind of device is trying to download (for example using a desktop pc and a browser) the browser download feature will show a dialog where the user could be able to change the name of the file (and remove the epub part if the user wants). 
fixes https://github.com/janeczku/calibre-web/issues/1357