### PR TITLE
Added option in order to synchronize only selected shelves on Kobo device

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -165,14 +165,14 @@ def HandleSyncRequest():
     if sync_token.books_last_id > -1:
         changed_entries = changed_entries.filter(db.Books.id > sync_token.books_last_id)
 
-    only_kobo_shelfs = (
+    only_kobo_shelves = (
                            calibre_db.session.query(ub.Shelf)
                                .filter(ub.Shelf.user_id == current_user.id)
                                .filter(ub.Shelf.kobo_sync)
                                .count()
                        ) > 0
 
-    if only_kobo_shelfs:
+    if only_kobo_shelves:
         changed_entries = (
             changed_entries.join(ub.BookShelf, db.Books.id == ub.BookShelf.book_id)
                 .join(ub.Shelf)
@@ -244,7 +244,7 @@ def HandleSyncRequest():
             })
             new_reading_state_last_modified = max(new_reading_state_last_modified, kobo_reading_state.last_modified)
 
-    sync_shelves(sync_token, sync_results, only_kobo_shelfs=only_kobo_shelfs)
+    sync_shelves(sync_token, sync_results, only_kobo_shelves=only_kobo_shelves)
 
     sync_token.books_last_created = new_books_last_created
     sync_token.books_last_modified = new_books_last_modified
@@ -605,7 +605,7 @@ def HandleTagRemoveItem(tag_id):
 
 # Add new, changed, or deleted shelves to the sync_results.
 # Note: Public shelves that aren't owned by the user aren't supported.
-def sync_shelves(sync_token, sync_results, only_kobo_shelfs=False):
+def sync_shelves(sync_token, sync_results, only_kobo_shelves=False):
     new_tags_last_modified = sync_token.tags_last_modified
 
     for shelf in ub.session.query(ub.ShelfArchive).filter(func.datetime(ub.ShelfArchive.last_modified) > sync_token.tags_last_modified,
@@ -622,7 +622,7 @@ def sync_shelves(sync_token, sync_results, only_kobo_shelfs=False):
         })
 
     extra_filters = []
-    if only_kobo_shelfs:
+    if only_kobo_shelves:
         for shelf in ub.session.query(ub.Shelf).filter(
             func.datetime(ub.Shelf.last_modified) > sync_token.tags_last_modified,
             ub.Shelf.user_id == current_user.id,

--- a/cps/shelf.py
+++ b/cps/shelf.py
@@ -239,6 +239,12 @@ def create_edit_shelf(shelf, title, page, shelf_id=False):
             shelf.is_public = 1
         else:
             shelf.is_public = 0
+
+        if "kobo_sync" in to_save:
+            shelf.kobo_sync = True
+        else:
+            shelf.kobo_sync = False
+
         if check_shelf_is_unique(shelf, to_save, shelf_id):
             shelf.name = to_save["title"]
             # shelf.last_modified = datetime.utcnow()

--- a/cps/shelf.py
+++ b/cps/shelf.py
@@ -30,7 +30,7 @@ from flask_login import login_required, current_user
 from sqlalchemy.sql.expression import func, true
 from sqlalchemy.exc import OperationalError, InvalidRequestError
 
-from . import logger, ub, calibre_db, db
+from . import logger, ub, calibre_db, db, config
 from .render_template import render_title_template
 from .usermanagement import login_required_if_no_ano
 
@@ -240,10 +240,8 @@ def create_edit_shelf(shelf, title, page, shelf_id=False):
         else:
             shelf.is_public = 0
 
-        if "kobo_sync" in to_save:
+        if config.config_kobo_sync and "kobo_sync" in to_save:
             shelf.kobo_sync = True
-        else:
-            shelf.kobo_sync = False
 
         if check_shelf_is_unique(shelf, to_save, shelf_id):
             shelf.name = to_save["title"]
@@ -269,7 +267,11 @@ def create_edit_shelf(shelf, title, page, shelf_id=False):
                 ub.session.rollback()
                 log.debug_or_exception(e)
                 flash(_(u"There was an error"), category="error")
-    return render_title_template('shelf_edit.html', shelf=shelf, title=title, page=page)
+    return render_title_template('shelf_edit.html',
+                                 shelf=shelf,
+                                 title=title,
+                                 page=page,
+                                 kobo_sync_enabled=config.config_kobo_sync)
 
 
 def check_shelf_is_unique(shelf, to_save, shelf_id=False):

--- a/cps/shelf.py
+++ b/cps/shelf.py
@@ -21,19 +21,19 @@
 #  along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import division, print_function, unicode_literals
-from datetime import datetime
+
 import sys
+from datetime import datetime
 
-from flask import Blueprint, request, flash, redirect, url_for
+from flask import Blueprint, flash, redirect, request, url_for
 from flask_babel import gettext as _
-from flask_login import login_required, current_user
+from flask_login import current_user, login_required
+from sqlalchemy.exc import InvalidRequestError, OperationalError
 from sqlalchemy.sql.expression import func, true
-from sqlalchemy.exc import OperationalError, InvalidRequestError
 
-from . import logger, ub, calibre_db, db, config
+from . import calibre_db, config, db, logger, ub
 from .render_template import render_title_template
 from .usermanagement import login_required_if_no_ano
-
 
 shelf = Blueprint('shelf', __name__)
 log = logger.create()
@@ -240,8 +240,11 @@ def create_edit_shelf(shelf, title, page, shelf_id=False):
         else:
             shelf.is_public = 0
 
-        if config.config_kobo_sync and "kobo_sync" in to_save:
-            shelf.kobo_sync = True
+        if config.config_kobo_sync:
+            if "kobo_sync" in to_save:
+                shelf.kobo_sync = True
+            else:
+                shelf.kobo_sync = False
 
         if check_shelf_is_unique(shelf, to_save, shelf_id):
             shelf.name = to_save["title"]
@@ -358,8 +361,8 @@ def order_shelf(shelf_id):
     shelf = ub.session.query(ub.Shelf).filter(ub.Shelf.id == shelf_id).first()
     result = list()
     if shelf and check_shelf_view_permissions(shelf):
-        result = calibre_db.session.query(db.Books)\
-            .join(ub.BookShelf,ub.BookShelf.book_id == db.Books.id , isouter=True) \
+        result = calibre_db.session.query(db.Books) \
+            .join(ub.BookShelf, ub.BookShelf.book_id == db.Books.id, isouter=True) \
             .add_columns(calibre_db.common_filters().label("visible")) \
             .filter(ub.BookShelf.shelf == shelf_id).order_by(ub.BookShelf.order.asc()).all()
     return render_title_template('shelf_order.html', entries=result,
@@ -368,7 +371,7 @@ def order_shelf(shelf_id):
 
 
 def change_shelf_order(shelf_id, order):
-    result = calibre_db.session.query(db.Books).join(ub.BookShelf,ub.BookShelf.book_id == db.Books.id)\
+    result = calibre_db.session.query(db.Books).join(ub.BookShelf, ub.BookShelf.book_id == db.Books.id) \
         .filter(ub.BookShelf.shelf == shelf_id).order_by(*order).all()
     for index, entry in enumerate(result):
         book = ub.session.query(ub.BookShelf).filter(ub.BookShelf.shelf == shelf_id) \
@@ -408,13 +411,13 @@ def render_show_shelf(shelf_type, shelf_id, page_no, sort_param):
             page = 'shelfdown.html'
 
         result, __, pagination = calibre_db.fill_indexpage(page_no, pagesize,
-                                                            db.Books,
-                                                            ub.BookShelf.shelf == shelf_id,
-                                                            [ub.BookShelf.order.asc()],
-                                                            ub.BookShelf,ub.BookShelf.book_id == db.Books.id)
+                                                           db.Books,
+                                                           ub.BookShelf.shelf == shelf_id,
+                                                           [ub.BookShelf.order.asc()],
+                                                           ub.BookShelf, ub.BookShelf.book_id == db.Books.id)
         # delete chelf entries where book is not existent anymore, can happen if book is deleted outside calibre-web
-        wrong_entries = calibre_db.session.query(ub.BookShelf)\
-            .join(db.Books, ub.BookShelf.book_id == db.Books.id, isouter=True)\
+        wrong_entries = calibre_db.session.query(ub.BookShelf) \
+            .join(db.Books, ub.BookShelf.book_id == db.Books.id, isouter=True) \
             .filter(db.Books.id == None).all()
         for entry in wrong_entries:
             log.info('Not existing book {} in {} deleted'.format(entry.book_id, shelf))

--- a/cps/templates/shelf_edit.html
+++ b/cps/templates/shelf_edit.html
@@ -13,6 +13,11 @@
           <input type="checkbox" name="is_public" {% if shelf.is_public == 1 %}checked{% endif %}> {{_('Share with Everyone')}}
         </label>
       </div>
+      <div class="checkbox">
+        <label>
+          <input type="checkbox" name="kobo_sync" {% if shelf.kobo_sync == 1 %}checked{% endif %}> {{_('Synchronize with Kobo device')}}
+        </label>
+      </div>
     {% endif %}
     <button type="submit" class="btn btn-default" id="submit">{{_('Save')}}</button>
     {% if shelf.id != None %}

--- a/cps/templates/shelf_edit.html
+++ b/cps/templates/shelf_edit.html
@@ -13,10 +13,13 @@
           <input type="checkbox" name="is_public" {% if shelf.is_public == 1 %}checked{% endif %}> {{_('Share with Everyone')}}
         </label>
       </div>
+    {% endif %}
+    {% if kobo_sync_enabled %}
       <div class="checkbox">
-        <label>
-          <input type="checkbox" name="kobo_sync" {% if shelf.kobo_sync == 1 %}checked{% endif %}> {{_('Synchronize with Kobo device')}}
-        </label>
+          <label>
+              <input type="checkbox" name="kobo_sync"
+                     {% if shelf.kobo_sync == 1 %}checked{% endif %}> {{ _('Synchronize with Kobo device') }}
+          </label>
       </div>
     {% endif %}
     <button type="submit" class="btn btn-default" id="submit">{{_('Save')}}</button>

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -498,6 +498,7 @@ def migrate_Database(session):
             conn.execute("ALTER TABLE shelf ADD column 'created' DATETIME")
             conn.execute("ALTER TABLE shelf ADD column 'last_modified' DATETIME")
             conn.execute("ALTER TABLE book_shelf_link ADD column 'date_added' DATETIME")
+            conn.execute("ALTER TABLE shelf ADD column 'kobo_sync' BOOLEAN DEFAULT false")
         for shelf in session.query(Shelf).all():
             shelf.uuid = str(uuid.uuid4())
             shelf.created = datetime.datetime.now()


### PR DESCRIPTION
* Added a flag to shelves in order to set whether they must be synchronized with Kobo device.
* Only books on kobo shelves are synchronized.
* Shelves modified after last sync with no kobo sync flag are remove from Kobo device.
* Update db on startup: kobo_sync field to shelf table.
* In order to keep old behavior, if no shelves are marked to kobo sync, all books and shelves are synchronized.

Maybe, it solves/helps: #1276