### PR TITLE
epub: Skip invalid dc:identifier

### DIFF
--- a/cps/epub.py
+++ b/cps/epub.py
@@ -102,7 +102,10 @@ def get_epub_info(tmp_file_path, original_file_name, original_file_extension):
 
     identifiers = []
     for node in p.xpath('dc:identifier', namespaces=ns):
-        identifier_name = node.attrib.values()[-1]
+        try:
+            identifier_name = node.attrib.values()[-1]
+        except IndexError:
+            continue
         identifier_value = node.text
         if identifier_name in ('uuid', 'calibre') or identifier_value is None:
             continue


### PR DESCRIPTION
I have a book where the `dc:identifier` metadata element does not have an attribute to signify what type of identifier this is. This causes an exception to be thrown on upload and makes the metadata fall back to the default template.

However, this seems to be perfectly valid, so maybe it's better to just skip the tag and return the rest of the metadata. This could be smarter and try to employ some heuristic about which type of identifier it could be, but from what I've seen these can be many different things.

Example metadata:

```
<?xml version="1.0" encoding="utf-8"?>
<package version="3.0" unique-identifier="BookId" xmlns="http://www.idpf.org/2007/opf">
  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
    <dc:identifier>978-1-938570-34-6</dc:identifier>
    <dc:language>en</dc:language>
    <dc:title>Tress of the Emerald Sea</dc:title>
    …
  </metadata>
</package>
```
