### PR TITLE
Automatic conversion in kepub during Kobo sync

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -178,6 +178,10 @@ def HandleSyncRequest():
 
     reading_states_in_new_entitlements = []
     for book in changed_entries:
+        formats = [data.format for data in book.data]
+        if not 'KEPUB' in formats and config.config_kepubifypath and 'EPUB' in formats:
+            helper.convert_book_format(book.id, config.config_calibre_dir, 'EPUB', 'KEPUB', current_user.nickname)
+
         kobo_reading_state = get_or_create_reading_state(book.id)
         entitlement = {
             "BookEntitlement": create_book_entitlement(book, archived=(book.id in archived_book_ids)),


### PR DESCRIPTION
The Kobo e-readers assume that ebook downloaded during sync are in `KEPUB` format, so they interpret as `KEPUB` even if they are `EPUB`.
This misunderstanding generates strange malfunctions (#1439 & #1484) that affect the reading experience.

The PR #1570 prefers the `KEPUB` format over the `EPUB`, but only if this is available, so the user must perform a manual conversion before starting the synchronization in order to have a correct behavior.
You would have a better user experience, and less error prone, with automatic conversion.

In my opinion the best time to perform this conversion is during synchronization.
In fact, in this way, ebooks are converted only when conversion is strictly necessary and it is ensured that all ebooks synchronized with the Kobo are actually in `KEPUB`.

This PR converts all new ebooks, only if they are not available in `KEPUB` and the kepubify path has been set.