### PR TITLE
Trim whitespace from filename when uploading

### DIFF
--- a/cps/helper.py
+++ b/cps/helper.py
@@ -254,7 +254,7 @@ def get_valid_filename(value, replace_whitespace=True):
         value = re.sub(r'[\*\+:\\\"/<>\?]+', u'_', value, flags=re.U)
         # pipe has to be replaced with comma
         value = re.sub(r'[\|]+', u',', value, flags=re.U)
-    value = value[:128]
+    value = value[:128].strip()
     if not value:
         raise ValueError("Filename cannot be empty")
     if sys.version_info.major == 3:


### PR DESCRIPTION
I was having an issue uploading a file, getting a permission denied error. It wasn't a permissions thing, instead the metadata of the book apparently has whitespace at the end of the author. So when concating the folder structure, it looks something like this: `calibrelib\Author Name \Book Title.epub`

Note the whitespace at the end of the author. This was causing the error. I simply strip whitespace from the ends.