### PR TITLE
Implement fetching metadata from mp3 files

### DIFF
--- a/cps/mp3.py
+++ b/cps/mp3.py
@@ -1,0 +1,32 @@
+from eyed3.core import Date
+from eyed3.id3 import Tag
+
+from cps.constants import BookMeta
+import eyed3
+
+
+def get_mp3_file_info(
+    tmp_file_path: str, original_file_extension: str, original_file_name: str
+) -> BookMeta:
+    mp3 = eyed3.load(tmp_file_path)
+    mp3_tags: Tag = mp3.tag if mp3 is not None else Tag()
+    release_date = mp3_tags.release_date
+    pubdate = "-".join([
+        release_date.year, release_date.month, release_date.day
+    ]) if isinstance(release_date, Date) else ""
+
+    return BookMeta(
+        file_path=tmp_file_path,
+        extension=original_file_extension,
+        title=mp3_tags.title or original_file_name,
+        author=mp3_tags.artist or mp3_tags.album_artist or "Unknown",
+        cover=None,
+        description="",
+        tags="",
+        series=mp3_tags.album or "",
+        series_id="",
+        languages="",
+        publisher=mp3_tags.publisher or "",
+        pubdate=pubdate,
+        identifiers=[],
+    )

--- a/cps/uploader.py
+++ b/cps/uploader.py
@@ -68,6 +68,13 @@ except ImportError as e:
     log.debug('Cannot import fb2, extracting fb2 metadata will not work: %s', e)
     use_fb2_meta = False
 
+try:
+    from . import mp3
+    use_mp3_meta = True
+except ImportError as e:
+    log.debug('Cannot import mp3, extracting mp3 metadata will not work: %s', e)
+    use_mp3_meta = False
+
 
 def process(tmp_file_path, original_file_name, original_file_extension, rarExecutable):
     meta = default_meta(tmp_file_path, original_file_name, original_file_extension)
@@ -75,15 +82,17 @@ def process(tmp_file_path, original_file_name, original_file_extension, rarExecu
     try:
         if ".PDF" == extension_upper:
             meta = pdf_meta(tmp_file_path, original_file_name, original_file_extension)
-        elif extension_upper in [".KEPUB", ".EPUB"] and use_epub_meta is True:
+        elif extension_upper in [".KEPUB", ".EPUB"] and use_epub_meta:
             meta = epub.get_epub_info(tmp_file_path, original_file_name, original_file_extension)
-        elif ".FB2" == extension_upper and use_fb2_meta is True:
+        elif ".FB2" == extension_upper and use_fb2_meta:
             meta = fb2.get_fb2_info(tmp_file_path, original_file_extension)
         elif extension_upper in ['.CBZ', '.CBT', '.CBR']:
             meta = comic.get_comic_info(tmp_file_path,
                                         original_file_name,
                                         original_file_extension,
                                         rarExecutable)
+        elif extension_upper == ".MP3" and use_mp3_meta:
+            meta = mp3.get_mp3_file_info(tmp_file_path, original_file_extension, original_file_name)
     except Exception as ex:
         log.warning('cannot parse metadata, using default: %s', ex)
 

--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -35,6 +35,7 @@ html2text>=2020.1.16,<2022.1.1
 python-dateutil>=2.1,<2.9.0
 beautifulsoup4>=4.0.1,<4.12.0
 faust-cchardet>=2.1.18
+eyed3>=0.9.7
 
 # Comics
 natsort>=2.2.0,<8.4.0


### PR DESCRIPTION
Here's a feature I'd like to have when importing audiobooks in MP3 format. 

A couple of notes/questions:
- your repo declares support of python3.5+, but `eye3d` which I used, states it supports 3.7+, would this be ok?
- the code here is pretty basic, should I also consider writing tests to it, or is it good as it is?