### PR TITLE
add Litres, ISSN and ISFDB tag references

### DIFF
--- a/cps/db.py
+++ b/cps/db.py
@@ -117,6 +117,8 @@ class Identifiers(Base):
             return u"Google Books"
         elif format_type == "kobo":
             return u"Kobo"
+        elif format_type == "litres":
+            return u"ЛитРес"
         if format_type == "lubimyczytac":
             return u"Lubimyczytac"
         else:

--- a/cps/db.py
+++ b/cps/db.py
@@ -119,6 +119,8 @@ class Identifiers(Base):
             return u"Kobo"
         elif format_type == "litres":
             return u"ЛитРес"
+        elif format_type == "issn":
+            return u"ISSN"
         if format_type == "lubimyczytac":
             return u"Lubimyczytac"
         else:
@@ -146,6 +148,8 @@ class Identifiers(Base):
             return u" https://lubimyczytac.pl/ksiazka/{0}".format(self.val)
         elif format_type == "litres":
             return u"https://www.litres.ru/{0}".format(self.val)
+        elif format_type == "issn":
+            return u"https://portal.issn.org/resource/ISSN/{0}".format(self.val)
         elif format_type == "url":
             return u"{0}".format(self.val)
         else:

--- a/cps/db.py
+++ b/cps/db.py
@@ -121,6 +121,8 @@ class Identifiers(Base):
             return u"ЛитРес"
         elif format_type == "issn":
             return u"ISSN"
+        elif format_type == "isfdb":
+            return u"ISFDB"
         if format_type == "lubimyczytac":
             return u"Lubimyczytac"
         else:
@@ -150,6 +152,8 @@ class Identifiers(Base):
             return u"https://www.litres.ru/{0}".format(self.val)
         elif format_type == "issn":
             return u"https://portal.issn.org/resource/ISSN/{0}".format(self.val)
+        elif format_type == "isfdb":
+            return u"http://www.isfdb.org/cgi-bin/pl.cgi?{0}".format(self.val)
         elif format_type == "url":
             return u"{0}".format(self.val)
         else:

--- a/cps/db.py
+++ b/cps/db.py
@@ -142,6 +142,8 @@ class Identifiers(Base):
             return u"https://www.kobo.com/ebook/{0}".format(self.val)
         elif format_type == "lubimyczytac":
             return u" https://lubimyczytac.pl/ksiazka/{0}".format(self.val)
+        elif format_type == "litres":
+            return u"https://www.litres.ru/{0}".format(self.val)
         elif format_type == "url":
             return u"{0}".format(self.val)
         else:


### PR DESCRIPTION
Links to https://www.litres.ru, https://portal.issn.org and http://www.isfdb.org/

examples:
https://www.litres.ru/47453330
https://portal.issn.org/resource/ISSN/1937-7843
http://www.isfdb.org/cgi-bin/pl.cgi?389761