### PR TITLE
Bugfix for Error 500 when giving non-existend database path

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -1668,9 +1668,10 @@ def _db_configuration_update_helper():
 
     if db_change or not db_valid or not config.db_configured \
             or config.config_calibre_dir != to_save["config_calibre_dir"]:
-        if not calibre_db.setup_db(to_save['config_calibre_dir'], ub.app_DB_path):
-            return _db_configuration_result(_('DB Location is not Valid, Please Enter Correct Path'),
-                                            gdrive_error)
+        if not os.path.exists(metadata_db) or not to_save['config_calibre_dir']:
+            return _db_configuration_result(_('DB Location is not Valid, Please Enter Correct Path'), gdrive_error)
+        else:
+            calibre_db.setup_db(to_save['config_calibre_dir'], ub.app_DB_path)
         config.store_calibre_uuid(calibre_db, db.Library_Id)
         # if db changed -> delete shelfs, delete download books, delete read books, kobo sync...
         if db_change:

--- a/cps/db.py
+++ b/cps/db.py
@@ -567,12 +567,12 @@ class CalibreDB:
 
         if not config_calibre_dir:
             cls.config.invalidate()
-            return False
+            return None
 
         dbpath = os.path.join(config_calibre_dir, "metadata.db")
         if not os.path.exists(dbpath):
             cls.config.invalidate()
-            return False
+            return None
 
         try:
             cls.engine = create_engine('sqlite://',
@@ -588,7 +588,7 @@ class CalibreDB:
             # conn.text_factory = lambda b: b.decode(errors = 'ignore') possible fix for #1302
         except Exception as ex:
             cls.config.invalidate(ex)
-            return False
+            return None
 
         cls.config.db_configured = True
 
@@ -598,7 +598,7 @@ class CalibreDB:
                 cls.setup_db_cc_classes(cc)
             except OperationalError as e:
                 log.error_or_exception(e)
-                return False
+                return None
 
         cls.session_factory = scoped_session(sessionmaker(autocommit=False,
                                                           autoflush=True,
@@ -607,7 +607,6 @@ class CalibreDB:
             inst.init_session()
 
         cls._init = True
-        return True
 
     def get_book(self, book_id):
         return self.session.query(Books).filter(Books.id == book_id).first()

--- a/cps/static/js/main.js
+++ b/cps/static/js/main.js
@@ -677,8 +677,8 @@ $(function() {
                 if ( data.change ) {
                     if ( data.valid ) {
                         confirmDialog(
-                        "db_submit",
-                    "GeneralChangeModal",
+                            "db_submit",
+                            "GeneralChangeModal",
                             0,
                             changeDbSettings
                         );


### PR DESCRIPTION
Fixes #2419, a bug where calibre-web breaks with an error 500 if one has a working DB configuration and then tries to update the DB path to a non-existent one.