### PR TITLE
[enhancement] cleaned up the setup.py install script

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-graft src/calibreweb
+graft cps

--- a/setup.py
+++ b/setup.py
@@ -21,26 +21,20 @@
 
 from setuptools import setup
 from setuptools import find_packages
-import os
 import re
-import codecs
+import ast
 
-here = os.path.abspath(os.path.dirname(__file__))
-
-def read(*parts):
-    with codecs.open(os.path.join(here, *parts), 'r') as fp:
-        return fp.read()
-
-def find_version(*file_paths):
-    version_file = read(*file_paths)
-    version_match = re.search(r"^STABLE_VERSION\s+=\s+{['\"]version['\"]:\s*['\"](.*)['\"]}",
-                              version_file, re.M)
-    if version_match:
-        return version_match.group(1)
-    raise RuntimeError("Unable to find version string.")
+STABLE_VERSION = ast.literal_eval(
+    re.findall(
+        "{.*}",
+        re.findall("^STABLE_VERSION.*",
+                   open("cps/constants.py").read(), re.MULTILINE)[0])[0])
 
 setup(
-    packages=find_packages("src"),
-    package_dir = {'': 'src'},
-    version=find_version("src", "calibreweb", "cps", "constants.py")
+    description="Web app for calibre",
+    version=STABLE_VERSION['version'],
+    author="Jan B",
+    url="https://github.com/janeczku/calibre-web",
+    packages=find_packages(),
+    py_modules=[ 'cps' ],
 )


### PR DESCRIPTION
Adding the work that I've done while porting to OpenBSD, its working nicely at https://lib.epsilonknot.xyz

This allows a default installation target and makes the setup.py script work again perfectly.

Caveats (most of them unrelated to this PR):
1)  the installation is not a module anymore, and can not be run as a simple
```
python3.7 -m cps.py
```
Instead I have to run it as 
```
python3.7 /usr/local/lib/python3.7/site-packages/cps.py
```
Unfortunately I don't have the skillset for getting this working :crying_cat_face: 

2) The installation cannot be run as a regular user as during startup calibre-web tries to create files in the installation directory.  
Current workaround - run as root :no_entry_sign:  
Desired fix - don't check for permissions in the install directory, but ask for where to read/write things

Again, I'm not sure how to get this working :crying_cat_face: 