### PR TITLE
Fix XML parsing error when using OPDS feeds

### DIFF
--- a/cps/templates/feed.xml
+++ b/cps/templates/feed.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/terms/">
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/terms/" xmlns:dcterms="http://purl.org/dc/terms/">
   <id>urn:uuid:2853dacf-ed79-42f5-8e8a-a7bb3d1ae6a2</id>
   <updated>{{ current_time }}</updated>
   <link rel="self"


### PR DESCRIPTION
Using the OPDS feeds with the MoonReader Android application yielded the following error:
"Error parsing XML: unbound prefix".
This was due to a missing namespace in the feed.xml template.
See https://github.com/janeczku/calibre-web/issues/1403 for more
information.