### PR TITLE
add python-version to gitignore and fixed caliblur on mobile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
+.python-version
 env/
 venv/
 eggs/

--- a/cps/static/css/caliBlur.css
+++ b/cps/static/css/caliBlur.css
@@ -6490,7 +6490,9 @@ body.edituser.admin > div.container-fluid > div.row-fluid > div.col-sm-10 > div.
         height: 150px;
         margin-bottom: 0
     }
-
+    .container-fluid .book .cover img {
+    width: 100px !important;
+    }
     #books .cover img, #books_rand .cover img, .book.isotope-item .cover img {
         width: 100px !important
     }


### PR DESCRIPTION
## Changes
- Added `.python-version` to git ignore in case (like me) people manage their python with pyenv and they want to have Calibre use an isolated / stable python version
- Fixed a mobile styling issue for Caliblur. In shelves/search/discover we had:
![Capture](https://user-images.githubusercontent.com/4482454/129464487-93a9b298-d818-4a4f-81ff-d0fa0d653f00.PNG)
And now have:
![Capture1](https://user-images.githubusercontent.com/4482454/129464505-97285858-af72-4dec-b474-254c6608790e.PNG)
