### PR TITLE
Use the kobo auth'd version for download link when proxied -- Fixes #1908

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -305,7 +305,8 @@ def get_download_url_for_book(book, book_format):
             book_format=book_format.lower()
         )
     return url_for(
-        "web.download_link",
+        "kobo.download_book",
+        auth_token=kobo_auth.get_auth_token(),
         book_id=book.id,
         book_format=book_format.lower(),
         _external=True,


### PR DESCRIPTION
I think this fixes the problem I brought up in #1908 

Non proxied:
```
curl -qs 'http://localhost:3000/kobo/748fcddbd2434fedc765d0394034d1a6/v1/library/sync?Filter=ALL&DownloadUrlFilter=Generic,Android&PrioritizeRecentReads=true' | jq '.[0].NewEntitlement.BookMetadata.DownloadUrls'
[
  {
    "Format": "KEPUB",
    "Platform": "Generic",
    "Size": 412767,
    "Url": "http://localhost:8083/kobo/748fcddbd2434fedc765d0394034d1a6/download/1/kepub"
  }
]
```

Proxied:
```
curl -qs 'https://proxy/kobo/748fcddbd2434fedc765d0394034d1a6/v1/library/sync?Filter=ALL&DownloadUrlFilter=Generic,Android&PrioritizeRecentReads=true' | jq '.[0].NewEntitlement.BookMetadata.DownloadUrls'
[
  {
    "Format": "KEPUB",
    "Platform": "Generic",
    "Size": 412767,
    "Url": "https://proxy/kobo/748fcddbd2434fedc765d0394034d1a6/download/1/kepub"
  }
]
```

Download keypub with key:
```
curl https://proxy/kobo/748fcddbd2434fedc765d0394034d1a6/download/1/kepub
Warning: Binary output can mess up your terminal. Use "--output -" to tell
Warning: curl to output it to your terminal anyway, or consider "--output
Warning: <FILE>" to save to a file.
```

Download old url:
```
curl https://proxy/download/1/kepub
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<title>Redirecting...</title>
<h1>Redirecting...</h1>
<p>You should be redirected automatically to target URL: <a href="/login?next=%2Fdownload%2F1%2Fkepub">/login?next=%2Fdownload%2F1%2Fkepub</a>.  If not click the link.%
```