### PR TITLE
Fix: ignore special files originating from Apple devices

### DIFF
--- a/cps/static/js/kthoom.js
+++ b/cps/static/js/kthoom.js
@@ -163,6 +163,14 @@ kthoom.ImageFile = function(file) {
             this.mimeType = undefined;
             break;
     }
+
+    // Reset mime type for special files originating from Apple devices
+    // This folder may contain files having image extensions (for example .jpg) but those files are not actual images
+    // Trying to view these files cause corrupted/empty pages in the comic reader and files should be ignored
+    if (this.filename.indexOf("__MACOSX") !== -1) {
+        this.mimeType = undefined;
+    }
+
     if ( this.mimeType !== undefined) {
         this.dataURI = createURLFromArray(file.fileData, this.mimeType);
     }


### PR DESCRIPTION
**Issue**
If .cbz archive is created on a Apple device, it may have __MACOSX folder. Files in that folder may have image extension but are actually not images files. Comic reader renders these files as corrupted pages.

![Error](https://user-images.githubusercontent.com/54019006/181200158-7884dbb5-73da-4e19-8b26-fe42b3f1e183.png)

For example:
- Original comic page in the archive root folder: DW_GS_001.jpg 
- Corresponding resource file in the __MACOSX folder: ._DW_GS_001.jpg

**Proposed fix**
Comic reader should ignore all files that have "__MACOSX" in the path.