### PR TITLE
Adapt find version path to actual repository structure

### DIFF
--- a/cps/constants.py
+++ b/cps/constants.py
@@ -129,7 +129,7 @@ def selected_roles(dictionary):
 BookMeta = namedtuple('BookMeta', 'file_path, extension, title, author, cover, description, tags, series, '
                                   'series_id, languages')
 
-STABLE_VERSION = {'version': '0.6.10 Beta'}
+STABLE_VERSION = {'version': '0.6.10b1'}
 
 NIGHTLY_VERSION = {}
 NIGHTLY_VERSION[0] = '$Format:%H$'

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 universal = 1
 
 [metadata]
-name = calibreweb
+name = calibre-web
 url = https://github.com/janeczku/calibre-web
 project_urls =
   Bug Tracker = https://github.com/janeczku/calibre-web/issues
@@ -33,9 +33,6 @@ keywords =
   library
 python_requires = >=2.6
 
-[options.entry_points]
-console_scripts =
-  cps = calibreweb:main
 [options]
 include_package_data = True
 dependency_links = comicapi @ git+https://github.com/OzzieIsaacs/comicapi.git@5346716578b2843f54d522f44d01bc8d25001d24#egg=comicapi

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ def find_version(*file_paths):
     raise RuntimeError("Unable to find version string.")
 
 setup(
-    packages=find_packages("src"),
-    package_dir = {'': 'src'},
-    version=find_version("src", "calibreweb", "cps", "constants.py")
+    packages=find_packages("./"),
+    package_dir = {'': './'},
+    version=find_version("cps", "constants.py")
 )

--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,6 @@ def find_version(*file_paths):
 setup(
     packages=find_packages("./"),
     package_dir = {'': './'},
-    version=find_version("cps", "constants.py")
+    version=find_version("cps", "constants.py"),
+    scripts=['cps.py']
 )


### PR DESCRIPTION
First of thanks for you work :D
I'm trying to package calibre web for nixos and found some issues with the setup.py.
The changes contain my suggestions for how to fix them, but I'm not really familiar with the pypi packaging process. Let me know what you think

- the setup.py expects a file structure that is not present in this repo. I think it should only use folders that are available.
- I also seen that your versioning schema does not conform to PEP 440 versioning https://www.python.org/dev/peps/pep-0440/
- The `console_script` is used for Python Functions not for Python scripts https://python-packaging.readthedocs.io/en/latest/command-line-scripts.html

