### PR TITLE
Fix typo "Shelfs" to "Shelves"

### DIFF
--- a/cps/templates/config_view_edit.html
+++ b/cps/templates/config_view_edit.html
@@ -113,7 +113,7 @@
         </div>
         <div class="form-group">
           <input type="checkbox" name="edit_shelf_role" id="edit_shelf_role" {% if conf.role_edit_shelfs() %}checked{% endif %}>
-          <label for="edit_shelf_role">{{_('Allow Editing Public Shelfs')}}</label>
+          <label for="edit_shelf_role">{{_('Allow Editing Public Shelves')}}</label>
         </div>
       </div>
     </div>

--- a/cps/templates/user_edit.html
+++ b/cps/templates/user_edit.html
@@ -119,7 +119,7 @@
         </div>
         <div class="form-group">
           <input type="checkbox" name="edit_shelf_role" id="edit_shelf_role" {% if content.role_edit_shelfs() %}checked{% endif %}>
-          <label for="edit_shelf_role">{{_('Allow Editing Public Shelfs')}}</label>
+          <label for="edit_shelf_role">{{_('Allow Editing Public Shelves')}}</label>
         </div>
       {% endif %}
     {% endif %}

--- a/cps/translations/cs/LC_MESSAGES/messages.po
+++ b/cps/translations/cs/LC_MESSAGES/messages.po
@@ -1859,7 +1859,7 @@ msgid "Allow Changing Password"
 msgstr "Povolit změnu hesla"
 
 #: cps/templates/config_view_edit.html:116 cps/templates/user_edit.html:122
-msgid "Allow Editing Public Shelfs"
+msgid "Allow Editing Public Shelves"
 msgstr "Povolit úpravy veřejných polic"
 
 #: cps/templates/config_view_edit.html:126

--- a/cps/translations/de/LC_MESSAGES/messages.po
+++ b/cps/translations/de/LC_MESSAGES/messages.po
@@ -1860,7 +1860,7 @@ msgid "Allow Changing Password"
 msgstr "Ändern des Passworts erlauben"
 
 #: cps/templates/config_view_edit.html:116 cps/templates/user_edit.html:122
-msgid "Allow Editing Public Shelfs"
+msgid "Allow Editing Public Shelves"
 msgstr "Editieren öffentlicher Bücherregale erlauben"
 
 #: cps/templates/config_view_edit.html:126

--- a/cps/translations/es/LC_MESSAGES/messages.po
+++ b/cps/translations/es/LC_MESSAGES/messages.po
@@ -1862,7 +1862,7 @@ msgid "Allow Changing Password"
 msgstr "Permitir cambiar la contraseña"
 
 #: cps/templates/config_view_edit.html:116 cps/templates/user_edit.html:122
-msgid "Allow Editing Public Shelfs"
+msgid "Allow Editing Public Shelves"
 msgstr "Permitir editar estantes públicos"
 
 #: cps/templates/config_view_edit.html:126

--- a/cps/translations/fi/LC_MESSAGES/messages.po
+++ b/cps/translations/fi/LC_MESSAGES/messages.po
@@ -1860,7 +1860,7 @@ msgid "Allow Changing Password"
 msgstr "Salli sananan vaihto"
 
 #: cps/templates/config_view_edit.html:116 cps/templates/user_edit.html:122
-msgid "Allow Editing Public Shelfs"
+msgid "Allow Editing Public Shelves"
 msgstr "Salli julkisten hyllyjen editointi"
 
 #: cps/templates/config_view_edit.html:126

--- a/cps/translations/fr/LC_MESSAGES/messages.po
+++ b/cps/translations/fr/LC_MESSAGES/messages.po
@@ -1873,7 +1873,7 @@ msgid "Allow Changing Password"
 msgstr "Permettre le changement de mot de passe"
 
 #: cps/templates/config_view_edit.html:116 cps/templates/user_edit.html:122
-msgid "Allow Editing Public Shelfs"
+msgid "Allow Editing Public Shelves"
 msgstr "Autoriser la modification d’étagères publiques"
 
 #: cps/templates/config_view_edit.html:126

--- a/cps/translations/hu/LC_MESSAGES/messages.po
+++ b/cps/translations/hu/LC_MESSAGES/messages.po
@@ -1860,7 +1860,7 @@ msgid "Allow Changing Password"
 msgstr "Jelszó változtatásának engedélyezése"
 
 #: cps/templates/config_view_edit.html:116 cps/templates/user_edit.html:122
-msgid "Allow Editing Public Shelfs"
+msgid "Allow Editing Public Shelves"
 msgstr "Nyilvános polcok szerkesztésének engedélyezése"
 
 #: cps/templates/config_view_edit.html:126

--- a/cps/translations/it/LC_MESSAGES/messages.po
+++ b/cps/translations/it/LC_MESSAGES/messages.po
@@ -1859,7 +1859,7 @@ msgid "Allow Changing Password"
 msgstr "Permetti la modifica della password"
 
 #: cps/templates/config_view_edit.html:116 cps/templates/user_edit.html:122
-msgid "Allow Editing Public Shelfs"
+msgid "Allow Editing Public Shelves"
 msgstr "Permetti la modifica degli scaffali pubblici"
 
 #: cps/templates/config_view_edit.html:126

--- a/cps/translations/ja/LC_MESSAGES/messages.po
+++ b/cps/translations/ja/LC_MESSAGES/messages.po
@@ -1860,7 +1860,7 @@ msgid "Allow Changing Password"
 msgstr "パスワード変更を許可"
 
 #: cps/templates/config_view_edit.html:116 cps/templates/user_edit.html:122
-msgid "Allow Editing Public Shelfs"
+msgid "Allow Editing Public Shelves"
 msgstr "みんなの本棚の編集を許可"
 
 #: cps/templates/config_view_edit.html:126

--- a/cps/translations/km/LC_MESSAGES/messages.po
+++ b/cps/translations/km/LC_MESSAGES/messages.po
@@ -1861,7 +1861,7 @@ msgid "Allow Changing Password"
 msgstr "អនុញ្ញាតឲប្តូរលេខសម្ងាត់"
 
 #: cps/templates/config_view_edit.html:116 cps/templates/user_edit.html:122
-msgid "Allow Editing Public Shelfs"
+msgid "Allow Editing Public Shelves"
 msgstr "អនុញ្ញាតឲកែប្រែធ្នើសាធារណៈ"
 
 #: cps/templates/config_view_edit.html:126

--- a/cps/translations/nl/LC_MESSAGES/messages.po
+++ b/cps/translations/nl/LC_MESSAGES/messages.po
@@ -1861,7 +1861,7 @@ msgid "Allow Changing Password"
 msgstr "Wachtwoord wijzigen toestaan"
 
 #: cps/templates/config_view_edit.html:116 cps/templates/user_edit.html:122
-msgid "Allow Editing Public Shelfs"
+msgid "Allow Editing Public Shelves"
 msgstr "Bewerken van openbare boekenplanken toestaan"
 
 #: cps/templates/config_view_edit.html:126

--- a/cps/translations/pl/LC_MESSAGES/messages.po
+++ b/cps/translations/pl/LC_MESSAGES/messages.po
@@ -1874,7 +1874,7 @@ msgid "Allow Changing Password"
 msgstr "Zezwalaj na zmianę hasła"
 
 #: cps/templates/config_view_edit.html:116 cps/templates/user_edit.html:122
-msgid "Allow Editing Public Shelfs"
+msgid "Allow Editing Public Shelves"
 msgstr "Zezwalaj na edycję półek publicznych"
 
 #: cps/templates/config_view_edit.html:126

--- a/cps/translations/ru/LC_MESSAGES/messages.po
+++ b/cps/translations/ru/LC_MESSAGES/messages.po
@@ -1861,7 +1861,7 @@ msgid "Allow Changing Password"
 msgstr "Разрешить смену пароля"
 
 #: cps/templates/config_view_edit.html:116 cps/templates/user_edit.html:122
-msgid "Allow Editing Public Shelfs"
+msgid "Allow Editing Public Shelves"
 msgstr "Разрешить редактирование публичных книжных полок"
 
 #: cps/templates/config_view_edit.html:126

--- a/cps/translations/sv/LC_MESSAGES/messages.po
+++ b/cps/translations/sv/LC_MESSAGES/messages.po
@@ -1860,7 +1860,7 @@ msgid "Allow Changing Password"
 msgstr "Tillåt Ändra lösenord"
 
 #: cps/templates/config_view_edit.html:116 cps/templates/user_edit.html:122
-msgid "Allow Editing Public Shelfs"
+msgid "Allow Editing Public Shelves"
 msgstr "Tillåt Redigering av offentliga hyllor"
 
 #: cps/templates/config_view_edit.html:126

--- a/cps/translations/tr/LC_MESSAGES/messages.po
+++ b/cps/translations/tr/LC_MESSAGES/messages.po
@@ -1860,7 +1860,7 @@ msgid "Allow Changing Password"
 msgstr "Şifre değiştirmeye izin ver"
 
 #: cps/templates/config_view_edit.html:116 cps/templates/user_edit.html:122
-msgid "Allow Editing Public Shelfs"
+msgid "Allow Editing Public Shelves"
 msgstr "Genel Kitaplıkları düzenlemeye izin ver"
 
 #: cps/templates/config_view_edit.html:126

--- a/cps/translations/uk/LC_MESSAGES/messages.po
+++ b/cps/translations/uk/LC_MESSAGES/messages.po
@@ -1859,7 +1859,7 @@ msgid "Allow Changing Password"
 msgstr "Дозволити зміну пароля"
 
 #: cps/templates/config_view_edit.html:116 cps/templates/user_edit.html:122
-msgid "Allow Editing Public Shelfs"
+msgid "Allow Editing Public Shelves"
 msgstr "Дозволити редагування публічних книжкових полиць"
 
 #: cps/templates/config_view_edit.html:126

--- a/cps/translations/zh_Hans_CN/LC_MESSAGES/messages.po
+++ b/cps/translations/zh_Hans_CN/LC_MESSAGES/messages.po
@@ -1860,7 +1860,7 @@ msgid "Allow Changing Password"
 msgstr "允许修改密码"
 
 #: cps/templates/config_view_edit.html:116 cps/templates/user_edit.html:122
-msgid "Allow Editing Public Shelfs"
+msgid "Allow Editing Public Shelves"
 msgstr "允许编辑公共书架"
 
 #: cps/templates/config_view_edit.html:126

--- a/messages.pot
+++ b/messages.pot
@@ -1859,7 +1859,7 @@ msgid "Allow Changing Password"
 msgstr ""
 
 #: cps/templates/config_view_edit.html:116 cps/templates/user_edit.html:122
-msgid "Allow Editing Public Shelfs"
+msgid "Allow Editing Public Shelves"
 msgstr ""
 
 #: cps/templates/config_view_edit.html:126


### PR DESCRIPTION
Updated all instances of "Allow Editing Public Shelfs" to "Allow Editing Public Shelves"