### PR TITLE
New filename sort for Comic Reader

### DIFF
--- a/cps/static/js/kthoom.js
+++ b/cps/static/js/kthoom.js
@@ -180,13 +180,15 @@ function initProgressClick() {
 
 function loadFromArrayBuffer(ab) {
     var lastCompletion = 0;
+    const collator = new Intl.Collator('en', { numeric: true, sensitivity: 'base' });
     loadArchiveFormats(['rar', 'zip', 'tar'], function() {
         // Open the file as an archive
         archiveOpenFile(ab, function (archive) {
             if (archive) {
                 totalImages = archive.entries.length
                 console.info('Uncompressing ' + archive.archive_type + ' ...');
-                archive.entries.forEach(function(e, i) {
+                entries = archive.entries.sort((a,b) => collator.compare(a.name, b.name));
+                entries.forEach(function(e, i) {
                     updateProgress( (i + 1)/ totalImages * 100);
                     if (e.is_file) {
                         e.readData(function(d) {


### PR DESCRIPTION
Prior filename sorting for Comic Reader would not work correctly for filenames with numbers on it. Comic Reader would open a file like this:
- 1.png, 10.png, 11.png ... 19.png, 2.png, 20.png, 21.png ...

This new filename sorting would change it to:

- 1.png, 2.png ... 11.png ... 19.png, 20.png, 21.png ...