### PR TITLE
Fix background black assumption

### DIFF
--- a/cps/uploader.py
+++ b/cps/uploader.py
@@ -36,6 +36,7 @@ except ImportError:
 
 try:
     from wand.image import Image
+    from wand.image import Color
     from wand import version as ImageVersion
     from wand.exceptions import PolicyError
     use_generic_pdf_cover = False
@@ -149,6 +150,8 @@ def pdf_preview(tmp_file_path, tmp_dir):
             img.options["pdf:use-cropbox"] = "true"
             img.read(filename=tmp_file_path + '[0]', resolution=150)
             img.compression_quality = 88
+            img.background_color = Color("white")
+            img.alpha_channel = "remove"
             img.save(filename=os.path.join(tmp_dir, cover_file_name))
         return cover_file_name
     except PolicyError as ex:


### PR DESCRIPTION
This is a 3 line fix for #1531 

1. Import `Color` from `wand.image` (alongside `Image`)
2. In `pdf_preview`, add two additional properties to remove the alpha channel (since we're exporting as jpg), and declare `img.background_color` as white.
