### PR TITLE
Embed metadata when sending to device

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -1721,6 +1721,7 @@ def _configuration_update_helper():
             constants.EXTENSIONS_UPLOAD = config.config_upload_formats.split(',')
 
         _config_string(to_save, "config_calibre")
+        _config_string(to_save, "config_binariesdir")
         _config_string(to_save, "config_converterpath")
         _config_string(to_save, "config_kepubifypath")
 

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -1724,6 +1724,10 @@ def _configuration_update_helper():
         _config_string(to_save, "config_binariesdir")
         _config_string(to_save, "config_converterpath")
         _config_string(to_save, "config_kepubifypath")
+        if "config_binariesdir" in to_save:
+            calibre_status = helper.check_calibre(config.config_binariesdir)
+            if calibre_status:
+                return _configuration_result(calibre_status)
 
         reboot_required |= _config_int(to_save, "config_login_type")
 

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -43,7 +43,7 @@ from . import constants, logger, helper, services, cli_param
 from . import db, calibre_db, ub, web_server, config, updater_thread, gdriveutils, \
     kobo_sync_status, schedule
 from .helper import check_valid_domain, send_test_mail, reset_password, generate_password_hash, check_email, \
-    valid_email, check_username
+    valid_email, check_username, get_calibre_binarypath
 from .gdriveutils import is_gdrive_ready, gdrive_support
 from .render_template import render_title_template, get_sidebar_config
 from .services.worker import WorkerThread
@@ -1727,8 +1727,7 @@ def _configuration_update_helper():
             calibre_status = helper.check_calibre(config.config_binariesdir)
             if calibre_status:
                 return _configuration_result(calibre_status)
-            # ToDo: Remove this and 'self.config_converterpath' and replace with 'config.get_calibre_binarypath("ebook-convert")' everywhere
-            to_save["config_converterpath"] = config.get_calibre_binarypath("ebook-convert")
+            to_save["config_converterpath"] = get_calibre_binarypath("ebook-convert")
             _config_string(to_save, "config_converterpath")
 
         reboot_required |= _config_int(to_save, "config_login_type")

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -1722,12 +1722,14 @@ def _configuration_update_helper():
 
         _config_string(to_save, "config_calibre")
         _config_string(to_save, "config_binariesdir")
-        _config_string(to_save, "config_converterpath")
         _config_string(to_save, "config_kepubifypath")
         if "config_binariesdir" in to_save:
             calibre_status = helper.check_calibre(config.config_binariesdir)
             if calibre_status:
                 return _configuration_result(calibre_status)
+            # ToDo: Remove this and 'self.config_converterpath' and replace with 'config.get_calibre_binarypath("ebook-convert")' everywhere
+            to_save["config_converterpath"] = config.get_calibre_binarypath("ebook-convert")
+            _config_string(to_save, "config_converterpath")
 
         reboot_required |= _config_int(to_save, "config_login_type")
 

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -269,15 +269,6 @@ class _ConfigSQL(object):
     def get_scheduled_task_settings(self):
         return {k:v for k, v in self.__dict__.items() if k.startswith('schedule_')}
 
-    def get_calibre_binarypath(self, binary):
-        binariesdir = self.config_binariesdir
-        if binariesdir:
-            if binary in constants.SUPPORTED_CALIBRE_BINARIES:
-                return os.path.join(binariesdir, binary)
-            else:
-                raise ValueError("'{}' is not a supported Calibre binary".format(binary))
-        return ""
-
     def set_from_dictionary(self, dictionary, field, convertor=None, default=None, encode=None):
         """Possibly updates a field of this object.
         The new value, if present, is grabbed from the given dictionary, and optionally passed through a convertor.
@@ -428,7 +419,7 @@ def autodetect_calibre_binaries():
     else:
         calibre_path = ["/opt/calibre/"]
     for element in calibre_path:
-        supported_binary_paths = [os.path.join(element, binary) for binary in constants.SUPPORTED_CALIBRE_BINARIES]
+        supported_binary_paths = [os.path.join(element, binary) for binary in constants.SUPPORTED_CALIBRE_BINARIES.values()]
         if all(os.path.isfile(binary_path) and os.access(binary_path, os.X_OK) for binary_path in supported_binary_paths):
             values = [process_wait([binary_path, "--version"], pattern='\(calibre (.*)\)') for binary_path in supported_binary_paths]
             if all(values):

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -172,10 +172,7 @@ class _ConfigSQL(object):
         if self.config_binariesdir == None: # pylint: disable=access-member-before-definition
             change = True
             self.config_binariesdir = autodetect_calibre_binaries()
-
-        if self.config_converterpath == None:  # pylint: disable=access-member-before-definition
-            change = True
-            self.config_converterpath = autodetect_converter_binary()
+            self.config_converterpath = autodetect_converter_binary(self.config_binariesdir)
 
         if self.config_kepubifypath == None:  # pylint: disable=access-member-before-definition
             change = True
@@ -441,13 +438,12 @@ def autodetect_calibre_binaries():
     return ""
 
 
-def autodetect_converter_binary():
-    calibre_path = autodetect_calibre_binaries()
+def autodetect_converter_binary(calibre_path):
     if sys.platform == "win32":
         converter_path = os.path.join(calibre_path, "ebook-convert.exe")
     else:
         converter_path = os.path.join(calibre_path, "ebook-convert")
-    if os.path.isfile(converter_path) and os.access(converter_path, os.X_OK):
+    if calibre_path and os.path.isfile(converter_path) and os.access(converter_path, os.X_OK):
         return converter_path
     return ""
 

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -278,8 +278,7 @@ class _ConfigSQL(object):
             if binary in constants.SUPPORTED_CALIBRE_BINARIES:
                 return os.path.join(binariesdir, binary)
             else:
-                # TODO: Error handling
-                pass
+                raise ValueError("'{}' is not a supported Calibre binary".format(binary))
         return ""
 
     def set_from_dictionary(self, dictionary, field, convertor=None, default=None, encode=None):

--- a/cps/constants.py
+++ b/cps/constants.py
@@ -154,7 +154,7 @@ EXTENSIONS_UPLOAD = {'txt', 'pdf', 'epub', 'kepub', 'mobi', 'azw', 'azw3', 'cbr'
 _extension = ""
 if sys.platform == "win32":
     _extension = ".exe"
-SUPPORTED_CALIBRE_BINARIES = {binary:binary + _extension for binary in ["ebook-convert", "calibredb"]}
+SUPPORTED_CALIBRE_BINARIES = {binary:binary + _extension for binary in ["ebook-convert", "calibredb", "ebook-meta"]}
 
 
 def has_flag(value, bit_flag):

--- a/cps/constants.py
+++ b/cps/constants.py
@@ -152,6 +152,9 @@ EXTENSIONS_UPLOAD = {'txt', 'pdf', 'epub', 'kepub', 'mobi', 'azw', 'azw3', 'cbr'
                      'opus', 'wav', 'flac', 'm4a', 'm4b'}
 
 
+SUPPORTED_CALIBRE_BINARIES = ["ebook-convert", "calibredb"]
+
+
 def has_flag(value, bit_flag):
     return bit_flag == (bit_flag & (value or 0))
 

--- a/cps/constants.py
+++ b/cps/constants.py
@@ -151,8 +151,10 @@ EXTENSIONS_UPLOAD = {'txt', 'pdf', 'epub', 'kepub', 'mobi', 'azw', 'azw3', 'cbr'
                      'prc', 'doc', 'docx', 'fb2', 'html', 'rtf', 'lit', 'odt', 'mp3', 'mp4', 'ogg',
                      'opus', 'wav', 'flac', 'm4a', 'm4b'}
 
-
-SUPPORTED_CALIBRE_BINARIES = ["ebook-convert", "calibredb"]
+_extension = ""
+if sys.platform == "win32":
+    _extension = ".exe"
+SUPPORTED_CALIBRE_BINARIES = [binary + _extension for binary in ["ebook-convert", "calibredb"]]
 
 
 def has_flag(value, bit_flag):

--- a/cps/constants.py
+++ b/cps/constants.py
@@ -154,7 +154,7 @@ EXTENSIONS_UPLOAD = {'txt', 'pdf', 'epub', 'kepub', 'mobi', 'azw', 'azw3', 'cbr'
 _extension = ""
 if sys.platform == "win32":
     _extension = ".exe"
-SUPPORTED_CALIBRE_BINARIES = [binary + _extension for binary in ["ebook-convert", "calibredb"]]
+SUPPORTED_CALIBRE_BINARIES = {binary:binary + _extension for binary in ["ebook-convert", "calibredb"]}
 
 
 def has_flag(value, bit_flag):

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -951,7 +951,7 @@ def check_calibre(calibre_location):
         return _('Please specify a directory, not a file')
 
     try:
-        supported_binary_paths = [os.path.join(calibre_location, binary) for binary in SUPPORTED_CALIBRE_BINARIES]
+        supported_binary_paths = [os.path.join(calibre_location, binary) for binary in SUPPORTED_CALIBRE_BINARIES.values()]
         binaries_available=[os.path.isfile(binary_path) and os.access(binary_path, os.X_OK) for binary_path in supported_binary_paths]
         if all(binaries_available):
             values = [process_wait([binary_path, "--version"], pattern='\(calibre (.*)\)') for binary_path in supported_binary_paths]
@@ -961,7 +961,7 @@ def check_calibre(calibre_location):
             else:
                 return _('Calibre binaries not viable')
         else:
-            missing_binaries=[path for path, available in zip(SUPPORTED_CALIBRE_BINARIES, binaries_available) if not available]
+            missing_binaries=[path for path, available in zip(SUPPORTED_CALIBRE_BINARIES.values(), binaries_available) if not available]
             return _('Missing calibre binaries: %(missing)s', missing=", ".join(missing_binaries))
 
     except (OSError, UnicodeDecodeError) as err:
@@ -1030,6 +1030,17 @@ def get_download_link(book_id, book_format, client):
         return do_download_file(book, book_format, client, data1, headers)
     else:
         abort(404)
+
+
+def get_calibre_binarypath(binary):
+        binariesdir = config.config_binariesdir
+        if binariesdir:
+            try:
+                return os.path.join(binariesdir, SUPPORTED_CALIBRE_BINARIES[binary])
+            except KeyError as ex:
+                log.error("Binary not supported by Calibre-Web: %s", SUPPORTED_CALIBRE_BINARIES[binary])
+                pass
+        return ""
 
 
 def clear_cover_thumbnail_cache(book_id):

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -952,7 +952,8 @@ def check_calibre(calibre_location):
 
     try:
         supported_binary_paths = [os.path.join(calibre_location, binary) for binary in SUPPORTED_CALIBRE_BINARIES]
-        if all(os.path.isfile(binary_path) and os.access(binary_path, os.X_OK) for binary_path in supported_binary_paths):
+        binaries_available=[os.path.isfile(binary_path) and os.access(binary_path, os.X_OK) for binary_path in supported_binary_paths]
+        if all(binaries_available):
             values = [process_wait([binary_path, "--version"], pattern='\(calibre (.*)\)') for binary_path in supported_binary_paths]
             if all(values):
                 version = values[0].group(1)
@@ -960,7 +961,8 @@ def check_calibre(calibre_location):
             else:
                 return _('Calibre binaries not viable')
         else:
-            return _('Missing calibre binaries in the specified directory')
+            missing_binaries=[path for path, available in zip(SUPPORTED_CALIBRE_BINARIES, binaries_available) if not available]
+            return _('Missing calibre binaries: %(missing)s', missing=", ".join(missing_binaries))
 
     except (OSError, UnicodeDecodeError) as err:
         log.error_or_exception(err)

--- a/cps/tasks/convert.py
+++ b/cps/tasks/convert.py
@@ -233,18 +233,19 @@ class TaskConvert(CalibreTask):
             # windows py2.7 encode as string with quotes empty element for parameters is okay
             # windows py 3.x no encode and as string with quotes empty element for parameters is okay
             # separate handling for windows and linux
-            quotes = [1, 2]
 
-            # TODO: Clean up.
-            # TODO: Maybe delete/clean-up tmp files directly.
+            quotes = [3, 5]
             tmp_dir = os.path.join(gettempdir(), 'calibre_web')
+            if not os.path.isdir(tmp_dir):
+                os.mkdir(tmp_dir)
             calibredb_binarypath = config.get_calibre_binarypath("calibredb")
             opf_command = [calibredb_binarypath, 'show_metadata', '--as-opf', str(book_id), '--with-library', config.config_calibre_dir]
-            p = process_open(opf_command)
+            p = process_open(opf_command, quotes)
             path_tmp_opf = os.path.join(tmp_dir, "metadata_" + str(current_milli_time()) + ".opf")
             with open(path_tmp_opf, 'w') as fd:
                 copyfileobj(p.stdout, fd)
 
+            quotes = [1, 2, 4, 6]
             command = [config.config_converterpath, (file_path + format_old_ext),
                        (file_path + format_new_ext), '--from-opf', path_tmp_opf,
                        '--cover', os.path.join(os.path.dirname(file_path), 'cover.jpg')]
@@ -257,7 +258,7 @@ class TaskConvert(CalibreTask):
                     quotes_index += 1
 
             p = process_open(command, quotes, newlines=False)
-        except OSError as e:
+        except (ValueError, OSError) as e:
             return 1, N_(u"Ebook-converter failed: %(error)s", error=e)
 
         while p.poll() is None:

--- a/cps/tasks/convert.py
+++ b/cps/tasks/convert.py
@@ -93,6 +93,16 @@ class TaskConvert(CalibreTask):
                 # todo: figure out how to incorporate this into the progress
                 try:
                     EmailText = N_(u"%(book)s send to Kindle", book=escape(self.title))
+                    # ToDo: Delete when OPF creation has been implemented
+                    if config.config_binariesdir:
+                        quotes = [3, 5]
+                        calibredb_binarypath = os.path.join(config.config_binariesdir, SUPPORTED_CALIBRE_BINARIES["calibredb"])
+                        opf_command = [calibredb_binarypath, 'show_metadata', '--as-opf', str(self.book_id), '--with-library', config.config_calibre_dir]
+                        p = process_open(opf_command, quotes)
+                        p.wait()
+                        path_opf = os.path.join(config.config_calibre_dir, cur_book.path, "metadata.opf")
+                        with open(path_opf, 'w') as fd:
+                            copyfileobj(p.stdout, fd)
                     worker_thread.add(self.user, TaskEmail(self.settings['subject'],
                                                            self.results["path"],
                                                            filename,

--- a/cps/tasks/convert.py
+++ b/cps/tasks/convert.py
@@ -241,6 +241,7 @@ class TaskConvert(CalibreTask):
             calibredb_binarypath = os.path.join(config.config_binariesdir, SUPPORTED_CALIBRE_BINARIES["calibredb"])
             opf_command = [calibredb_binarypath, 'show_metadata', '--as-opf', str(book_id), '--with-library', config.config_calibre_dir]
             p = process_open(opf_command, quotes)
+            p.wait()
             path_tmp_opf = os.path.join(tmp_dir, "metadata_" + str(current_milli_time()) + ".opf")
             with open(path_tmp_opf, 'w') as fd:
                 copyfileobj(p.stdout, fd)

--- a/cps/tasks/convert.py
+++ b/cps/tasks/convert.py
@@ -235,10 +235,11 @@ class TaskConvert(CalibreTask):
             # separate handling for windows and linux
             quotes = [1, 2]
 
-            # TODO: Clean up and make cli work with windows.
+            # TODO: Clean up.
+            # TODO: Maybe delete/clean-up tmp files directly.
             tmp_dir = os.path.join(gettempdir(), 'calibre_web')
-            path_calibrecli = os.path.join(os.path.dirname(config.config_converterpath), "calibredb")
-            opf_command = [path_calibrecli, 'show_metadata', '--as-opf', str(book_id), '--with-library', config.config_calibre_dir]
+            calibredb_binarypath = config.get_calibre_binarypath("calibredb")
+            opf_command = [calibredb_binarypath, 'show_metadata', '--as-opf', str(book_id), '--with-library', config.config_calibre_dir]
             p = process_open(opf_command)
             path_tmp_opf = os.path.join(tmp_dir, "metadata_" + str(current_milli_time()) + ".opf")
             with open(path_tmp_opf, 'w') as fd:

--- a/cps/tasks/convert.py
+++ b/cps/tasks/convert.py
@@ -37,7 +37,7 @@ from cps.ub import init_db_thread
 
 from cps.tasks.mail import TaskEmail
 from cps import gdriveutils
-
+from cps.constants import SUPPORTED_CALIBRE_BINARIES
 
 log = logger.create()
 
@@ -238,7 +238,7 @@ class TaskConvert(CalibreTask):
             tmp_dir = os.path.join(gettempdir(), 'calibre_web')
             if not os.path.isdir(tmp_dir):
                 os.mkdir(tmp_dir)
-            calibredb_binarypath = config.get_calibre_binarypath("calibredb")
+            calibredb_binarypath = os.path.join(config.config_binariesdir, SUPPORTED_CALIBRE_BINARIES["calibredb"])
             opf_command = [calibredb_binarypath, 'show_metadata', '--as-opf', str(book_id), '--with-library', config.config_calibre_dir]
             p = process_open(opf_command, quotes)
             path_tmp_opf = os.path.join(tmp_dir, "metadata_" + str(current_milli_time()) + ".opf")
@@ -258,7 +258,7 @@ class TaskConvert(CalibreTask):
                     quotes_index += 1
 
             p = process_open(command, quotes, newlines=False)
-        except (ValueError, OSError) as e:
+        except OSError as e:
             return 1, N_(u"Ebook-converter failed: %(error)s", error=e)
 
         while p.poll() is None:

--- a/cps/tasks/convert.py
+++ b/cps/tasks/convert.py
@@ -21,10 +21,8 @@ import re
 from glob import glob
 from shutil import copyfile, copyfileobj
 from markupsafe import escape
-#donrar
 from tempfile import gettempdir
 from time import time
-#enddonrar
 
 from sqlalchemy.exc import SQLAlchemyError
 from flask_babel import lazy_gettext as N_
@@ -237,7 +235,7 @@ class TaskConvert(CalibreTask):
             # separate handling for windows and linux
             quotes = [1, 2]
 
-            # TODO: Clean up and make cli work with windows. Also, implement changing covers.
+            # TODO: Clean up and make cli work with windows.
             tmp_dir = os.path.join(gettempdir(), 'calibre_web')
             path_calibrecli = os.path.join(os.path.dirname(config.config_converterpath), "calibredb")
             opf_command = [path_calibrecli, 'show_metadata', '--as-opf', str(book_id), '--with-library', config.config_calibre_dir]
@@ -247,7 +245,8 @@ class TaskConvert(CalibreTask):
                 copyfileobj(p.stdout, fd)
 
             command = [config.config_converterpath, (file_path + format_old_ext),
-                       (file_path + format_new_ext), '--from-opf', path_tmp_opf]
+                       (file_path + format_new_ext), '--from-opf', path_tmp_opf,
+                       '--cover', os.path.join(os.path.dirname(file_path), 'cover.jpg')]
             quotes_index = 3
             if config.config_calibre:
                 parameters = config.config_calibre.split(" ")

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -323,6 +323,13 @@
     </div>
     <div id="collapsefive" class="panel-collapse collapse">
       <div class="panel-body">
+           <label for="config_binariesdir">{{_('Path to Calibre Binaries')}}</label>
+           <div class="form-group input-group">
+           <input type="text" class="form-control" id="config_binariesdir" name="config_binariesdir" value="{% if config.config_binariesdir != None %}{{ config.config_binariesdir }}{% endif %}" autocomplete="off">
+           <span class="input-group-btn">
+             <button type="button" data-toggle="modal" id="binaries_modal_path" data-link="config_binariesdir" data-target="#fileModal" class="btn btn-default"><span class="glyphicon glyphicon-folder-open"></span></button>
+           </span>
+           </div>
            <label for="config_converterpath">{{_('Path to Calibre E-Book Converter')}}</label>
            <div class="form-group input-group">
             <input type="text" class="form-control" id="config_converterpath" name="config_converterpath" value="{% if config.config_converterpath != None %}{{ config.config_converterpath }}{% endif %}" autocomplete="off">

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -330,13 +330,6 @@
              <button type="button" data-toggle="modal" id="binaries_modal_path" data-link="config_binariesdir" data-target="#fileModal" class="btn btn-default"><span class="glyphicon glyphicon-folder-open"></span></button>
            </span>
            </div>
-           <label for="config_converterpath">{{_('Path to Calibre E-Book Converter')}}</label>
-           <div class="form-group input-group">
-            <input type="text" class="form-control" id="config_converterpath" name="config_converterpath" value="{% if config.config_converterpath != None %}{{ config.config_converterpath }}{% endif %}" autocomplete="off">
-            <span class="input-group-btn">
-              <button type="button" data-toggle="modal" id="converter_modal_path" data-link="config_converterpath" data-target="#fileModal" class="btn btn-default"><span class="glyphicon glyphicon-folder-open"></span></button>
-            </span>
-           </div>
            <div class="form-group">
               <label for="config_calibre">{{_('Calibre E-Book Converter Settings')}}</label>
               <input type="text" class="form-control" id="config_calibre" name="config_calibre" value="{% if config.config_calibre != None %}{{ config.config_calibre }}{% endif %}" autocomplete="off">


### PR DESCRIPTION
This is a draft PR for embedding metadata when sending to devices. It depends on  #2463. At the moment the Calibre CLI is used to create OPF files, these parts of the code should be deleted once Calibre-Web supports OPF files. 