### PR TITLE
removed extra reference to calibre_db (calibre_db.calibre_db..) typo?

### DIFF
--- a/cps/web.py
+++ b/cps/web.py
@@ -657,7 +657,7 @@ def books_list(data, sort, book_id, page):
             abort(404)
     elif data == "discover":
         if current_user.check_visibility(constants.SIDEBAR_RANDOM):
-            entries, __, pagination = calibre_db.calibre_db.fill_indexpage(page, db.Books, True, [func.randomblob(2)])
+            entries, __, pagination = calibre_db.fill_indexpage(page, db.Books, True, [func.randomblob(2)])
             pagination = Pagination(1, config.config_books_per_page, config.config_books_per_page)
             return render_title_template('discover.html', entries=entries, pagination=pagination, id=book_id,
                                          title=_(u"Discover (Random Books)"), page="discover")


### PR DESCRIPTION
**Describe the bug/problem**
Looks like a typo TBH: calibre_db.calibre_db.fill_indexpage() should be calibre_db.fill_indexpage()

Changing cps/web.py line 660 fixes the problem accordingly.
entries, __, pagination = calibre_db.fill_indexpage(page, db.Books, True, [func.randomblob(2)])

**To Reproduce**
Fresh install, library is functioning, all else is functioning.
Click on "Discover"
500 Error

**Logfile**
Traceback (most recent call last):
File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 2447, in wsgi_app
response = self.full_dispatch_request()
File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1952, in full_dispatch_request
rv = self.handle_user_exception(e)
File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1821, in handle_user_exception
reraise(exc_type, exc_value, tb)
File "/usr/local/lib/python3.7/site-packages/flask/_compat.py", line 39, in reraise
raise value
File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1950, in full_dispatch_request
rv = self.dispatch_request()
File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1936, in dispatch_request
return self.view_functions[rule.endpoint](**req.view_args)
File "/usr/local/app/calibre-web/cps/web.py", line 201, in decorated_view
return login_required(func)(*args, **kwargs)
File "/usr/local/lib/python3.7/site-packages/flask_login/utils.py", line 272, in decorated_view
return func(*args, **kwargs)
File "/usr/local/app/calibre-web/cps/web.py", line 660, in books_list
entries, __, pagination = calibre_db.calibre_db.fill_indexpage(page, db.Books, True, [func.randomblob(2)])
AttributeError: 'CalibreDB' object has no attribute 'calibre_db'

Platform	FreeBSD 11.3-RELEASE-p9 FreeBSD 11.3-RELEASE-p9 #0 r325575+c153e5c9a38(HEAD): Wed May 20 16:09:43 EDT 2020 root@mp20.tn.ixsystems.com:/freenas-releng/freenas/_BE/objs/freenas-releng/freenas/_BE/os/sys/FreeNAS.amd64 amd64 amd64
Python	3.7.7 (default, May 14 2020, 01:19:39) [Clang 8.0.0 (tags/RELEASE_800/final 356365)]
Calibre_Web	0.6.8 Beta - $Format:%H$ - $Format:%cI$
WebServer	Tornado 6.0.4
Flask	1.1.2
Flask_Login	0.5.0
Flask_Principal	0.4.0
Werkzeug	1.0.1
Babel	2.8.0
Jinja2	2.11.2
Requests	2.23.0
SqlAlchemy	1.3.17
pySqlite	2.6.0
SQLite	3.31.1
iso639	0.4.5
pytz	2020.1
Unidecode	installed
Image Magick	ImageMagick 7.0.10-6 Q16 amd64 2020-05-23 https://imagemagick.org
PyPdf	v1.26.0
lxml	v4.5.1.0
Wand	0.5.9
Pillow	v7.0.0
Comic_API	not installed
ebook converter	ebook-convert (calibre 4.17.0)
unrar	not installed
kepubify	not installed
