### PR TITLE
Added ability to not truncate title

### DIFF
--- a/cps/jinjia.py
+++ b/cps/jinjia.py
@@ -51,12 +51,14 @@ def url_for_other_page(page):
 
 # shortentitles to at longest nchar, shorten longer words if necessary
 @jinjia.app_template_filter('shortentitle')
-def shortentitle_filter(s, nchar=20):
+def shortentitle_filter(s, nchar=20, truncate_title=True):
     text = s.split()
     res = ""  # result
     suml = 0  # overall length
     for line in text:
-        if suml >= 60:
+        # truncate title if more than 60 characters and we don't want to show
+        # the entire title
+        if suml >= 60 and truncate_title:
             res += '...'
             break
         # if word longer than 20 chars truncate line and append '...', otherwise add whole word to result

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -89,7 +89,7 @@
             {% endif %}
         </div>
       </div>
-      <h2 id="title">{{entry.title|shortentitle(40)}}</h2>
+      <h2 id="title">{{entry.title|shortentitle(40, False)}}</h2>
       <p class="author">
           {% for author in entry.authors %}
             <a href="{{url_for('web.books_list',  data='author', sort_param='new', book_id=author.id ) }}">{{author.name.replace('|',',')}}</a>


### PR DESCRIPTION
Fixes #1482 

This PR adds an optional parameter to the `shortentitle_filter` function for Jinja to prevent shortening titles in the Details page. I tested it with both themes, and it looks like book titles are still shortened correctly everywhere else. The caliBlur theme (second image) shows the title is not shortened in the main view, but is still shortened just below the search bar.

Title not truncated:
![image](https://user-images.githubusercontent.com/5686638/102965272-bfec5e00-44aa-11eb-91b8-614198860fc6.png)
![image](https://user-images.githubusercontent.com/5686638/102965291-ca0e5c80-44aa-11eb-85d4-29bb67e0d7c4.png)

Title still truncated in main view:
![image](https://user-images.githubusercontent.com/5686638/102965330-dd212c80-44aa-11eb-86f0-b5379bb418b8.png)

I did find an issue when browsing with a mobile device where the 26 characters of the english alphabet were too long to fit on the screen (shown below), but that is a different issue from the title being shortened.
![image](https://user-images.githubusercontent.com/5686638/102965474-1f4a6e00-44ab-11eb-845d-5d241c37ae97.png)
