### PR TITLE
Added options on Comic Viewer to remove y-scrollbar and reset page scroll after changing pages

### DIFF
--- a/cps/static/css/kthoom.css
+++ b/cps/static/css/kthoom.css
@@ -227,3 +227,14 @@ th {
 .dark-theme .overlay {
   background-color: rgba(0, 0, 0, 0.8);
 }
+
+/* Hide scrollbar for Chrome, Safari and Opera */
+.disabled-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
+/* Hide scrollbar for IE, Edge and Firefox */
+.disabled-scrollbar {
+  -ms-overflow-style: none;  /* IE and Edge */
+  scrollbar-width: none;  /* Firefox */
+}

--- a/cps/static/js/kthoom.js
+++ b/cps/static/js/kthoom.js
@@ -69,7 +69,9 @@ var settings = {
     rotateTimes: 0,
     fitMode: kthoom.Key.B,
     theme: "light",
-    direction: 0 // 0 = Left to Right, 1 = Right to Left
+    direction: 0, // 0 = Left to Right, 1 = Right to Left
+	nextPage: 0, // 0 = Reset to Top, 1 = Remember Position
+	scrollbar: 1 // 0 = Hide Scrollbar, 1 = Show Scrollbar
 };
 
 kthoom.saveSettings = function() {
@@ -282,6 +284,7 @@ function updatePage() {
     }
 
     $("body").toggleClass("dark-theme", settings.theme === "dark");
+	$("#mainContent").toggleClass("disabled-scrollbar", settings.scrollbar === 0);
 
     kthoom.setSettings();
     kthoom.saveSettings();
@@ -439,6 +442,9 @@ function showPrevPage() {
         currentImage++;
     } else {
         updatePage();
+		if (settings.nextPage === 0) {
+			$("#mainContent").scrollTop(0);
+		}
     }
 }
 
@@ -449,6 +455,9 @@ function showNextPage() {
         currentImage--;
     } else {
         updatePage();
+		if (settings.nextPage === 0) {
+			$("#mainContent").scrollTop(0);
+		}
     }
 }
 
@@ -650,6 +659,9 @@ function init(filename) {
     $("#thumbnails").on("click", "a", function() {
         currentImage = $(this).data("page") - 1;
         updatePage();
+		if (settings.nextPage === 0) {
+			$("#mainContent").scrollTop(0);
+		}
     });
 
     // Fullscreen mode

--- a/cps/templates/readcbr.html
+++ b/cps/templates/readcbr.html
@@ -158,6 +158,24 @@
               </div>
             </td>
           </tr>
+	        <tr>
+            <th>{{_('Next Page')}}:</th>
+            <td>
+              <div class="inputs">
+                <label for="resetToTop"><input type="radio" id="resetToTop" name="nextPage" value="0" /> {{_('Reset to Top')}}</label>
+                <label for="rememberPosition"><input type="radio" id="rememberPosition" name="nextPage" value="1" /> {{_('Remember Position')}}</label>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <th>{{_('Scrollbar')}}:</th>
+            <td>
+              <div class="inputs">
+                <label for="showScrollbar"><input type="radio" id="showScrollbar" name="scrollbar" value="1" /> {{_('Show')}}</label>
+                <label for="hideScrollbar"><input type="radio" id="hideScrollbar" name="scrollbar" value="0" /> {{_('Hide')}}</label>
+              </div>
+            </td>
+          </tr>
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
- PR centered around some QoL changes for **Scale: Width** comic readers 
- Added an option to disable y-scrollbar on Comic Viewer
   - This helps readers who prefer to use Scale: Width and don't need/want the scrollbar
- Added Reset to Top behavior on Comic Viewer
  - After every new page, the Comic Reader will scroll the new page all the way to the top. This helps readers using Scale: Width so they don't have to manually scroll to the top every new page
  -  **Reset to Top**: Will always scroll to top after every next/previous page or selecting a page from the ToC
  - **Remember Position**: Default behavior

![image](https://user-images.githubusercontent.com/68790233/116008183-9b83c800-a5e9-11eb-968c-e0901244660d.png)

_Missing translations_
_Missing Keyboard Shortcuts_
