### PR TITLE
Prevent virtual keyboard login auto capitalization

### DIFF
--- a/cps/templates/login.html
+++ b/cps/templates/login.html
@@ -7,7 +7,7 @@
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <div class="form-group">
       <label for="username">{{_('Username')}}</label>
-      <input type="text" class="form-control" id="username" name="username" placeholder="{{_('Username')}}">
+      <input type="text" class="form-control" id="username" name="username" autocapitalize="off" placeholder="{{_('Username')}}">
     </div>
     <div class="form-group">
       <label for="password">{{_('Password')}}</label>


### PR DESCRIPTION
Stops virtual keyboards, such as the ones on mobile devices, to default to uppercase for the first letter of the login user input field.