### PR TITLE
Fixed a few graphical issues and the fact that caliblur book details was broken after engaging infinite scroll

### DIFF
--- a/cps/static/css/caliBlur.css
+++ b/cps/static/css/caliBlur.css
@@ -577,10 +577,6 @@ body.shelforder > div.container-fluid > div.row-fluid > div.col-sm-10:before {
     color: hsla(0, 0%, 100%, .7)
 }
 
-div.btn-group[role=group][aria-label="Download, send to Kindle, reading"] > .downloadBtn {
-    border-left: 2px solid rgba(0, 0, 0, .15)
-}
-
 div[aria-label="Edit/Delete book"] > .btn {
     width: 50px;
     height: 60px;
@@ -3145,6 +3141,10 @@ div.btn-group[role=group][aria-label="Download, send to Kindle, reading"] > div.
     margin: 0;
     overflow: hidden;
     padding: 0
+}
+#readbtn {
+  height: 100%;
+  padding: 16px;
 }
 
 #add-to-shelf > span.caret, #btnGroupDrop1 > span.caret, #read-in-browser > span.caret, .btn-toolbar > .btn-group > #btnGroupDrop2 > span.caret, .btn-toolbar > .btn-group > .btn-group > #btnGroupDrop2 > span.caret {

--- a/cps/static/css/caliBlur.css
+++ b/cps/static/css/caliBlur.css
@@ -2936,8 +2936,9 @@ body > div.container-fluid > div > div.col-sm-10 > div > div > div.col-sm-3.col-
 }
 
 #bookDetailsModal > .modal-dialog.modal-lg > .modal-content > .modal-body > div > div > div > div.col-sm-3.col-lg-3.col-xs-5 > div.cover, body > div.container-fluid > div > div.col-sm-10 > div > div > div.col-sm-3.col-lg-3.col-xs-5 > div.cover {
-    margin: 0;
+    margin: auto;
     width: 100%;
+    max-width: 200px;
 }
 
 #bookDetailsModal > .modal-dialog.modal-lg > .modal-content > .modal-body > div > div > div > div.col-sm-3.col-lg-3.col-xs-5 > div.cover > img, body > div.container-fluid > div > div.col-sm-10 > div > div > div.col-sm-3.col-lg-3.col-xs-5 > div.cover > img {

--- a/cps/static/js/main.js
+++ b/cps/static/js/main.js
@@ -316,6 +316,8 @@ $(function() {
         $loadMore.on( "append.infiniteScroll", function( event, response, path, data ) {
             if ($("body").hasClass("blur")) {
                 $(".pagination").addClass("hidden").html(() => $(response).find(".pagination").html());
+                $(" a:not(.dropdown-toggle) ")
+                  .removeAttr("data-toggle");
             }
             $(".load-more .row").isotope( "appended", $(data), null );
         });


### PR DESCRIPTION
Fixed several issues in caliblur theme:

- Book display no longer has borders that go way outside the cover
- Made the toolbar in book details page less ugly in caliblur
- Fixed the fact that book details view was broken in caliblur if book was scrolled to via infinite scroll (see https://github.com/gilbN/theme.park/issues/168 - this was actually a calibre web problem)