### PR TITLE
Remove global Session object, replace with CalibreDB class

### DIFF
--- a/cps/__init__.py
+++ b/cps/__init__.py
@@ -83,6 +83,8 @@ log = logger.create()
 
 from . import services
 
+db.CalibreDB.setup_db(config, cli.settingspath)
+
 calibre_db = db.CalibreDB()
 
 def create_app():
@@ -91,7 +93,7 @@ def create_app():
     if sys.version_info < (3, 0):
         app.static_folder = app.static_folder.decode('utf-8')
         app.root_path = app.root_path.decode('utf-8')
-        app.instance_path = app.instance_path .decode('utf-8')
+        app.instance_path = app.instance_path.decode('utf-8')
 
     cache_buster.init_cache_busting(app)
 
@@ -101,7 +103,6 @@ def create_app():
     app.secret_key = os.getenv('SECRET_KEY', config_sql.get_flask_session_key(ub.session))
 
     web_server.init_app(app, config)
-    calibre_db.setup_db(config, cli.settingspath)
 
     babel.init_app(app)
     _BABEL_TRANSLATIONS.update(str(item) for item in babel.list_translations())

--- a/cps/db.py
+++ b/cps/db.py
@@ -423,10 +423,15 @@ class CalibreDB():
     def __init__(self):
         """ Initialize a new CalibreDB session
         """
-        if not self._init:
-            raise Exception("CalibreDB not initialized")
-        self.session = self.session_factory()
+        self.session = None
+        if self._init:
+            self.initSession()
+
         self.instances.add(self)
+
+
+    def initSession(self):
+        self.session = self.session_factory()
         self.update_title_sort(self.config)
 
     @classmethod
@@ -534,6 +539,9 @@ class CalibreDB():
         cls.session_factory = scoped_session(sessionmaker(autocommit=False,
                                                           autoflush=True,
                                                           bind=cls.engine))
+        for inst in cls.instances:
+            inst.initSession()
+            
         cls._init = True
         return True
 

--- a/cps/db.py
+++ b/cps/db.py
@@ -413,9 +413,10 @@ class AlchemyEncoder(json.JSONEncoder):
 class CalibreDB():
     _init = False
     engine = None
-    log = None  # todo: ??? this isn't used, and even then, not sure if it's supposed to be per session or what
     config = None
     session_factory = None
+    # This is a WeakSet so that references here don't keep other CalibreDB
+    # instances alive once they reach the end of their respective scopes
     instances = WeakSet()
 
     def __init__(self):

--- a/cps/db.py
+++ b/cps/db.py
@@ -51,8 +51,6 @@ try:
 except ImportError:
     use_unidecode = False
 
-Session = None
-
 cc_exceptions = ['datetime', 'comments', 'composite', 'series']
 cc_classes = {}
 
@@ -438,9 +436,6 @@ class CalibreDB():
     def setup_db(cls, config, app_db_path):
         cls.config = config
         cls.dispose()
-
-        # todo: remove...?
-        global Session
 
         if not config.config_calibre_dir:
             config.invalidate()

--- a/cps/tasks/convert.py
+++ b/cps/tasks/convert.py
@@ -53,7 +53,7 @@ class TaskConvert(CalibreTask):
 
     def _convert_ebook_format(self):
         error_message = None
-        local_session = db.Session()
+        local_session = db.CalibreDB()
         file_path = self.file_path
         book_id = self.bookid
         format_old_ext = u'.' + self.settings['old_book_format'].lower()

--- a/cps/tasks/convert.py
+++ b/cps/tasks/convert.py
@@ -53,7 +53,7 @@ class TaskConvert(CalibreTask):
 
     def _convert_ebook_format(self):
         error_message = None
-        local_session = db.CalibreDB()
+        local_session = db.CalibreDB().session
         file_path = self.file_path
         book_id = self.bookid
         format_old_ext = u'.' + self.settings['old_book_format'].lower()


### PR DESCRIPTION
Recently a global session object was introduced (feacbe8ebd35803ebd9ed88cc931564cfc9bcb86) that allowed another thread to get a local session object for it's own use.

I had a need to not just get a new session, but also utilize functions that come with the CalibreDB class. I couldn't just call the global `calibre_db` variable tho because it contained a session that was incompatible with other threads, and I didn't want to rewrite all the methods to have a session object injected as an argument

This PR aims to improve upon that. the database setup is now done on the class itself. Local sessions can be created using `local_ssession = CalibreDB()`. The `__init__()` function will use the previously set up session maker and set `self.session`. Additionally, it will register itself to the class's ` instances` list - this is required so that we can iterate over all active instances and dispose of them correctly (that being said, there will usually only ever be 1 instance unless a thread / task has created another).

I should note that I ran this through the testing framework and everything seems like it's working :)