### PR TITLE
Fixing "Settings database is not writeable. Exiting..." when using pypy3

### DIFF
--- a/cps/ub.py
+++ b/cps/ub.py
@@ -474,34 +474,34 @@ def migrate_Database(session):
         ArchivedBook.__table__.create(bind=engine)
     if not engine.dialect.has_table(engine.connect(), "registration"):
         ReadBook.__table__.create(bind=engine)
-        conn = engine.connect()
-        conn.execute("insert into registration (domain, allow) values('%.%',1)")
+        with engine.connect() as conn:
+            conn.execute("insert into registration (domain, allow) values('%.%',1)")
         session.commit()
     try:
         session.query(exists().where(Registration.allow)).scalar()
         session.commit()
     except exc.OperationalError:  # Database is not compatible, some columns are missing
-        conn = engine.connect()
-        conn.execute("ALTER TABLE registration ADD column 'allow' INTEGER")
-        conn.execute("update registration set 'allow' = 1")
+        with engine.connect() as conn:
+            conn.execute("ALTER TABLE registration ADD column 'allow' INTEGER")
+            conn.execute("update registration set 'allow' = 1")
         session.commit()
     try:
         session.query(exists().where(RemoteAuthToken.token_type)).scalar()
         session.commit()
     except exc.OperationalError:  # Database is not compatible, some columns are missing
-        conn = engine.connect()
-        conn.execute("ALTER TABLE remote_auth_token ADD column 'token_type' INTEGER DEFAULT 0")
-        conn.execute("update remote_auth_token set 'token_type' = 0")
+        with engine.connect() as conn:
+            conn.execute("ALTER TABLE remote_auth_token ADD column 'token_type' INTEGER DEFAULT 0")
+            conn.execute("update remote_auth_token set 'token_type' = 0")
         session.commit()
     try:
         session.query(exists().where(ReadBook.read_status)).scalar()
     except exc.OperationalError:
-        conn = engine.connect()
-        conn.execute("ALTER TABLE book_read_link ADD column 'read_status' INTEGER DEFAULT 0")
-        conn.execute("UPDATE book_read_link SET 'read_status' = 1 WHERE is_read")
-        conn.execute("ALTER TABLE book_read_link ADD column 'last_modified' DATETIME")
-        conn.execute("ALTER TABLE book_read_link ADD column 'last_time_started_reading' DATETIME")
-        conn.execute("ALTER TABLE book_read_link ADD column 'times_started_reading' INTEGER DEFAULT 0")
+        with engine.connect() as conn:
+            conn.execute("ALTER TABLE book_read_link ADD column 'read_status' INTEGER DEFAULT 0")
+            conn.execute("UPDATE book_read_link SET 'read_status' = 1 WHERE is_read")
+            conn.execute("ALTER TABLE book_read_link ADD column 'last_modified' DATETIME")
+            conn.execute("ALTER TABLE book_read_link ADD column 'last_time_started_reading' DATETIME")
+            conn.execute("ALTER TABLE book_read_link ADD column 'times_started_reading' INTEGER DEFAULT 0")
         session.commit()
     test = session.query(ReadBook).filter(ReadBook.last_modified == None).all()
     for book in test:
@@ -510,11 +510,11 @@ def migrate_Database(session):
     try:
         session.query(exists().where(Shelf.uuid)).scalar()
     except exc.OperationalError:
-        conn = engine.connect()
-        conn.execute("ALTER TABLE shelf ADD column 'uuid' STRING")
-        conn.execute("ALTER TABLE shelf ADD column 'created' DATETIME")
-        conn.execute("ALTER TABLE shelf ADD column 'last_modified' DATETIME")
-        conn.execute("ALTER TABLE book_shelf_link ADD column 'date_added' DATETIME")
+        with engine.connect() as conn:
+            conn.execute("ALTER TABLE shelf ADD column 'uuid' STRING")
+            conn.execute("ALTER TABLE shelf ADD column 'created' DATETIME")
+            conn.execute("ALTER TABLE shelf ADD column 'last_modified' DATETIME")
+            conn.execute("ALTER TABLE book_shelf_link ADD column 'date_added' DATETIME")
         for shelf in session.query(Shelf).all():
             shelf.uuid = str(uuid.uuid4())
             shelf.created = datetime.datetime.now()
@@ -525,31 +525,31 @@ def migrate_Database(session):
     # Handle table exists, but no content
     cnt = session.query(Registration).count()
     if not cnt:
-        conn = engine.connect()
-        conn.execute("insert into registration (domain, allow) values('%.%',1)")
+        with engine.connect() as conn:
+            conn.execute("insert into registration (domain, allow) values('%.%',1)")
         session.commit()
     try:
         session.query(exists().where(BookShelf.order)).scalar()
     except exc.OperationalError:  # Database is not compatible, some columns are missing
-        conn = engine.connect()
-        conn.execute("ALTER TABLE book_shelf_link ADD column 'order' INTEGER DEFAULT 1")
+        with engine.connect() as conn:
+            conn.execute("ALTER TABLE book_shelf_link ADD column 'order' INTEGER DEFAULT 1")
         session.commit()
     try:
         create = False
         session.query(exists().where(User.sidebar_view)).scalar()
     except exc.OperationalError:  # Database is not compatible, some columns are missing
-        conn = engine.connect()
-        conn.execute("ALTER TABLE user ADD column `sidebar_view` Integer DEFAULT 1")
+        with engine.connect() as conn:
+            conn.execute("ALTER TABLE user ADD column `sidebar_view` Integer DEFAULT 1")
         session.commit()
         create = True
     try:
         if create:
-            conn = engine.connect()
-            conn.execute("SELECT language_books FROM user")
+            with engine.connect() as conn:
+                conn.execute("SELECT language_books FROM user")
             session.commit()
     except exc.OperationalError:
-        conn = engine.connect()
-        conn.execute("UPDATE user SET 'sidebar_view' = (random_books* :side_random + language_books * :side_lang "
+        with engine.connect() as conn:
+            conn.execute("UPDATE user SET 'sidebar_view' = (random_books* :side_random + language_books * :side_lang "
                      "+ series_books * :side_series + category_books * :side_category + hot_books * "
                      ":side_hot + :side_autor + :detail_random)",
                      {'side_random': constants.SIDEBAR_RANDOM, 'side_lang': constants.SIDEBAR_LANGUAGE,
@@ -560,29 +560,29 @@ def migrate_Database(session):
     try:
         session.query(exists().where(User.denied_tags)).scalar()
     except exc.OperationalError:  # Database is not compatible, some columns are missing
-        conn = engine.connect()
-        conn.execute("ALTER TABLE user ADD column `denied_tags` String DEFAULT ''")
-        conn.execute("ALTER TABLE user ADD column `allowed_tags` String DEFAULT ''")
-        conn.execute("ALTER TABLE user ADD column `denied_column_value` String DEFAULT ''")
-        conn.execute("ALTER TABLE user ADD column `allowed_column_value` String DEFAULT ''")
+        with engine.connect() as conn:
+            conn.execute("ALTER TABLE user ADD column `denied_tags` String DEFAULT ''")
+            conn.execute("ALTER TABLE user ADD column `allowed_tags` String DEFAULT ''")
+            conn.execute("ALTER TABLE user ADD column `denied_column_value` String DEFAULT ''")
+            conn.execute("ALTER TABLE user ADD column `allowed_column_value` String DEFAULT ''")
         session.commit()
     try:
         session.query(exists().where(User.series_view)).scalar()
     except exc.OperationalError:
-        conn = engine.connect()
-        conn.execute("ALTER TABLE user ADD column `series_view` VARCHAR(10) DEFAULT 'list'")
+        with engine.connect() as conn:
+            conn.execute("ALTER TABLE user ADD column `series_view` VARCHAR(10) DEFAULT 'list'")
 
     if session.query(User).filter(User.role.op('&')(constants.ROLE_ANONYMOUS) == constants.ROLE_ANONYMOUS).first() \
         is None:
         create_anonymous_user(session)
     try:
         # check if one table with autoincrement is existing (should be user table)
-        conn = engine.connect()
-        conn.execute("SELECT COUNT(*) FROM sqlite_sequence WHERE name='user'")
+        with engine.connect() as conn:
+            conn.execute("SELECT COUNT(*) FROM sqlite_sequence WHERE name='user'")
     except exc.OperationalError:
         # Create new table user_id and copy contents of table user into it
-        conn = engine.connect()
-        conn.execute("CREATE TABLE user_id (id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,"
+        with engine.connect() as conn:
+            conn.execute("CREATE TABLE user_id (id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,"
                      "nickname VARCHAR(64),"
                      "email VARCHAR(120),"
                      "role SMALLINT,"
@@ -594,19 +594,19 @@ def migrate_Database(session):
                      "series_view VARCHAR(10),"
                      "UNIQUE (nickname),"
                      "UNIQUE (email))")
-        conn.execute("INSERT INTO user_id(id, nickname, email, role, password, kindle_mail,locale,"
+            conn.execute("INSERT INTO user_id(id, nickname, email, role, password, kindle_mail,locale,"
                      "sidebar_view, default_language, series_view) "
                      "SELECT id, nickname, email, role, password, kindle_mail, locale,"
                      "sidebar_view, default_language FROM user")
         # delete old user table and rename new user_id table to user:
-        conn.execute("DROP TABLE user")
-        conn.execute("ALTER TABLE user_id RENAME TO user")
+            conn.execute("DROP TABLE user")
+            conn.execute("ALTER TABLE user_id RENAME TO user")
         session.commit()
 
     # Remove login capability of user Guest
     try:
-        conn = engine.connect()
-        conn.execute("UPDATE user SET password='' where nickname = 'Guest' and password !=''")
+        with engine.connect() as conn:
+            conn.execute("UPDATE user SET password='' where nickname = 'Guest' and password !=''")
         session.commit()
     except exc.OperationalError:
         print('Settings database is not writeable. Exiting...')


### PR DESCRIPTION
When using pypy3 and restarting the calibre web server it prints out "Settings database is not writeable. Exiting...".
![image](https://user-images.githubusercontent.com/17516655/89748643-15a40900-dabc-11ea-95a2-3a39b7552dc4.png)

After commenting out the try catch clause I found that it was due to the database being locked.
![image](https://user-images.githubusercontent.com/17516655/89748985-cbbc2280-dabd-11ea-886a-a185555c1da4.png)

This was odd as when I switched to using python3 to launch the server it successfully wrote to the settings database.

I assumed that it had to do with differences between how pypy3 and python3 garbage collect leading to conn.close() being called implicitly on python3 but not on pypy3.

I changed the "conn = engine.connect()" using the examples at https://docs.sqlalchemy.org/en/13/core/connections.html as an example and this seems to have fixed the problem with launching the server with pypy3. I have also tested the changes with python 2.7.16 and python 3.7.3.