### PR TITLE
Added basic dark mode support to the ePub reader

### DIFF
--- a/cps/static/js/reading/epub.js
+++ b/cps/static/js/reading/epub.js
@@ -46,17 +46,29 @@ var reader;
     // Dark mode logic
     $("#colorMode").on( "click", function() {
       if ($("#colorMode").prop("checked")) {
-        $("#main").css("background", "#343233");
-        $("#titlebar").css("color", "#ccc")
-        $("iframe").contents().find("body").css('background-color', '#4b4b4b');
-        $("iframe").contents().find("body").css('color', '#ccc');
-        $("iframe").contents().find("a:link").css('color', '#fe8019');
+        darkMode();
       } else {
         $("#main").css("background", "#fff");
         $("#titlebar").css("color", "#4f4f4f")
         $("iframe").contents().find("body").css('background-color', 'white');
         $("iframe").contents().find("body").css('color', 'black');
         $("iframe").contents().find("a:link").css('color', '#00f');
+      }
+    })
+
+    function darkMode() {
+      console.log("Dark mode activated");
+      $("#main").css("background", "#343233");
+      $("#titlebar").css("color", "#ccc")
+      $("iframe").contents().find("body").css('background-color', '#4b4b4b');
+      $("iframe").contents().find("body").css('color', '#ccc');
+      $("iframe").contents().find("a:link").css('color', '#fe8019');
+    }
+
+    //Prevent dark mode from changing on page reload
+    $(".arrow").on("click", function() {
+      if ($("#colorMode").prop("checked") && $("iframe").contents().find("body").css('background-color') == 'rgb(255, 255, 255)') {
+        darkMode();
       }
     })
 

--- a/cps/static/js/reading/epub.js
+++ b/cps/static/js/reading/epub.js
@@ -42,4 +42,22 @@ var reader;
             alert(error);
         });
     }
+
+    // Dark mode logic
+    $("#colorMode").on( "click", function() {
+      if ($("#colorMode").prop("checked")) {
+        $("#main").css("background", "#343233");
+        $("#titlebar").css("color", "#ccc")
+        $("iframe").contents().find("body").css('background-color', '#4b4b4b');
+        $("iframe").contents().find("body").css('color', '#ccc');
+        $("iframe").contents().find("a:link").css('color', '#fe8019');
+      } else {
+        $("#main").css("background", "#fff");
+        $("#titlebar").css("color", "#4f4f4f")
+        $("iframe").contents().find("body").css('background-color', 'white');
+        $("iframe").contents().find("body").css('color', 'black');
+        $("iframe").contents().find("a:link").css('color', '#00f');
+      }
+    })
+
 })();

--- a/cps/templates/read.html
+++ b/cps/templates/read.html
@@ -73,6 +73,9 @@
                   <p>
                     <input type="checkbox" id="sidebarReflow" name="sidebarReflow">{{_('Reflow text when sidebars are open.')}}
                   </p>
+                  <p>
+                    <input type="checkbox" id="colorMode" name="colorMode">{{_('Read this in Dark Mode (Experimental)')}}
+                  </p>
               </div>
               <div class="closer icon-cancel-circled"></div>
           </div>


### PR DESCRIPTION
I added a toggle button that allows toggling of dark mode in the ePub reader through the built-in settings menu

However, the only drawback that I had was the `iframe` that contains the content for the ePub gets refreshed after every section, which wipes the temporary css changes that changed its colors. The best way I found to solve this is to check the background of the `iframe` every time a page is turned

Suggestions welcome!