### PR TITLE
caliBlur! style: Fixes issue with edit metadata button not getting styled correctly

### DIFF
--- a/cps/static/css/caliBlur.min.css
+++ b/cps/static/css/caliBlur.min.css
@@ -585,7 +585,7 @@ div.btn-group[role=group][aria-label="Download, send to Kindle, reading"] > .dow
     border-left: 2px solid rgba(0, 0, 0, .15)
 }
 
-div[aria-label="Edit/Delete book"] > .btn-warning {
+div[aria-label="Edit/Delete book"] > .btn {
     width: 50px;
     height: 60px;
     margin: 0;
@@ -600,7 +600,7 @@ div[aria-label="Edit/Delete book"] > .btn-warning {
     color: transparent
 }
 
-div[aria-label="Edit/Delete book"] > .btn-warning > span {
+div[aria-label="Edit/Delete book"] > .btn > span {
     visibility: visible;
     position: relative;
     display: inline-block;
@@ -616,7 +616,7 @@ div[aria-label="Edit/Delete book"] > .btn-warning > span {
     margin: auto
 }
 
-div[aria-label="Edit/Delete book"] > .btn-warning > span:before {
+div[aria-label="Edit/Delete book"] > .btn > span:before {
     content: "\EA5d";
     font-family: plex-icons;
     font-size: 20px;
@@ -625,7 +625,7 @@ div[aria-label="Edit/Delete book"] > .btn-warning > span:before {
     height: 60px
 }
 
-div[aria-label="Edit/Delete book"] > .btn-warning > span:hover {
+div[aria-label="Edit/Delete book"] > .btn > span:hover {
     color: #fff
 }
 


### PR DESCRIPTION
This was affecting the Develop branch because it looks like the edit metadata button had a class change (from `btn-warning` to `btn-primary`). I updated it to just select `btn` so that the style gets applied regardless

Before:

![image](https://user-images.githubusercontent.com/3904767/91647368-06174080-ea28-11ea-8df1-c87c75e8265b.png)


After:

![image](https://user-images.githubusercontent.com/3904767/91647369-09aac780-ea28-11ea-9601-7f7ae3997277.png)
