### PR TITLE
Declare variables before using them

### DIFF
--- a/cps/db.py
+++ b/cps/db.py
@@ -624,6 +624,8 @@ class CalibreDB():
             .join(*join, isouter=True) \
             .filter(db_filter) \
             .filter(self.common_filters(allow_show_archived))
+        entries = list()
+        pagination = list()
         try:
             pagination = Pagination(page, pagesize,
                                     len(query.all()))


### PR DESCRIPTION
It should fix the following stacktrace:

```
[2021-02-18 14:46:14,771] ERROR {cps:1891} Exception on / [GET]
Traceback (most recent call last):
  File "/opt/calibre/vendor/flask/app.py", line 2447, in wsgi_app
    response = self.full_dispatch_request()
  File "/opt/calibre/vendor/flask/app.py", line 1952, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/opt/calibre/vendor/flask/app.py", line 1821, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/opt/calibre/vendor/flask/_compat.py", line 39, in reraise
    raise value
  File "/opt/calibre/vendor/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/opt/calibre/vendor/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/opt/calibre/cps/usermanagement.py", line 38, in decorated_view
    return login_required(func)(*args, **kwargs)
  File "/opt/calibre/vendor/flask_login/utils.py", line 272, in decorated_view
    return func(*args, **kwargs)
  File "/opt/calibre/cps/web.py", line 719, in index
    return render_books_list("newest", sort_param, 1, page)
  File "/opt/calibre/cps/web.py", line 422, in render_books_list
    entries, random, pagination = calibre_db.fill_indexpage(page, 0, db.Books, True, order)
  File "/opt/calibre/cps/db.py", line 610, in fill_indexpage
    return self.fill_indexpage_with_archived_books(page, pagesize, database, db_filter, order, False, *join)
  File "/opt/calibre/cps/db.py", line 635, in fill_indexpage_with_archived_books
    #    book = self.order_authors(book)
UnboundLocalError: local variable 'entries' referenced before assignment
```