### PR TITLE
Added proper UI support for dark mode on the ePub reader

### DIFF
--- a/cps/static/css/kthoom.css
+++ b/cps/static/css/kthoom.css
@@ -181,7 +181,6 @@ th {
 }
 
 .settings-column {
-  float: left;
   min-width: 35%;
   padding-bottom: 10px;
 }

--- a/cps/templates/read.html
+++ b/cps/templates/read.html
@@ -13,6 +13,7 @@
         <link rel="stylesheet" href="{{ url_for('static', filename='css/libs/normalize.css') }}">
         <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
         <link rel="stylesheet" href="{{ url_for('static', filename='css/popup.css') }}">
+        <link rel="stylesheet" href="{{ url_for('static', filename='css/kthoom.css') }}" type="text/css"/>
     </head>
     <body>
       <div id="sidebar">
@@ -70,10 +71,39 @@
           <div class="md-content">
               <h3>{{_('Settings')}}</h3>
               <div>
-                  <p>
-                    <input type="checkbox" id="sidebarReflow" name="sidebarReflow">{{_('Reflow text when sidebars are open.')}}
-                  </p>
+                <div class="settings-column">
+                  <table>
+                    <tbody>
+                      <th>
+                        <div class="inputs">
+                          <input type="checkbox" id="sidebarReflow" name="sidebarReflow"> {{_('Reflow text when sidebars are open.')}}
+                        </div>
+                      </th>
+                    </tbody>
+                  </table>
+                </div>
+                <div class="settings-column">
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>{{_('Settings')}}</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <th>{{_('Theme')}}:</th>
+                        <td>
+                          <div class="inputs">
+                            <label for="lightTheme"><input type="radio" id="lightTheme" name="theme" value="light" checked /> {{_('Light')}}</label>
+                            <label for="darkTheme"><input type="radio" id="darkTheme" name="theme" value="dark" /> {{_('Dark')}}</label>
+                          </div>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
               </div>
+
               <div class="closer icon-cancel-circled"></div>
           </div>
       </div>


### PR DESCRIPTION
This is an implementation of UI support for dark mode in the ePub reader, that only includes the HTML and CSS changes of the settings menu

This continues the discussion in my previous PR #1736

Although, to properly add a theme for `epub.min.js`, the configuration code needs to be put in a JS file, because right now it appears that these functions are part of a minified JS file at `cps/static/js/libs/reader.min.js`, which I do not know how is generated