### PR TITLE
Remove Google+ OAuth scope

### DIFF
--- a/cps/oauth_bb.py
+++ b/cps/oauth_bb.py
@@ -122,7 +122,7 @@ if ub.oauth_support:
     ele2 = dict(provider_name='google',
                 id=oauth_ids[1].id,
                 active=oauth_ids[1].active,
-                scope=["https://www.googleapis.com/auth/plus.me", "https://www.googleapis.com/auth/userinfo.email"],
+                scope=["https://www.googleapis.com/auth/userinfo.email"],
                 oauth_client_id=oauth_ids[1].oauth_client_id,
                 oauth_client_secret=oauth_ids[1].oauth_client_secret,
                 obtain_link='https://github.com/settings/developers')


### PR DESCRIPTION
The scope is no longer available per https://developers.google.com/+/api-shutdown

Fixes #1472 
Fixes #1573