### PR TITLE
Two-Page viewer support (and others) for comic books 

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -1173,7 +1173,8 @@ def _configuration_ldap_helper(to_save):
     reboot_required |= _config_string(to_save, "config_ldap_key_path")
     _config_string(to_save, "config_ldap_group_name")
 
-    to_save["config_ldap_provider_url"] = urlparse(to_save.get("config_ldap_provider_url","")).hostname or ""
+    address = urlparse(to_save.get("config_ldap_provider_url", ""))
+    to_save["config_ldap_provider_url"] = (address.hostname or address.path).strip("/")
     reboot_required |= _config_string(to_save, "config_ldap_provider_url")
 
     if to_save.get("config_ldap_serv_password_e", "") != "":

--- a/cps/static/css/kthoom.css
+++ b/cps/static/css/kthoom.css
@@ -131,9 +131,13 @@ body {
   display: none !important;
 }
 
-#mainContent {
+#scrollWrapper {
   overflow: auto;
+}
+
+#mainContent {
   outline: none;
+  margin: auto;
 }
 
 #mainText {
@@ -150,9 +154,13 @@ body {
 }
 
 #mainContent > canvas {
-  display: block;
+  display: inline;
   margin-left: auto;
   margin-right: auto;
+}
+
+#mainContent > canvas.block {
+  display: block;
 }
 
 .long-strip > .mainImage {

--- a/cps/static/css/kthoom.css
+++ b/cps/static/css/kthoom.css
@@ -156,8 +156,10 @@ body {
 
 #mainContent > canvas {
   display: inline;
-  margin-left: 2.5px;
-  margin-right: 2.5px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 2.5px;
+  padding-right: 2.5px;
 }
 
 
@@ -176,7 +178,6 @@ body {
 
 #mainContent.wide-strip > .mainImage {
   display: inline-block;
-  margin-right: 5px;
 }
 
 #mainContent.wide-strip > .mainImage:first-of-type {
@@ -184,7 +185,6 @@ body {
 }
 
 #mainContent.wide-strip > .mainImage:last-of-type {
-  margin-right: 0px;
   padding-right: var(--edge-padding);
 }
 

--- a/cps/static/css/kthoom.css
+++ b/cps/static/css/kthoom.css
@@ -137,6 +137,7 @@ body {
 
 #mainContent {
   --edge-padding: 0px;
+  white-space: nowrap;
   outline: none;
   margin: auto;
 }

--- a/cps/static/css/kthoom.css
+++ b/cps/static/css/kthoom.css
@@ -156,11 +156,13 @@ body {
 }
 
 #mainContent > canvas {
-  display: inline;
+  display: inline-block;
   margin-left: auto;
   margin-right: auto;
 }
+
 #mainContent.double > canvas {
+  vertical-align: middle;
   padding-left: 2.5px;
   padding-right: 2.5px;
 }

--- a/cps/static/css/kthoom.css
+++ b/cps/static/css/kthoom.css
@@ -136,6 +136,7 @@ body {
 }
 
 #mainContent {
+  --edge-padding: 0px;
   outline: none;
   margin: auto;
 }
@@ -155,20 +156,36 @@ body {
 
 #mainContent > canvas {
   display: inline;
-  margin-left: auto;
-  margin-right: auto;
+  margin-left: 2.5px;
+  margin-right: 2.5px;
 }
 
-#mainContent > canvas.block {
+
+#mainContent.long-strip > canvas {
   display: block;
-}
-
-.long-strip > .mainImage {
   margin-bottom: 4px;
 }
 
-.long-strip > .mainImage:last-child {
+#mainContent.long-strip > .mainImage:last-child {
   margin-bottom: 0px !important;
+}
+
+#mainContent.wide-strip {
+  white-space: nowrap;
+}
+
+#mainContent.wide-strip > .mainImage {
+  display: inline-block;
+  margin-right: 5px;
+}
+
+#mainContent.wide-strip > .mainImage:first-of-type {
+  padding-left: var(--edge-padding);
+}
+
+#mainContent.wide-strip > .mainImage:last-of-type {
+  margin-right: 0px;
+  padding-right: var(--edge-padding);
 }
 
 #titlebar {

--- a/cps/static/css/kthoom.css
+++ b/cps/static/css/kthoom.css
@@ -159,10 +159,11 @@ body {
   display: inline;
   margin-left: auto;
   margin-right: auto;
+}
+#mainContent.double > canvas {
   padding-left: 2.5px;
   padding-right: 2.5px;
 }
-
 
 #mainContent.long-strip > canvas {
   display: block;

--- a/cps/static/js/kthoom.js
+++ b/cps/static/js/kthoom.js
@@ -282,6 +282,21 @@ function pageDisplayUpdate() {
 
         if (settings.pageDisplay === 1) {
             $(".mainImage").eq(currentImage+1).removeClass("hide");
+            // Only display 1 image if it or its neighbors are landscape
+            for (let i=-1; i<=1; i++) {
+                var ratioStr = $(".mainImage").eq(currentImage+i).css("aspect-ratio")
+                if (!(ratioStr)) continue
+                ratioStr = ratioStr.split(" ")
+                if (parseFloat(ratioStr[1]) / parseFloat(ratioStr[3]) > 1 ) {
+                    if ([-1, 1].includes(i)) {
+                        $(".mainImage").eq(currentImage+i).addClass("hide")
+                    } else {
+                        $(".mainImage").eq(currentImage-1).addClass("hide")
+                        $(".mainImage").eq(currentImage+1).addClass("hide")
+                        $(".mainImage").eq(currentImage).css("height", innerHeight - 50 )
+                    }
+                }
+            }
         }
     } else if (settings.pageDisplay === 2){
         $("#mainContent").addClass("long-strip");
@@ -487,7 +502,7 @@ function updateScale() {
             if (settings.pageDisplay != 1) {
                 canvasArray.css("width", "100%");
             } else {
-                canvasArray.css("width", "50%")
+                canvasArray.css("width", "calc(50% - 5px)")
             }
             break;
         default:
@@ -626,7 +641,7 @@ function drawCanvas() {
             if (settings.pageDisplay != 1) {
                 canvasElement.css("width", "100%");
             } else {
-                canvasElement.css("width", "50%")
+                canvasElement.css("width", "calc(50% - 5px)")
             }
             break;
         default:

--- a/cps/static/js/kthoom.js
+++ b/cps/static/js/kthoom.js
@@ -281,7 +281,7 @@ function pageDisplayUpdate() {
         $(".mainImage").eq(currentImage).removeClass("hide");
 
         if (settings.pageDisplay === 1) {
-            $("#mainContent").removeClass("double");
+            $("#mainContent").addClass("double");
             $(".mainImage").eq(currentImage+1).removeClass("hide");
         }
     } else if (settings.pageDisplay === 2){

--- a/cps/static/js/kthoom.js
+++ b/cps/static/js/kthoom.js
@@ -501,13 +501,11 @@ function updateScale() {
     $("#mainContent").css({maxHeight: maxheight + 5});
 
     if(settings.pageDisplay <= 1) {
-        canvasArray.addClass("hide");
         pageDisplayUpdate();
     } else if (settings.pageDisplay === 3) {
         var paddingSize = (innerWidth - $(".mainImage").width()) / 2
         $("#mainContent").css('--edge-padding', paddingSize + "px")
     }
-
 
     kthoom.setSettings();
     kthoom.saveSettings();
@@ -634,13 +632,12 @@ function drawCanvas() {
             break;
     }
 
-    if(settings.pageDisplay === 0 ) {
+    if(settings.pageDisplay === 0) {
         canvasElement.addClass("hide");
     } else if (settings.pageDisplay === 3) {
         var paddingSize = (innerWidth - $(".mainImage").width()) / 2
         $("#mainContent").css('--edge-padding', paddingSize + "px")
     }
-
 
     //Fill with Placeholder text. setImage will override this
     canvasElement.width = innerWidth - 100;
@@ -843,7 +840,6 @@ function init(filename) {
 function currentImageOffset(imageIndex) {
     if (settings.pageDisplay===3) {
         if (imageIndex===0) return $("#mainContent").position().left
-
         var padding = (innerWidth - $(".mainImage").eq(imageIndex).width()) / 2
         return $(".mainImage").eq(imageIndex).offset().left - $("#mainContent").position().left - padding
     }

--- a/cps/static/js/kthoom.js
+++ b/cps/static/js/kthoom.js
@@ -72,7 +72,8 @@ var settings = {
     theme: "light",
     direction: 0, // 0 = Left to Right, 1 = Right to Left
 	scrollbar: 1, // 0 = Hide Scrollbar, 1 = Show Scrollbar
-    pageDisplay: 0 // 0 = Single Page, 1 = Long Strip
+    pageDisplay: 0, // 0 = Single Page, 1 = Long Strip
+    blockCover: false // 
 };
 
 kthoom.saveSettings = function() {
@@ -267,7 +268,7 @@ function updatePage() {
 
 function setTheme() {
     $("body").toggleClass("dark-theme", settings.theme === "dark");
-	$("#mainContent").toggleClass("disabled-scrollbar", settings.scrollbar === 0);
+	$("#scrollWrapper").toggleClass("disabled-scrollbar", settings.scrollbar === 0);
 }
 
 function pageDisplayUpdate() {
@@ -276,6 +277,10 @@ function pageDisplayUpdate() {
         $(".mainImage").eq(currentImage).removeClass("hide");
         $("#mainContent").removeClass("long-strip");
     } else {
+        $(".mainImage").eq(0).removeClass("block")
+        if (settings.blockCover === true) {
+            $(".mainImage").eq(0).addClass("block")
+        }
         $(".mainImage").removeClass("hide");
         $("#mainContent").addClass("long-strip");
         scrollCurrentImageIntoView();
@@ -442,11 +447,11 @@ function showNextPage() {
 function scrollCurrentImageIntoView() {
     if(settings.pageDisplay == 0) {
         // This will scroll all the way up when Single Page is selected
-		$("#mainContent").scrollTop(0);
+		$("#scrollWrapper").scrollTop(0);
     } else {
         // This will scroll to the image when Long Strip is selected
-        $("#mainContent").stop().animate({
-            scrollTop: $(".mainImage").eq(currentImage).offset().top + $("#mainContent").scrollTop() - $("#mainContent").offset().top
+        $("#scrollWrapper").stop().animate({
+            scrollTop: $(".mainImage").eq(currentImage).offset().top + $("#scrollWrapper").scrollTop() - $("#scrollWrapper").offset().top
         }, 200);
     }
 }
@@ -484,6 +489,10 @@ function updateScale() {
     $("#mainContent > canvas.error").css("height", 200);
 
     $("#mainContent").css({maxHeight: maxheight + 5});
+    if ($("#mainContent > canvas").length > 0) {
+        $("#mainContent").css("max-width", "100%");
+        $("#mainContent").css({maxWidth: canvasArray.width()*2 + 5});
+    }
     kthoom.setSettings();
     kthoom.saveSettings();
 }
@@ -618,6 +627,12 @@ function drawCanvas() {
     x.strokeStyle = (settings.theme === "dark") ? "white" : "black";
     x.fillText("Loading Page #" + (currentImage + 1), innerWidth / 2, 100);
 
+    if ($("#mainContent > canvas").length > 0) {
+        $("#mainContent").css("max-width", "100%");
+        $("#mainContent").css({maxWidth: $("#mainContent > canvas").width()*2 + 5});
+    }
+
+
     $("#mainContent").append(canvasElement);
 }
 
@@ -654,7 +669,7 @@ function init(filename) {
         // We need this in a timeout because if we call it during the CSS transition, IE11 shakes the page ¯\_(ツ)_/¯
         setTimeout(function() {
             // Focus on the TOC or the main content area, depending on which is open
-            $("#main:not(.closed) #mainContent, #sidebar.open #tocView").focus();
+            $("#main:not(.closed) #scrollWrapper, #sidebar.open #tocView").focus();
             scrollTocToActive();
         }, 500);
     });
@@ -674,7 +689,7 @@ function init(filename) {
 
         settings[this.name] = value;
 
-        if(["hflip", "vflip", "rotateTimes"].includes(this.name)) {
+        if(["hflip", "vflip", "rotateTimes", "blockCover"].includes(this.name)) {
             reloadImages();
         } else if(this.name === "direction") {
             return updateProgress();
@@ -687,7 +702,7 @@ function init(filename) {
     // Close modal
     $(".closer, .overlay").click(function() {
         $(".md-show").removeClass("md-show");
-		$("#mainContent").focus(); // focus back on the main container so you use up/down keys without having to click on it
+		$("#scrollWrapper").focus(); // focus back on the main container so you use up/down keys without having to click on it
     });
 
     // TOC thumbnail pagination
@@ -701,7 +716,7 @@ function init(filename) {
         $("#fullscreen").click(function() {
             screenfull.toggle($("#container")[0]);
 			// Focus on main container so you can use up/down keys immediately after fullscreen
-			$("#mainContent").focus();
+			$("#scrollWrapper").focus();
         });
 
         if (screenfull.raw) {
@@ -715,9 +730,9 @@ function init(filename) {
     }
 
     // Focus the scrollable area so that keyboard scrolling work as expected
-    $("#mainContent").focus();
+    $("#scrollWrapper").focus();
 
-    $("#mainContent").swipe( {
+    $("#scrollWrapper").swipe( {
         swipeRight:function() {
             showLeftPage();
         },
@@ -728,8 +743,8 @@ function init(filename) {
     $(".mainImage").click(function(evt) {
         // Firefox does not support offsetX/Y so we have to manually calculate
         // where the user clicked in the image.
-        var mainContentWidth = $("#mainContent").width();
-        var mainContentHeight = $("#mainContent").height();
+        var mainContentWidth = $("#scrollWrapper").width();
+        var mainContentHeight = $("#scrollWrapper").height();
         var comicWidth = evt.target.clientWidth;
         var comicHeight = evt.target.clientHeight;
         var offsetX = (mainContentWidth - comicWidth) / 2;
@@ -762,8 +777,8 @@ function init(filename) {
     });
 
     // Scrolling up/down will update current image if a new image is into view (for Long Strip Display)
-    $("#mainContent").scroll(function(){
-        var scroll = $("#mainContent").scrollTop();
+    $("#scrollWrapper").scroll(function(){
+        var scroll = $("#scrollWrapper").scrollTop();
         if(settings.pageDisplay === 0) {
             // Don't trigger the scroll for Single Page
         } else if(scroll > prevScrollPosition) {
@@ -792,5 +807,5 @@ function init(filename) {
 }
 
 function currentImageOffset(imageIndex) {
-    return $(".mainImage").eq(imageIndex).offset().top - $("#mainContent").position().top
+    return $(".mainImage").eq(imageIndex).offset().top - $("#scrollWrapper").position().top
 }

--- a/cps/static/js/kthoom.js
+++ b/cps/static/js/kthoom.js
@@ -72,7 +72,7 @@ var settings = {
     theme: "light",
     direction: 0, // 0 = Left to Right, 1 = Right to Left
 	scrollbar: 1, // 0 = Hide Scrollbar, 1 = Show Scrollbar
-    pageDisplay: 0, // 0 = Single Page, 1 = Long Strip
+    pageDisplay: 0 // 0 = Single Page, 1 = Long Strip
 };
 
 kthoom.saveSettings = function() {

--- a/cps/static/js/kthoom.js
+++ b/cps/static/js/kthoom.js
@@ -272,6 +272,7 @@ function setTheme() {
 
 function pageDisplayUpdate() {
     $(".mainImage").removeClass("hide");
+    $("#mainContent").removeClass("double");
     $("#mainContent").removeClass("long-strip");
     $("#mainContent").removeClass("wide-strip");
 
@@ -280,6 +281,7 @@ function pageDisplayUpdate() {
         $(".mainImage").eq(currentImage).removeClass("hide");
 
         if (settings.pageDisplay === 1) {
+            $("#mainContent").removeClass("double");
             $(".mainImage").eq(currentImage+1).removeClass("hide");
         }
     } else if (settings.pageDisplay === 2){

--- a/cps/static/js/kthoom.js
+++ b/cps/static/js/kthoom.js
@@ -73,7 +73,6 @@ var settings = {
     direction: 0, // 0 = Left to Right, 1 = Right to Left
 	scrollbar: 1, // 0 = Hide Scrollbar, 1 = Show Scrollbar
     pageDisplay: 0, // 0 = Single Page, 1 = Long Strip
-    soloCover: false // 
 };
 
 kthoom.saveSettings = function() {
@@ -282,21 +281,6 @@ function pageDisplayUpdate() {
 
         if (settings.pageDisplay === 1) {
             $(".mainImage").eq(currentImage+1).removeClass("hide");
-            // Only display 1 image if it or its neighbors are landscape
-            for (let i=-1; i<=1; i++) {
-                var ratioStr = $(".mainImage").eq(currentImage+i).css("aspect-ratio")
-                if (!(ratioStr)) continue
-                ratioStr = ratioStr.split(" ")
-                if (parseFloat(ratioStr[1]) / parseFloat(ratioStr[3]) > 1 ) {
-                    if ([-1, 1].includes(i)) {
-                        $(".mainImage").eq(currentImage+i).addClass("hide")
-                    } else {
-                        $(".mainImage").eq(currentImage-1).addClass("hide")
-                        $(".mainImage").eq(currentImage+1).addClass("hide")
-                        $(".mainImage").eq(currentImage).css("height", innerHeight - 50 )
-                    }
-                }
-            }
         }
     } else if (settings.pageDisplay === 2){
         $("#mainContent").addClass("long-strip");
@@ -487,7 +471,7 @@ function updateScale() {
     canvasArray.css("width", "");
     canvasArray.css("height", "");
     canvasArray.css("maxWidth", "");
-    canvasArray.css("maxHeight", "100%");
+    canvasArray.css("maxHeight", "");
 
 
     switch (settings.fitMode) {
@@ -519,7 +503,7 @@ function updateScale() {
         pageDisplayUpdate();
     } else if (settings.pageDisplay === 3) {
         var paddingSize = (innerWidth - $(".mainImage").width()) / 2
-        $("#mainContent").css('--edge-padding', paddingSize.toString() + "px")
+        $("#mainContent").css('--edge-padding', paddingSize + "px")
     }
 
 
@@ -652,7 +636,7 @@ function drawCanvas() {
         canvasElement.addClass("hide");
     } else if (settings.pageDisplay === 3) {
         var paddingSize = (innerWidth - $(".mainImage").width()) / 2
-        $("#mainContent").css('--edge-padding', paddingSize.toString() + "px")
+        $("#mainContent").css('--edge-padding', paddingSize + "px")
     }
 
 

--- a/cps/templates/readcbr.html
+++ b/cps/templates/readcbr.html
@@ -73,9 +73,10 @@
       </div>
     </div>
   </div>
-
-  <div id="mainContent" tabindex="-1">
-    <div id="mainText" style="display:none"></div>
+  <div id="scrollWrapper">
+    <div id="mainContent" tabindex="-1">
+      <div id="mainText" style="display:none"></div>
+    </div>
   </div>
   <div id="left" class="arrow" onclick="showLeftPage()">‹</div>
   <div id="right" class="arrow" onclick="showRightPage()">›</div>
@@ -128,6 +129,7 @@
               <div class="inputs">
                 <label for="singlePage"><input type="radio" id="singlePage" name="pageDisplay" value="0" /> {{_('Single Page')}}</label>
                 <label for="longStrip"><input type="radio" id="longStrip" name="pageDisplay" value="1" /> {{_('Long Strip')}}</label>
+                <label for="blockCover"><input type="checkbox" id="blockCover" name="blockCover" /> {{_('Cover')}}</label>
               </div>
             </td>
           </tr>

--- a/cps/templates/readcbr.html
+++ b/cps/templates/readcbr.html
@@ -128,8 +128,10 @@
             <td>
               <div class="inputs">
                 <label for="singlePage"><input type="radio" id="singlePage" name="pageDisplay" value="0" /> {{_('Single Page')}}</label>
-                <label for="longStrip"><input type="radio" id="longStrip" name="pageDisplay" value="1" /> {{_('Long Strip')}}</label>
-                <label for="blockCover"><input type="checkbox" id="blockCover" name="blockCover" /> {{_('Cover')}}</label>
+                <label for="doublePage"><input type="radio" id="doublePage" name="pageDisplay" value="1" /> {{_('Double Page')}}</label>
+                <br />
+                <label for="longStrip"><input type="radio" id="longStrip" name="pageDisplay" value="2" /> {{_('Long Strip')}}</label>
+                <label for="wideStrip"><input type="radio" id="wideStrip" name="pageDisplay" value="3" /> {{_('Wide Strip')}}</label>
               </div>
             </td>
           </tr>


### PR DESCRIPTION
Hey, hope your day(s) are going well!

I've added a few enhancements to the comic book reader page ([as issue 1790](https://github.com/janeczku/calibre-web/issues/1790)). I've added a very basic Double-Page view mode mode. as well as a Wide Strip view mode, which acts like the existing Long Strip view mode, but horizontally. 

For this addition there's just a few extra lines added to a few areas, with the options, and some extra CSS to make it all fit. 

There was also a bug with the `$("#scrollWrapper").scroll` function where the tocView would only ever update to be `0`, which has now been fixed.

Any feedback is appreciated!