### PR TITLE
Fix proxy cover images to Kobo store

### DIFF
--- a/cps/helper.py
+++ b/cps/helper.py
@@ -747,9 +747,10 @@ def get_book_cover(book_id, resolution=None):
     return get_book_cover_internal(book, use_generic_cover_on_failure=True, resolution=resolution)
 
 
-# Called only by kobo sync -> cover not found should be answered with 404 and not with default cover
-def get_book_cover_with_uuid(book_uuid, resolution=None):
+def get_book_cover_with_uuid(book_uuid, resolution=None, none_on_missing=False):
     book = calibre_db.get_book_by_uuid(book_uuid)
+    if not book and none_on_missing:
+        return  # allows kobo.HandleCoverImageRequest to proxy request
     return get_book_cover_internal(book, use_generic_cover_on_failure=False, resolution=resolution)
 
 

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -732,29 +732,27 @@ def delete_book(book, calibrepath, book_format):
         return delete_book_file(book, calibrepath, book_format)
 
 
-def get_cover_on_failure(use_generic_cover):
-    if use_generic_cover:
-        try:
-            return send_from_directory(_STATIC_DIR, "generic_cover.jpg")
-        except PermissionError:
-            log.error("No permission to access generic_cover.jpg file.")
-            abort(403)
-    abort(404)
+def get_cover_on_failure():
+    try:
+        return send_from_directory(_STATIC_DIR, "generic_cover.jpg")
+    except PermissionError:
+        log.error("No permission to access generic_cover.jpg file.")
+        abort(403)
 
 
 def get_book_cover(book_id, resolution=None):
     book = calibre_db.get_filtered_book(book_id, allow_show_archived=True)
-    return get_book_cover_internal(book, use_generic_cover_on_failure=True, resolution=resolution)
+    return get_book_cover_internal(book, resolution=resolution)
 
 
-def get_book_cover_with_uuid(book_uuid, resolution=None, none_on_missing=False):
+def get_book_cover_with_uuid(book_uuid, resolution=None):
     book = calibre_db.get_book_by_uuid(book_uuid)
-    if not book and none_on_missing:
+    if not book:
         return  # allows kobo.HandleCoverImageRequest to proxy request
-    return get_book_cover_internal(book, use_generic_cover_on_failure=False, resolution=resolution)
+    return get_book_cover_internal(book, resolution=resolution)
 
 
-def get_book_cover_internal(book, use_generic_cover_on_failure, resolution=None):
+def get_book_cover_internal(book, resolution=None):
     if book and book.has_cover:
 
         # Send the book cover thumbnail if it exists in cache
@@ -770,16 +768,16 @@ def get_book_cover_internal(book, use_generic_cover_on_failure, resolution=None)
         if config.config_use_google_drive:
             try:
                 if not gd.is_gdrive_ready():
-                    return get_cover_on_failure(use_generic_cover_on_failure)
+                    return get_cover_on_failure()
                 path = gd.get_cover_via_gdrive(book.path)
                 if path:
                     return redirect(path)
                 else:
                     log.error('{}/cover.jpg not found on Google Drive'.format(book.path))
-                    return get_cover_on_failure(use_generic_cover_on_failure)
+                    return get_cover_on_failure()
             except Exception as ex:
                 log.error_or_exception(ex)
-                return get_cover_on_failure(use_generic_cover_on_failure)
+                return get_cover_on_failure()
 
         # Send the book cover from the Calibre directory
         else:
@@ -787,9 +785,9 @@ def get_book_cover_internal(book, use_generic_cover_on_failure, resolution=None)
             if os.path.isfile(os.path.join(cover_file_path, "cover.jpg")):
                 return send_from_directory(cover_file_path, "cover.jpg")
             else:
-                return get_cover_on_failure(use_generic_cover_on_failure)
+                return get_cover_on_failure()
     else:
-        return get_cover_on_failure(use_generic_cover_on_failure)
+        return get_cover_on_failure()
 
 
 def get_book_cover_thumbnail(book, resolution):
@@ -812,7 +810,7 @@ def get_series_thumbnail_on_failure(series_id, resolution):
         .filter(db.Books.has_cover == 1) \
         .first()
 
-    return get_book_cover_internal(book, use_generic_cover_on_failure=True, resolution=resolution)
+    return get_book_cover_internal(book, resolution=resolution)
 
 
 def get_series_cover_thumbnail(series_id, resolution=None):

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -930,7 +930,10 @@ def get_current_bookmark_response(current_bookmark):
 @kobo.route("/<book_uuid>/<width>/<height>/<Quality>/<isGreyscale>/image.jpg")
 @requires_kobo_auth
 def HandleCoverImageRequest(book_uuid, width, height, Quality, isGreyscale):
-    book_cover = helper.get_book_cover_with_uuid(book_uuid, resolution=COVER_THUMBNAIL_SMALL)
+    book_cover = helper.get_book_cover_with_uuid(
+        book_uuid,
+        resolution=COVER_THUMBNAIL_SMALL,
+        none_on_missing=config.config_kobo_proxy)
     if not book_cover:
         if config.config_kobo_proxy:
             log.debug("Cover for unknown book: %s proxied to kobo" % book_uuid)
@@ -941,7 +944,7 @@ def HandleCoverImageRequest(book_uuid, width, height, Quality, isGreyscale):
         else:
             log.debug("Cover for unknown book: %s requested" % book_uuid)
             # additional proxy request make no sense, -> direct return
-            return make_response(jsonify({}))
+            return abort(404)
     log.debug("Cover request received for book %s" % book_uuid)
     return book_cover
 

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -930,23 +930,21 @@ def get_current_bookmark_response(current_bookmark):
 @kobo.route("/<book_uuid>/<width>/<height>/<Quality>/<isGreyscale>/image.jpg")
 @requires_kobo_auth
 def HandleCoverImageRequest(book_uuid, width, height, Quality, isGreyscale):
-    book_cover = helper.get_book_cover_with_uuid(
-        book_uuid,
-        resolution=COVER_THUMBNAIL_SMALL,
-        none_on_missing=config.config_kobo_proxy)
-    if not book_cover:
-        if config.config_kobo_proxy:
-            log.debug("Cover for unknown book: %s proxied to kobo" % book_uuid)
-            return redirect(KOBO_IMAGEHOST_URL +
-                            "/{book_uuid}/{width}/{height}/false/image.jpg".format(book_uuid=book_uuid,
-                                                                                   width=width,
-                                                                                   height=height), 307)
-        else:
-            log.debug("Cover for unknown book: %s requested" % book_uuid)
-            # additional proxy request make no sense, -> direct return
-            return abort(404)
-    log.debug("Cover request received for book %s" % book_uuid)
-    return book_cover
+    book_cover = helper.get_book_cover_with_uuid(book_uuid, resolution=COVER_THUMBNAIL_SMALL)
+    if book_cover:
+        log.debug("Serving local cover image of book %s" % book_uuid)
+        return book_cover
+
+    if not config.config_kobo_proxy:
+        log.debug("Returning 404 for cover image of unknown book %s" % book_uuid)
+        # additional proxy request make no sense, -> direct return
+        return abort(404)
+
+    log.debug("Redirecting request for cover image of unknown book %s to Kobo" % book_uuid)
+    return redirect(KOBO_IMAGEHOST_URL +
+                    "/{book_uuid}/{width}/{height}/false/image.jpg".format(book_uuid=book_uuid,
+                                                                            width=width,
+                                                                            height=height), 307)
 
 
 @kobo.route("")


### PR DESCRIPTION
Proxying cover requests to the Kobo store failed because of way generic covers could be generated for missing covers.

An option `use_generic_cover_on_failure` was previously introduced to disable generic cover generation and return a 404 status code instead, if set to `False`. Because of that 404, the redirect to the Kobo store was never reached.

I've removed all the `use_generic_cover_on_failure` handling, performing the redirect or 404 in the `HandleCoverImageRequest` method instead.