### PR TITLE
Update cover to retain correct aspect ratio

### DIFF
--- a/cps/static/css/style.css
+++ b/cps/static/css/style.css
@@ -172,7 +172,7 @@ table .bg-dark-danger a { color: #fff; }
 
 .container-fluid .book .cover span .img {
   bottom: 0;
-  height: 100%;
+  width: 100%;
   position: absolute;
 }
 


### PR DESCRIPTION
### What is this doing?

This is a simple, but notable CSS update that changes the poster/cover layout to stretch against width instead of height. Instead of covers being stretched out of their normal aspect ratio, they are now brought to the max width of the container and retain their true shape.

Notes:
- Tiny covers still fill the space because they're stretched to 100% width.
- Shadows are retained on the edge of the image.

### Why?

Stretched text/content can make parsing the covers, both text and image, difficult for some users. It's a common strategy to make the content fit the container when content shapes/aspect ratios can not be guaranteed.

### Alternatives/additions

The space under the image is not clickable with this change. An addition that could be made, if that's not preferable, would be to move the anchor tag up in the structure so it wraps the div with a class of `cover`.

```html
<div class="cover">
  <a>
    <span>
      <img>
```

```html
<a>
  <div class="cover">
    <span>
      <img>
```

### Example

Note the first three books in the first row and the explorer's guide in the second.

#### Before

<img width="903" alt="Screenshot 2023-04-23 at 12 57 21 AM" src="https://user-images.githubusercontent.com/1731429/233827403-b9f802c8-9a3e-43a9-ade2-feb9761608c7.png">

#### After

<img width="918" alt="Screenshot 2023-04-23 at 12 57 58 AM" src="https://user-images.githubusercontent.com/1731429/233827408-16202d53-85c4-494f-a20c-dcc36a03dda0.png">
