### PR TITLE
Fix for hidden input 'next' on login form

### DIFF
--- a/cps/web.py
+++ b/cps/web.py
@@ -1434,7 +1434,7 @@ def login():
                     log.info('Login failed for user "%s" IP-adress: %s', form['username'], ipAdress)
                     flash(_(u"Wrong Username or Password"), category="error")
 
-    next_url = url_for('web.index')
+    next_url = request.args.get('next', default=url_for("web.index"), type=str)
     return render_title_template('login.html',
                                  title=_(u"login"),
                                  next_url=next_url,


### PR DESCRIPTION
Hello.

**Problem:**
When trying to access a book, without being logged in, after logging in I'm always redirected to the `url_for("web.index")`.

**Expected behaviour:**
After successfully logging in, I should be redirected to the book page I was trying to access.

**Solution:**
I modified the `next_url` parameter that gets passed in the `render_title_template('login.html',...)` (cps/web.py : 1437) function so that it can have 2 possible values. 
If the GET param `next` exists, it's value will be used. If not present, then the `next_url` will have the default `url_for("web.index")`.

I couldn't find any issue submitted about this problem, sorry if I missed it.
Thanks, let me know what you think