### PR TITLE
feat(api): include external port option

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -623,6 +623,7 @@ def _configuration_update_helper():
         gdriveError = _configuration_gdrive_helper(to_save)
 
         reboot_required |= _config_int(to_save, "config_port")
+        reboot_required |= _config_int(to_save, "config_external_port")
 
         reboot_required |= _config_string(to_save, "config_keyfile")
         if config.config_keyfile and not os.path.isfile(config.config_keyfile):

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -57,6 +57,7 @@ class _Settings(_Base):
 
     config_calibre_dir = Column(String)
     config_port = Column(Integer, default=constants.DEFAULT_PORT)
+    config_external_port = Column(Integer, default=constants.DEFAULT_PORT)
     config_certfile = Column(String)
     config_keyfile = Column(String)
 

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -267,14 +267,15 @@ def HandleMetadataRequest(book_uuid):
 
 def get_download_url_for_book(book, book_format):
     if not current_app.wsgi_app.is_proxied:
-        if ':' in request.host and not request.host.endswith(']') :
+        if ':' in request.host and not request.host.endswith(']'):
             host = "".join(request.host.split(':')[:-1])
         else:
             host = request.host
+
         return "{url_scheme}://{url_base}:{url_port}/download/{book_id}/{book_format}".format(
             url_scheme=request.scheme,
             url_base=host,
-            url_port=config.config_port,
+            url_port=config.config_external_port,
             book_id=book.id,
             book_format=book_format.lower()
         )
@@ -925,7 +926,7 @@ def HandleInitRequest():
         calibre_web_url = "{url_scheme}://{url_base}:{url_port}".format(
             url_scheme=request.scheme,
             url_base=host,
-            url_port=config.config_port
+            url_port=config.config_external_port
         )
         kobo_resources["image_host"] = calibre_web_url
         kobo_resources["image_url_quality_template"] = unquote(calibre_web_url +
@@ -935,16 +936,14 @@ def HandleInitRequest():
                                                                        width="{width}",
                                                                        height="{height}",
                                                                        Quality='{Quality}',
-                                                                       isGreyscale='isGreyscale'
-                                                               ))
+                                                                       isGreyscale='isGreyscale'))
         kobo_resources["image_url_template"] = unquote(calibre_web_url +
                                                        url_for("kobo.HandleCoverImageRequest",
                                                                auth_token=kobo_auth.get_auth_token(),
                                                                book_uuid="{ImageId}",
                                                                width="{width}",
                                                                height="{height}",
-                                                               isGreyscale='false'
-                                                       ))
+                                                               isGreyscale='false'))
     else:
         kobo_resources["image_host"] = url_for("web.index", _external=True).strip("/")
         kobo_resources["image_url_quality_template"] = unquote(url_for("kobo.HandleCoverImageRequest",
@@ -962,7 +961,6 @@ def HandleInitRequest():
                                                                height="{height}",
                                                                isGreyscale='false',
                                                                _external=True))
-
 
     response = make_response(jsonify({"Resources": kobo_resources}))
     response.headers["x-kobo-apitoken"] = "e30="

--- a/cps/templates/admin.html
+++ b/cps/templates/admin.html
@@ -88,6 +88,10 @@
             <div class="col-xs-6 col-sm-6">{{_('Port')}}</div>
             <div class="col-xs-6 col-sm-6">{{config.config_port}}</div>
         </div>
+        <div class="row">
+          <div class="col-xs-6 col-sm-6">{{_('External Port')}}</div>
+          <div class="col-xs-6 col-sm-6">{{config.config_external_port}}</div>
+        </div>
       </div>
       <div class="col-xs-12 col-sm-6">
         <div class="row">

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -90,6 +90,10 @@
           <label for="config_port">{{_('Server Port')}}</label>
           <input type="number" min="1" max="65535" class="form-control" name="config_port" id="config_port" value="{% if config.config_port != None %}{{ config.config_port }}{% endif %}" autocomplete="off" required>
         </div>
+        <div class="form-group">
+          <label for="config_external_port">{{_('Server External Port (for reverse proxy API calls)')}}</label>
+          <input type="number" min="1" max="65535" class="form-control" name="config_external_port" id="config_external_port" value="{% if config.config_external_port != None %}{{ config.config_external_port }}{% endif %}" autocomplete="off" required>
+        </div>
         <label for="config_certfile">{{_('SSL certfile location (leave it empty for non-SSL Servers)')}}</label>
          <div class="form-group input-group">
           <input type="text" class="form-control" id="config_certfile" name="config_certfile" value="{% if config.config_certfile != None %}{{ config.config_certfile }}{% endif %}" autocomplete="off">


### PR DESCRIPTION
### Description

This should help with a fix when downloading from a URL that goes through a reverse proxy, especially through Docker.

As there could be port mappings within Docker (`12345:8083`), then a reverse proxy: (`54321 -> 12345`), and even potential router port forwarding (`34125 -> 54321`). This allows the user to make API calls correctly to links like `api_endpoint` for Kobo.