### PR TITLE
feat(ldap): add a field that allows to override LDAP User Object Filter when a user is imported

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -564,6 +564,7 @@ def _configuration_ldap_helper(to_save, gdriveError):
     reboot_required |= _config_string(to_save, "config_ldap_user_object")
     reboot_required |= _config_string(to_save, "config_ldap_group_object_filter")
     reboot_required |= _config_string(to_save, "config_ldap_group_members_field")
+    reboot_required |= _config_string(to_save, "config_ldap_member_user_object")
     reboot_required |= _config_checkbox(to_save, "config_ldap_openldap")
     reboot_required |= _config_int(to_save, "config_ldap_encryption")
     reboot_required |= _config_string(to_save, "config_ldap_cert_path")
@@ -598,10 +599,17 @@ def _configuration_ldap_helper(to_save, gdriveError):
 
     if config.config_ldap_user_object.count("%s") != 1:
         return reboot_required, _configuration_result(_('LDAP User Object Filter needs to Have One "%s" Format Identifier'),
-                                     gdriveError)
+                                                      gdriveError)
     if config.config_ldap_user_object.count("(") != config.config_ldap_user_object.count(")"):
         return reboot_required, _configuration_result(_('LDAP User Object Filter Has Unmatched Parenthesis'),
-                                     gdriveError)
+                                                      gdriveError)
+
+    if config.config_ldap_member_user_object.count("%s") != 1:
+        return reboot_required, _configuration_result(_('LDAP Member User Filter needs to Have One "%s" Format Identifier'),
+                                                      gdriveError)
+    if config.config_ldap_member_user_object.count("(") != config.config_ldap_member_user_object.count(")"):
+        return reboot_required, _configuration_result(_('LDAP Member User Filter Has Unmatched Parenthesis'),
+                                                      gdriveError)
 
     if config.config_ldap_cert_path and not os.path.isdir(config.config_ldap_cert_path):
         return reboot_required, _configuration_result(_('LDAP Certificate Location is not Valid, Please Enter Correct Path'),

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -112,6 +112,7 @@ class _Settings(_Base):
     config_ldap_cert_path = Column(String, default="")
     config_ldap_dn = Column(String, default='dc=example,dc=org')
     config_ldap_user_object = Column(String, default='uid=%s')
+    config_ldap_member_user_object = Column(String, default='cn=%s')
     config_ldap_openldap = Column(Boolean, default=True)
     config_ldap_group_object_filter = Column(String, default='(&(objectclass=posixGroup)(cn=%s))')
     config_ldap_group_members_field = Column(String, default='memberUid')

--- a/cps/services/simpleldap.py
+++ b/cps/services/simpleldap.py
@@ -64,6 +64,7 @@ def init_app(app, config):
     app.config['LDAP_OPENLDAP'] = bool(config.config_ldap_openldap)
     app.config['LDAP_GROUP_OBJECT_FILTER'] = config.config_ldap_group_object_filter
     app.config['LDAP_GROUP_MEMBERS_FIELD'] = config.config_ldap_group_members_field
+    app.config['LDAP_MEMBER_USER_OBJECT_FILTER'] = config.config_ldap_member_user_object
 
     _ldap.init_app(app)
 

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -310,6 +310,10 @@
             <label for="config_ldap_group_members_field">{{_('LDAP Group Members Field')}}</label>
             <input type="text" class="form-control" id="config_ldap_group_members_field" name="config_ldap_group_members_field" value="{% if config.config_ldap_group_members_field != None %}{{ config.config_ldap_group_members_field }}{% endif %}" autocomplete="off">
           </div>
+          <div class="form-group">
+              <label for="config_ldap_user_object">{{_('LDAP Member User Filter')}}</label>
+              <input type="text" class="form-control" id="config_ldap_member_user_object" name="config_ldap_member_user_object" value="{% if config.config_ldap_member_user_object != None %}{{ config.config_ldap_member_user_object }}{% endif %}" autocomplete="off">
+          </div>
       </div>
       {% endif %}
       {% if feature_support['oauth'] %}


### PR DESCRIPTION
I created [this feature request yesterday](https://github.com/janeczku/calibre-web/issues/1534), and since I had some free time to implement it, there you go :)

The goal of this pull request is to allow admins to use another LDAP filter to import users, and to use a field as nickname that is not necessarily in the member field of the group.

In my case, I had this format in member field : 
`CN=Firstname LastName,OU=...OU=...,DC=...,DC=...`
but I wanted to use sAMAccountName as login in Calibre-Web.

Note 1 : this is the first time EVER I code in Python, so I might have missed some points
Note 2 : I will be unavailable from 25 july to 10 august