### PR TITLE
Fix filemodal file selection dialog

### DIFF
--- a/cps/static/js/main.js
+++ b/cps/static/js/main.js
@@ -652,10 +652,10 @@ $(function() {
         var folder = target.data("folderonly");
         var filter = target.data("filefilter");
         $("#element_selected").text(path);
-        $("#file_confirm")[0].attributes["data-link"].value = target.data("link");
-        $("#file_confirm")[0].attributes["data-folderonly"].value = (typeof folder === 'undefined') ? false : true;
-        $("#file_confirm")[0].attributes["data-filefilter"].value = (typeof filter === 'undefined') ? "" : filter;
-        $("#file_confirm")[0].attributes["data-newfile"].value = target.data("newfile");
+        $("#file_confirm").data("link", target.data("link"));
+        $("#file_confirm").data("folderonly", (typeof folder === 'undefined') ? false : true);
+        $("#file_confirm").data("filefilter", (typeof filter === 'undefined') ? "" : filter);
+        $("#file_confirm").data("newfile", target.data("newfile"));
         fillFileTable(path,"dir", folder, filter);
     });
 
@@ -669,7 +669,7 @@ $(function() {
         var folder = $(file_confirm).data("folderonly");
         var filter = $(file_confirm).data("filefilter");
         var newfile = $(file_confirm).data("newfile");
-        if (newfile !== 'undefined') {
+        if (newfile !== "") {
             $("#element_selected").text(path + $("#new_file".text()));
         } else {
             $("#element_selected").text(path);


### PR DESCRIPTION
Hi there,
While playing around calibre-web I noticed a peculiar behaviour: if there's more than one filepicker on a page after using any of them the others operate on the text input related to the one that was opened first. 
Some debugging revealed that this happens due to the fact that `$(this).data("link")` on the line 663 returns a value from jQuery cache (that contains a link to the first input) and ignores changes to DOM made via `$("#file_confirm")[0].attributes["data-link"].value =` ([more info on that behaviour](https://stackoverflow.com/questions/42854273/jquery-after-replacing-attribute-value-getting-old-value)). I changed the way the data is being written and read to be consistent consistent, it has eliminated the problem.

FWIW, here's a formal description of the issue:

Steps to reproduce
1. Navigate to http://localhost:8083/admin/config
2. Unfold "Server Configuration" section
3. Click the filepicker next to the text input under "SSL certfile location (leave it empty for non-SSL Servers)"
4. Navigate to an arbitrary location
5. Confirm selection
6. Click the filepicker next to the text input under "SSL Keyfile location (leave it empty for non-SSL Servers)
7. Navigate to an arbitrary location
8. Confirm selection

Expected result:
The value of the first text input is set to the result of step 5
The value of the second text input is set to the result of step 8

Actual result:
The value of the first text input is set to the result of step 8
The second text input is empty