### PR TITLE
Fix missing audio icon for other audio formats than mp3

### DIFF
--- a/cps/templates/author.html
+++ b/cps/templates/author.html
@@ -65,7 +65,7 @@
             {% endif %}
           {% endfor %}
           {% for format in entry.data %}
-            {% if format.format|lower == 'mp3' %}
+            {% if format.format|lower in g.constants.EXTENSIONS_AUDIO %}
             <span class="glyphicon glyphicon-music"></span>
             {% endif %}
           {% endfor %}

--- a/cps/templates/index.html
+++ b/cps/templates/index.html
@@ -104,7 +104,7 @@
             {% endif %}
           {% endfor %}
           {% for format in entry.data %}
-            {% if format.format|lower == 'mp3' %}
+            {% if format.format|lower in g.constants.EXTENSIONS_AUDIO %}
             <span class="glyphicon glyphicon-music"></span>
             {% endif %}
           {%endfor%}

--- a/cps/templates/search.html
+++ b/cps/templates/search.html
@@ -67,7 +67,7 @@
             {% endif %}
           {% endfor %}
           {% for format in entry.data %}
-            {% if format.format|lower == 'mp3' %}
+            {% if format.format|lower in g.constants.EXTENSIONS_AUDIO %}
             <span class="glyphicon glyphicon-music"></span>
             {% endif %}
           {% endfor %}

--- a/cps/web.py
+++ b/cps/web.py
@@ -293,6 +293,7 @@ def edit_required(f):
 def before_request():
     if current_user.is_authenticated:
         confirm_login()
+    g.constants = constants
     g.user = current_user
     g.allow_registration = config.config_public_reg
     g.allow_anonymous = config.config_anonbrowse


### PR DESCRIPTION
Books with audio formats different than mp3 didn't display audio icon next to author name in list of books.