### PR TITLE
Fix: issue 2471

### DIFF
--- a/cps/tasks/mail.py
+++ b/cps/tasks/mail.py
@@ -164,6 +164,7 @@ class TaskEmail(CalibreTask):
                 self.send_standard_email(msg)
             else:
                 self.send_gmail_email(msg)
+                self._handleSuccess()
         except MemoryError as e:
             log.error_or_exception(e, stacklevel=3)
             self._handleError(u'MemoryError sending e-mail: {}'.format(str(e)))


### PR DESCRIPTION
Hello. 
I've noticed that when using the Gmail Account with OAuth2 email settings, 
the status of the task never changes from _Started_ when the email is sent successfully, for errors tho it changes correctly.
Same problem is mentioned here #2471.
Fix was pretty minor, I've just added the _handleSuccess() method call after the gmail function.
Lemme know if it's enough, in my tests everything works ok.
Thanks