### PR TITLE
Multiple authors and publication date in opds feed

### DIFF
--- a/cps/templates/feed.xml
+++ b/cps/templates/feed.xml
@@ -53,7 +53,7 @@
         <name>{{entry.Books.publishers[0].name}}</name>
       </publisher>
     {% endif %}
-    <published>{{entry.Books.pubdate}}</published>
+    <published>{{entry.Books.pubdate.strftime("%Y-%m-%dT%H:%M:%S+00:00")}}</published>
     {% for lang in entry.Books.languages %}
       <dcterms:language>{{lang.lang_code}}</dcterms:language>
     {% endfor %}

--- a/cps/templates/feed.xml
+++ b/cps/templates/feed.xml
@@ -43,16 +43,17 @@
     <title>{{entry.Books.title}}</title>
     <id>urn:uuid:{{entry.Books.uuid}}</id>
     <updated>{{entry.Books.atom_timestamp}}</updated>
-    {% if entry.Books.authors.__len__() > 0 %}
+    {% for author in entry.Books.authors %}
       <author>
-        <name>{{entry.Books.authors[0].name}}</name>
+        <name>{{author.name}}</name>
       </author>
-    {% endif %}
+    {% endfor %}
     {% if entry.Books.publishers.__len__() > 0 %}
       <publisher>
         <name>{{entry.Books.publishers[0].name}}</name>
       </publisher>
     {% endif %}
+    <published>{{entry.Books.pubdate}}</published>
     {% for lang in entry.Books.languages %}
       <dcterms:language>{{lang.lang_code}}</dcterms:language>
     {% endfor %}


### PR DESCRIPTION
Adds some metadata to the opds feed (multiple authors and publication date). 

Some reader software picks up on this, others doesn't. What is being displayed and how differs greatly from reader to reader. For example, another way to display multiple authors is 
```
{% if entry.Books.authors.__len__() > 0 %}
    <author>
      <name>{% for author in entry.Books.authors %}{{author.name}}{% if not loop.last %} &amp; {% endif %}{% endfor %}</name>
    </author>
{% endif %}
```
While some can work with both others can only use one or the other. 

So while I'd really like to also add multiple identifiers (ISBN, DOI, Amazon, ...) I have not found a way to have any reader software pick up on it. I'm not sure if it is even worth implementing this. Would greatly appreciate input! Fixes #2402.