### PR TITLE
Forward Overdrive requests to Kobo Store

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -860,6 +860,7 @@ def HandleUserRequest(dummy=None):
 @kobo.route("/v1/products/<dummy>/recommendations", methods=["GET", "POST"])
 @kobo.route("/v1/products/<dummy>/nextread", methods=["GET", "POST"])
 @kobo.route("/v1/products/<dummy>/reviews", methods=["GET", "POST"])
+@kobo.route("/v1/products/books/external/<dummy>", methods=["GET", "POST"])
 @kobo.route("/v1/products/books/series/<dummy>", methods=["GET", "POST"])
 @kobo.route("/v1/products/books/<dummy>", methods=["GET", "POST"])
 @kobo.route("/v1/products/dailydeal", methods=["GET", "POST"])


### PR DESCRIPTION
When loading books from OverDrive, Kobo readers make requests to `/v1/products/books/external/<overdrive ids>`.
This adds a route to forward these requests to the Kobo Store, so that OverDrive still works when using Calibre-Web's Kobo sync server.

I've tested this manually with my Libra H2O connecting to my Calibre-Web server running on Ubuntu 20.04.1. Without this patch, most OverDrive pages would not load and new loans would not be downloaded during a sync, but after adding this everything seems to work as expected.