### PR TITLE
fixes for 946, 2284 caliblur

### DIFF
--- a/cps/static/css/caliBlur.css
+++ b/cps/static/css/caliBlur.css
@@ -4423,38 +4423,6 @@ body.advanced_search > div.container-fluid > div.row-fluid > div.col-sm-10 > div
         left: 49px;
         margin-top: 5px
     }
-
-    body:not(.blur) > .navbar > .container-fluid > .navbar-header:after, body:not(.blur) > .navbar > .container-fluid > .navbar-header:before {
-        color: hsla(0, 0%, 100%, .7);
-        cursor: pointer;
-        display: block;
-        font-family: plex-icons-new, serif;
-        font-size: 20px;
-        font-stretch: 100%;
-        font-style: normal;
-        font-variant-caps: normal;
-        font-variant-east-asian: normal;
-        font-variant-numeric: normal;
-        font-weight: 400;
-        height: 60px;
-        letter-spacing: normal;
-        line-height: 60px;
-        position: absolute
-    }
-
-    body:not(.blur) > .navbar > .container-fluid > .navbar-header:before {
-        content: "\EA30";
-        -webkit-font-variant-ligatures: normal;
-        font-variant-ligatures: normal;
-        left: 20px
-    }
-
-    body:not(.blur) > .navbar > .container-fluid > .navbar-header:after {
-        content: "\EA2F";
-        -webkit-font-variant-ligatures: normal;
-        font-variant-ligatures: normal;
-        left: 60px
-    }
 }
 
 body.admin > div.container-fluid > div > div.col-sm-10 > div.container-fluid > div.row:first-of-type > div.col > h2:before, body.admin > div.container-fluid > div > div.col-sm-10 > div.discover > h2:first-of-type:before, body.edituser.admin > div.container-fluid > div.row-fluid > div.col-sm-10 > div.discover > h1:before, body.newuser.admin > div.container-fluid > div.row-fluid > div.col-sm-10 > div.discover > h1:before {

--- a/cps/static/js/caliBlur.js
+++ b/cps/static/js/caliBlur.js
@@ -16,7 +16,6 @@
  */
 // Move advanced search to side-menu
 $("a[href*='advanced']").parent().insertAfter("#nav_new");
-$("body").addClass("blur");
 $("body.stat").addClass("stats");
 $("body.config").addClass("admin");
 $("body.uiconfig").addClass("admin");
@@ -29,8 +28,8 @@ $("body > div.container-fluid > div > div.col-sm-10 > div.filterheader").attr("s
 // Back button
 curHref = window.location.href.split("/");
 prevHref = document.referrer.split("/");
-$(".navbar-form.navbar-left")
-    .before('<div class="plexBack"><a href="' + encodeURI(document.referrer) + '"></a></div>');
+$(".plexBack a").attr('href', encodeURI(document.referrer));
+
 if (history.length === 1 ||
     curHref[0] +
     curHref[1] +
@@ -44,14 +43,9 @@ if (history.length === 1 ||
 
 //Weird missing a after pressing back from edit.
 setTimeout(function () {
-    if ($(".plexBack a").length < 1) {
-        $(".plexBack").append('<a href="' + encodeURI(document.referrer) + '"></a>');
-    }
+    $(".plexBack a").attr('href', encodeURI(document.referrer));
 }, 10);
 
-// Home button
-$(".plexBack").before('<div class="home-btn"></div>');
-$("a.navbar-brand").clone().appendTo(".home-btn").empty().removeClass("navbar-brand");
 /////////////////////////////////
 // Start of Book Details Work //
 ///////////////////////////////
@@ -326,13 +320,8 @@ url = window.location.pathname
 // Move create shelf
 $("#nav_createshelf").prependTo(".your-shelves");
 
-// Create drop-down for profile and move elements to it
-$("#main-nav")
-    .prepend('<li class="dropdown"><a href="#" class="dropdown-toggle profileDrop" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><span class="glyphicon glyphicon-user"></span></a><ul class="dropdown-menu profileDropli"></ul></li>');
-$("#top_user").parent().addClass("dropdown").appendTo(".profileDropli");
-$("#nav_about").addClass("dropdown").appendTo(".profileDropli");
-$("#register").parent().addClass("dropdown").appendTo(".profileDropli");
-$("#logout").parent().addClass("dropdown").appendTo(".profileDropli");
+// Move About link it the profile dropdown
+$(".profileDropli #top_user").parent().after($("#nav_about").addClass("dropdown"))
 
 // Remove the modals except from some areas where they are needed
 bodyClass = $("body").attr("class").split(" ");

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -27,7 +27,7 @@
       <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
     <![endif]-->
   </head>
-  <body class="{{ page }} {{ bodyClass }}" data-text="{{_('Home')}}" data-textback="{{_('Back')}}">
+  <body class="{{ page }} {{ bodyClass }} {% if g.current_theme == 1 %} blur {% endif %}" data-text="{{_('Home')}}" data-textback="{{_('Back')}}">
     <!-- Static navbar -->
     <div class="navbar navbar-default navbar-static-top" role="navigation">
       <div class="container-fluid">
@@ -40,6 +40,10 @@
           </button>
           <a class="navbar-brand" href="{{url_for('web.index')}}">{{instance}}</a>
         </div>
+        {% if g.current_theme == 1 %}
+            <div class="home-btn"><a class="home-btn-tooltip" href="/" data-toggle="tooltip" title="" data-placement="bottom" data-original-title="Home"></a></div>
+            <div class="plexBack"><a href="{{url_for('web.index')}}"></a></div>
+        {% endif %}
         {% if g.user.is_authenticated or g.allow_anonymous %}
           <form class="navbar-form navbar-left" role="search" action="{{url_for('search.simple_search')}}" method="GET">
             <div class="form-group input-group input-group-sm">
@@ -59,6 +63,20 @@
           {% endif %}
           <ul class="nav navbar-nav navbar-right" id="main-nav">
             {% if g.user.is_authenticated or g.allow_anonymous %}
+              {% if g.current_theme == 1 %}
+              <li class="dropdown"><a href="#" class="dropdown-toggle profileDrop" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><span class="glyphicon glyphicon-user"></span></a>
+                <ul class="dropdown-menu profileDropli">
+                    <li><a id="top_user" data-text="{{_('Account')}}" href="{{url_for('web.profile')}}"><span class="glyphicon glyphicon-user"></span> <span class="hidden-sm">{{g.user.name}}</span></a></li>
+                    {% if g.allow_registration and not g.user.is_authenticated %}
+                    <li><a id="login" href="{{url_for('web.login')}}"><span class="glyphicon glyphicon-log-in"></span> {{_('Login')}}</a></li>
+                    <li><a id="register" href="{{url_for('web.register')}}"><span class="glyphicon glyphicon-user"></span> {{_('Register')}}</a></li>
+                    {% endif %}
+                    {% if not g.user.is_anonymous %}
+                    <li><a id="logout" href="{{url_for('web.logout')}}"><span class="glyphicon glyphicon-log-out"></span> <span class="hidden-sm">{{_('Logout')}}</span></a></li>
+                    {% endif %}
+                </ul>
+              </li>
+              {% endif %}
               {% if g.user.role_upload() and g.allow_upload %}
                   <li>
                     <form id="form-upload" class="navbar-form" action="{{ url_for('edit-book.upload') }}" data-title="{{_('Uploading...')}}" data-footer="{{_('Close')}}" data-failed="{{_('Error')}}" data-message="{{_('Upload done, processing, please wait...')}}" method="post" enctype="multipart/form-data">
@@ -71,17 +89,19 @@
                   </li>
               {% endif %}
               {% if not g.user.is_anonymous and not simple%}
-                <li><a id="top_tasks" href="{{url_for('tasks.get_tasks_status')}}"><span class="glyphicon glyphicon-tasks"></span> <span class="hidden-sm">{{_('Tasks')}}</span></a></li>
+                <li class="top_tasks"><a id="top_tasks" href="{{url_for('tasks.get_tasks_status')}}"><span class="glyphicon glyphicon-tasks"></span> <span class="hidden-sm">{{_('Tasks')}}</span></a></li>
               {% endif %}
               {% if g.user.role_admin() %}
                 <li><a id="top_admin" data-text="{{_('Settings')}}" href="{{url_for('admin.admin')}}"><span class="glyphicon glyphicon-dashboard"></span> <span class="hidden-sm">{{_('Admin')}}</span></a></li>
               {% endif %}
+              {% if g.current_theme == 0 %}
               <li><a id="top_user" data-text="{{_('Account')}}" href="{{url_for('web.profile')}}"><span class="glyphicon glyphicon-user"></span> <span class="hidden-sm">{{g.user.name}}</span></a></li>
-              {% if not g.user.is_anonymous %}
-              <li><a id="logout" href="{{url_for('web.logout')}}"><span class="glyphicon glyphicon-log-out"></span> <span class="hidden-sm">{{_('Logout')}}</span></a></li>
+                {% if not g.user.is_anonymous %}
+                <li><a id="logout" href="{{url_for('web.logout')}}"><span class="glyphicon glyphicon-log-out"></span> <span class="hidden-sm">{{_('Logout')}}</span></a></li>
+                {% endif %}
               {% endif %}
             {% endif %}
-            {% if g.allow_registration and not g.user.is_authenticated %}
+            {% if g.allow_registration and not g.user.is_authenticated and g.current_theme == 0 %}
             <li><a id="login" href="{{url_for('web.login')}}"><span class="glyphicon glyphicon-log-in"></span> {{_('Login')}}</a></li>
             <li><a id="register" href="{{url_for('web.register')}}"><span class="glyphicon glyphicon-user"></span> {{_('Register')}}</a></li>
             {% endif %}

--- a/cps/templates/login.html
+++ b/cps/templates/login.html
@@ -22,6 +22,14 @@
     {% if config.config_login_type == 0 and mail%}
     <button type="submit" name="forgot" value="forgot" class="btn btn-default">{{_('Forgot Password?')}}</button>
     {% endif %}
+    {% if g.current_theme == 1 %}
+      {% if g.allow_registration %}
+      <a class="btn btn-default" id="register" href="{{url_for('web.register')}}"><span class="glyphicon glyphicon-user"></span> {{_('Register')}}</a>
+      {% endif %}
+      {% if g.allow_anonymous %}
+      <a class="btn btn-default" href="{{url_for('web.index')}}">{{ _('Home') }}</a>
+      {% endif %}
+    {%endif%}
     {% if config.config_remote_login %}
     <a href="{{url_for('remotelogin.remote_login')}}" id="remote_login" class="pull-right">{{_('Log in with Magic Link')}}</a>
     {% endif %}


### PR DESCRIPTION
Resolves #946.
Most of the caliBlur ui is set using js after the html is loaded (really a hassle), so I tried to simplify the structure and logic because I couldn't fix it as it was.
For Login page I've added 2 buttons (register and home) for both possible settings (allow public registration, allow anonymus browsing)
![Screenshot 2022-10-21 at 21 11 28](https://user-images.githubusercontent.com/21315004/197279165-1c7301c5-6d51-4b25-915e-8ded708892bd.png)
and for the register page and the rest of the site when user is anonymus, the links are grouped in the profile dropdown
![Screenshot 2022-10-21 at 21 12 50](https://user-images.githubusercontent.com/21315004/197279290-2701aa0e-0128-45c1-bcb9-0c0a9076b929.png)

To simplify the logic and make it easier to customize/edit, I've added the _blur_ class on body in the html, so lot of css is applied immediately, and other small changes. 
The class also fixed #2284 (for me the refresh happended on chrome too)

I've tested the changes as much as I could do, hopefully everything is ok.

Let me know if anything
Cheers