### PR TITLE
mp3 player was missing the csrf_token

### DIFF
--- a/cps/static/js/libs/bar-ui.js
+++ b/cps/static/js/libs/bar-ui.js
@@ -177,6 +177,9 @@
 
         whileplaying: function () {
 
+          // get csrf_token
+          let csrf_token = $("input[name='csrf_token']").val();
+
 
           //This sends a bookmark update to calibreweb every 30 seconds.
           if (this.progressBuffer == undefined) {
@@ -187,7 +190,10 @@
 
             $.ajax(calibre.bookmarkUrl, {
               method: "post",
-              data: { bookmark: this.position }
+              data: {
+                csrf_token: csrf_token,
+                bookmark: this.position
+              }
             }).fail(function (xhr, status, error) {
               console.error(error);
             });
@@ -313,14 +319,14 @@
         },
 
         onstop: function () {
-          
+
           $.ajax(calibre.bookmarkUrl, {
             method: "post",
             data: { bookmark: this.position }
           }).fail(function (xhr, status, error) {
             console.error(error);
           });
-        
+
           utils.css.remove(dom.o, 'playing');
 
         },

--- a/cps/templates/listenmp3.html
+++ b/cps/templates/listenmp3.html
@@ -114,6 +114,8 @@
 
 </div>
 
+<input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+
 <script>
 soundManager.setup({
   useHTML5Audio: true,
@@ -137,6 +139,7 @@ window.calibre = {
         bookmarkUrl: "{{ url_for('web.set_bookmark', book_id=mp3file, book_format=audioformat.upper()) }}",
         bookmark: "{{ bookmark.bookmark_key if bookmark != None }}",
         useBookmarks: "{{ g.user.is_authenticated | tojson }}"
+
             };
 </script>
 </body>


### PR DESCRIPTION
When listening to an audio file, the position is sent back to the server every 30 seconds.

But the call was missing the csrf_token in the request, thus getting a 400 bad request.

Addind the csrf_token to the page and the requests allows the call to succeed, and we are able to resume audio playing from the last know position.