### PR TITLE
Fix #1507 by ensuring we're using numbers.

### DIFF
--- a/cps/helper.py
+++ b/cps/helper.py
@@ -466,7 +466,7 @@ def reset_password(user_id):
 def generate_random_password():
     s = "abcdefghijklmnopqrstuvwxyz01234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ!@#$%&*()?"
     passlen = 8
-    return "".join(s[c % len(s)] for c in os.urandom(passlen))
+    return "".join(s[c % len(s)] for c in list(os.urandom(passlen)))
 
 
 def uniq(input):


### PR DESCRIPTION
os.urandom produces a byte-string, eg. b'a%'; and Python sees the operator '%'
as a string-interpolation one.