### PR TITLE
Quick search improvements

### DIFF
--- a/cps/db.py
+++ b/cps/db.py
@@ -954,12 +954,10 @@ class CalibreDB:
 
     # read search results from calibre-database and return it (function is used for feed and simple search
     def get_search_results(self, term, config, offset=None, order=None, limit=None, *join):
-        self.session.connection().connection.connection.create_function("partial_token_set_ratio", 2, partial_token_set_ratio)
-        self.session.connection().connection.connection.create_function("sort", 1, lambda tags :print(f"<Book:  {tags} >") or 3)
         order = order[0] if order else [Books.sort]
         pagination = None
-        #result = self.search_query(term, config, *join).order_by(*order).all()#*order
-        result = self.search_query(term, config, *join).order_by(desc(func.partial_ratio(Books.title.name+" "+Books.author_sort.name+" "+Books.tags.get(),term))).all()
+        result = self.search_query(term, config, *join).order_by(*order).all()
+        #sort here
         for row in result:
             print(row)
 

--- a/cps/db.py
+++ b/cps/db.py
@@ -887,7 +887,7 @@ class CalibreDB:
             .filter(and_(Books.authors.any(and_(*q)), func.lower(Books.title).ilike("%" + title + "%"))).first()
 
     def search_query(self, term, config, *join):
-        term.strip().lower()
+        term=term.strip().lower()
         self.session.connection().connection.connection.create_function("lower", 1, lcase)
         self.session.connection().connection.connection.create_function("partial_ratio", 2, partial_ratio)
         q = list()

--- a/cps/db.py
+++ b/cps/db.py
@@ -931,7 +931,15 @@ class CalibreDB:
                 func.partial_ratio(func.lower(Books.title),word)>=FUZZY_SEARCH_ACCURACY
             ]
             results=results.filter(or_(*filter_expression))
+        #TODO sort
 
+        # score = 0
+        # for word in words:
+        #     score += max(
+        #         attr1 % word,
+        #         attr2 % word,
+        #     )
+        # sort by score desc
         return results
 
     def get_cc_columns(self, config, filter_config_custom_read=False):

--- a/cps/db.py
+++ b/cps/db.py
@@ -381,11 +381,12 @@ class Books(Base):
         self.has_cover = (has_cover != None)
 
     def __repr__(self):
-        return "<Books('{0},{1}{2}{3}{4}{5}{6}{7}{8}{9}{10}')>".format(self.title, self.sort, self.author_sort,
+        return "<Books('{0} , {1} {2} {3} {4} {5} {6} {7} {8} {9} {10} {11}')>".format(self.title, self.sort, self.author_sort,
                                                                  self.timestamp, self.pubdate, self.series_index,
                                                                  self.last_modified, self.path, self.has_cover,
-                                                                       [tag.name for tag in self.tags],
-                                                                       [series.name for series in self.series])
+                                                                       " ".join([tag.name for tag in self.tags]),
+                                                                       " ".join([series.name for series in self.series]), " ".join([author.name for author in self.authors])," ".join([publisher.name for publisher in self.publishers]))
+
 
     @property
     def atom_timestamp(self):
@@ -959,7 +960,6 @@ class CalibreDB:
         sorted(result,key=lambda book:1)
         for res in result:
             print(res[0])
-            print(f"{res[0].title} {[tag.name for tag in res[0].tags]} {[series.name for series in res[0].series]}")
         result_count = len(result)
         if offset != None and limit != None:
             offset = int(offset)

--- a/cps/db.py
+++ b/cps/db.py
@@ -905,14 +905,13 @@ class CalibreDB:
         term = term.strip().lower()
         self.session.connection().connection.connection.create_function("lower", 1, lcase)
         self.session.connection().connection.connection.create_function("max_ratio", 2, max_ratio)
-        q = list()
         # splits search term into single words
-        words = re.split("[, ]+", term)
+        words = re.split("[,\s]+", term)
         # put the longest words first to make queries more efficient
         words.sort(key=len, reverse=True)
-        words=[x for x in filter(lambda w:len(w)>3,words)]
+        words=list(filter(lambda w:len(w)>3,words))
         # no word in search term is longer than 3 letters -> return empty query #TODO give some kind of error message
-        if not any([len(word)>3 for word in words]):
+        if len(words)==0:
             return self.session.query(Books).filter(False)
 
         query = self.generate_linked_query(config.config_read_column, Books)
@@ -970,8 +969,6 @@ class CalibreDB:
         pagination = None
         result = self.search_query(term, config, *join).order_by(*order).all()
         result = sorted(result,key=lambda query:partial_token_sort_ratio(str(query[0]),term),reverse=True)
-        for res in result:
-            print(str(res[0]))
         result_count = len(result)
         if offset != None and limit != None:
             offset = int(offset)

--- a/cps/db.py
+++ b/cps/db.py
@@ -988,8 +988,8 @@ class CalibreDB:
 
         if with_count:
             if not languages:
-                languages = self.session.query(Languages, func.count('books_languages_link.book')) \
-                    .join(books_languages_link).join(Books) \
+                languages = self.session.query(Languages, func.count('books_languages_link.book'))\
+                    .join(books_languages_link).join(Books)\
                     .filter(self.common_filters(return_all_languages=return_all_languages)) \
                     .group_by(text('books_languages_link.lang_code')).all()
             tags = list()

--- a/cps/db.py
+++ b/cps/db.py
@@ -916,7 +916,7 @@ class CalibreDB:
                 filter_expression.append(
                     getattr(Books,
                             'custom_column_' + str(c.id)).any(
-                        func.lower(cc_classes[c.id].value).ilike("%" + term + "%"))) #TODO ?
+                        func.lower(cc_classes[c.id].value).ilike("%" + term + "%")))
         # filter out multiple languages and archived books,
         results=query.filter(self.common_filters(True))
 

--- a/cps/db.py
+++ b/cps/db.py
@@ -954,10 +954,10 @@ class CalibreDB:
 
     # read search results from calibre-database and return it (function is used for feed and simple search
     def get_search_results(self, term, config, offset=None, order=None, limit=None, *join):
+        self.session.connection().connection.connection.create_function("partial_token_set_ratio", 2, partial_token_set_ratio)
         order = order[0] if order else [Books.sort]
         pagination = None
-        result = self.search_query(term, config, *join).order_by(*order).all()
-        sorted(result,key=lambda book:1)
+        result = self.search_query(term, config, *join).order_by(func.desc(func.partial_token_set_ratio(str(Books),term))).all()
         for res in result:
             print(res[0])
         result_count = len(result)

--- a/cps/db.py
+++ b/cps/db.py
@@ -916,7 +916,7 @@ class CalibreDB:
                 filter_expression.append(
                     getattr(Books,
                             'custom_column_' + str(c.id)).any(
-                        func.lower(cc_classes[c.id].value).ilike("%" + term + "%"))) #TODO ?
+                        func.lower(cc_classes[c.id].value).ilike("%" + term + "%")))
         # filter out multiple languages and archived books,
         results=query.filter(self.common_filters(True))
 
@@ -932,9 +932,7 @@ class CalibreDB:
             ]
             results=results.filter(or_(*filter_expression))
 
-        try: return results
-        except Exception:
-            print(traceback.format_exc())
+        return results
 
     def get_cc_columns(self, config, filter_config_custom_read=False):
         tmp_cc = self.session.query(CustomColumns).filter(CustomColumns.datatype.notin_(cc_exceptions)).all()

--- a/cps/db.py
+++ b/cps/db.py
@@ -33,6 +33,7 @@ from sqlalchemy.orm import relationship, sessionmaker, scoped_session
 from sqlalchemy.orm.collections import InstrumentedList
 from sqlalchemy.ext.declarative import DeclarativeMeta
 from sqlalchemy.exc import OperationalError
+
 try:
     # Compatibility with sqlalchemy 2.0
     from sqlalchemy.orm import declarative_base
@@ -41,6 +42,7 @@ except ImportError:
 from sqlalchemy.pool import StaticPool
 from sqlalchemy.sql.expression import and_, true, false, text, func, or_
 from sqlalchemy.ext.associationproxy import association_proxy
+from sqlalchemy import desc
 from flask_login import current_user
 from flask_babel import gettext as _
 from flask_babel import get_locale
@@ -53,7 +55,7 @@ from weakref import WeakSet
 from thefuzz.fuzz import partial_ratio, partial_token_set_ratio
 
 # %-level, 100 means exact match
-FUZZY_SEARCH_ACCURACY=80
+FUZZY_SEARCH_ACCURACY = 80
 
 log = logger.create()
 
@@ -381,12 +383,21 @@ class Books(Base):
         self.has_cover = (has_cover != None)
 
     def __repr__(self):
-        return "<Books('{0} , {1} {2} {3} {4} {5} {6} {7} {8} {9} {10} {11}')>".format(self.title, self.sort, self.author_sort,
-                                                                 self.timestamp, self.pubdate, self.series_index,
-                                                                 self.last_modified, self.path, self.has_cover,
-                                                                       " ".join([tag.name for tag in self.tags]),
-                                                                       " ".join([series.name for series in self.series]), " ".join([author.name for author in self.authors])," ".join([publisher.name for publisher in self.publishers]))
+        return "<Books('{0},{1}{2}{3}{4}{5}{6}{7}{8}')>".format(self.title, self.sort, self.author_sort,
+                                                                self.timestamp, self.pubdate, self.series_index,
+                                                                self.last_modified, self.path, self.has_cover)
 
+    def __sort_str(self):
+        return "{0} {1} {2} {3} {4}".format(self.title, " ".join([tag.name for tag in self.tags]),
+                                                " ".join(
+                                                    [series.name for series
+                                                     in self.series]),
+                                                " ".join(
+                                                    [author.name for author
+                                                     in self.authors]),
+                                                " ".join([publisher.name for
+                                                          publisher in
+                                                          self.publishers]))
 
     @property
     def atom_timestamp(self):
@@ -428,13 +439,15 @@ class CustomColumns(Base):
         content['category_sort'] = "value"
         content['is_csp'] = False
         content['is_editable'] = self.editable
-        content['rec_index'] = sequence + 22     # toDo why ??
+        content['rec_index'] = sequence + 22  # toDo why ??
         if isinstance(value, datetime):
-            content['#value#'] = {"__class__": "datetime.datetime", "__value__": value.strftime("%Y-%m-%dT%H:%M:%S+00:00")}
+            content['#value#'] = {"__class__": "datetime.datetime",
+                                  "__value__": value.strftime("%Y-%m-%dT%H:%M:%S+00:00")}
         else:
             content['#value#'] = value
         content['#extra#'] = extra
-        content['is_multiple2'] = {} if not self.is_multiple else {"cache_to_list": "|", "ui_to_list": ",", "list_to_ui": ", "}
+        content['is_multiple2'] = {} if not self.is_multiple else {"cache_to_list": "|", "ui_to_list": ",",
+                                                                   "list_to_ui": ", "}
         return json.dumps(content, ensure_ascii=False)
 
 
@@ -455,7 +468,7 @@ class AlchemyEncoder(json.JSONEncoder):
                         el = list()
                         # ele = None
                         for ele in data:
-                            if hasattr(ele, 'value'):       # converter for custom_column values
+                            if hasattr(ele, 'value'):  # converter for custom_column values
                                 el.append(str(ele.value))
                             elif ele.get:
                                 el.append(ele.get())
@@ -493,7 +506,6 @@ class CalibreDB:
         self.session = None
         if init:
             self.init_db(expire_on_commit)
-
 
     def init_db(self, expire_on_commit=True):
         if self._init:
@@ -666,13 +678,13 @@ class CalibreDB:
         if not read_column:
             bd = (self.session.query(Books, ub.ReadBook.read_status, ub.ArchivedBook.is_archived).select_from(Books)
                   .join(ub.ReadBook, and_(ub.ReadBook.user_id == int(current_user.id), ub.ReadBook.book_id == book_id),
-                  isouter=True))
+                        isouter=True))
         else:
             try:
                 read_column = cc_classes[read_column]
                 bd = (self.session.query(Books, read_column.value, ub.ArchivedBook.is_archived).select_from(Books)
                       .join(read_column, read_column.book == book_id,
-                      isouter=True))
+                            isouter=True))
             except (KeyError, AttributeError, IndexError):
                 log.error("Custom Column No.{} does not exist in calibre database".format(read_column))
                 # Skip linking read column and return None instead of read status
@@ -725,11 +737,11 @@ class CalibreDB:
                 pos_cc_list = current_user.allowed_column_value.split(',')
                 pos_content_cc_filter = true() if pos_cc_list == [''] else \
                     getattr(Books, 'custom_column_' + str(self.config.config_restricted_column)). \
-                    any(cc_classes[self.config.config_restricted_column].value.in_(pos_cc_list))
+                        any(cc_classes[self.config.config_restricted_column].value.in_(pos_cc_list))
                 neg_cc_list = current_user.denied_column_value.split(',')
                 neg_content_cc_filter = false() if neg_cc_list == [''] else \
                     getattr(Books, 'custom_column_' + str(self.config.config_restricted_column)). \
-                    any(cc_classes[self.config.config_restricted_column].value.in_(neg_cc_list))
+                        any(cc_classes[self.config.config_restricted_column].value.in_(neg_cc_list))
             except (KeyError, AttributeError, IndexError):
                 pos_content_cc_filter = false()
                 neg_content_cc_filter = true()
@@ -809,18 +821,18 @@ class CalibreDB:
         element = 0
         while indx:
             if indx >= 3:
-                query = query.outerjoin(join[element], join[element+1]).outerjoin(join[element+2])
+                query = query.outerjoin(join[element], join[element + 1]).outerjoin(join[element + 2])
                 indx -= 3
                 element += 3
             elif indx == 2:
-                query = query.outerjoin(join[element], join[element+1])
+                query = query.outerjoin(join[element], join[element + 1])
                 indx -= 2
                 element += 2
             elif indx == 1:
                 query = query.outerjoin(join[element])
                 indx -= 1
                 element += 1
-        query = query.filter(db_filter)\
+        query = query.filter(db_filter) \
             .filter(self.common_filters(allow_show_archived))
         entries = list()
         pagination = list()
@@ -890,17 +902,17 @@ class CalibreDB:
             .filter(and_(Books.authors.any(and_(*q)), func.lower(Books.title).ilike("%" + title + "%"))).first()
 
     def search_query(self, term, config, *join):
-        term=term.strip().lower()
+        term = term.strip().lower()
         self.session.connection().connection.connection.create_function("lower", 1, lcase)
         self.session.connection().connection.connection.create_function("partial_ratio", 2, partial_ratio)
         q = list()
-        #splits search term into single words
+        # splits search term into single words
         words = re.split("[, ]+", term)
-        #put the longest words first to make queries more efficient
-        words.sort(key=len,reverse=True)
-        #search authors for match
+        # put the longest words first to make queries more efficient
+        words.sort(key=len, reverse=True)
+        # search authors for match
         for word in words:
-            q.append(Books.authors.any(func.partial_ratio(func.lower(Authors.name),word)>=FUZZY_SEARCH_ACCURACY))
+            q.append(Books.authors.any(func.partial_ratio(func.lower(Authors.name), word) >= FUZZY_SEARCH_ACCURACY))
 
         query = self.generate_linked_query(config.config_read_column, Books)
         if len(join) == 6:
@@ -912,7 +924,7 @@ class CalibreDB:
         elif len(join) == 1:
             query = query.outerjoin(join[0])
 
-        filter_expression=[]
+        filter_expression = []
         cc = self.get_cc_columns(config, filter_config_custom_read=True)
         for c in cc:
             if c.datatype not in ["datetime", "rating", "bool", "int", "float"]:
@@ -921,19 +933,19 @@ class CalibreDB:
                             'custom_column_' + str(c.id)).any(
                         func.lower(cc_classes[c.id].value).ilike("%" + term + "%")))
         # filter out multiple languages and archived books,
-        results=query.filter(self.common_filters(True))
+        results = query.filter(self.common_filters(True))
 
-        #search tags, series and titles, also add author queries
+        # search tags, series and titles, also add author queries
         for word in words:
-            filter_expression=[
-                Books.tags.any(func.partial_ratio(func.lower(Tags.name),word)>=FUZZY_SEARCH_ACCURACY),
-                Books.series.any(func.partial_ratio(func.lower(Series.name),word)>=FUZZY_SEARCH_ACCURACY),
-                #change to or_ to allow mix of title and author in query term
+            filter_expression = [
+                Books.tags.any(func.partial_ratio(func.lower(Tags.name), word) >= FUZZY_SEARCH_ACCURACY),
+                Books.series.any(func.partial_ratio(func.lower(Series.name), word) >= FUZZY_SEARCH_ACCURACY),
+                # change to or_ to allow mix of title and author in query term
                 Books.authors.any(or_(*q)),
-                Books.publishers.any(func.partial_ratio(func.lower(Publishers.name),word)>=FUZZY_SEARCH_ACCURACY),
-                func.partial_ratio(func.lower(Books.title),word)>=FUZZY_SEARCH_ACCURACY
+                Books.publishers.any(func.partial_ratio(func.lower(Publishers.name), word) >= FUZZY_SEARCH_ACCURACY),
+                func.partial_ratio(func.lower(Books.title), word) >= FUZZY_SEARCH_ACCURACY
             ]
-            results=results.filter(or_(*filter_expression))
+            results = results.filter(or_(*filter_expression))
         return results
 
     def get_cc_columns(self, config, filter_config_custom_read=False):
@@ -954,10 +966,12 @@ class CalibreDB:
 
     # read search results from calibre-database and return it (function is used for feed and simple search
     def get_search_results(self, term, config, offset=None, order=None, limit=None, *join):
-        self.session.connection().connection.connection.create_function("partial_token_set_ratio", 2, partial_token_set_ratio)
+        self.session.connection().connection.connection.create_function("partial_token_set_ratio", 2,
+                                                                        partial_token_set_ratio)
         order = order[0] if order else [Books.sort]
         pagination = None
-        result = self.search_query(term, config, *join).order_by(func.desc(func.partial_token_set_ratio(str(Books),term))).all()
+        result = self.search_query(term, config, *join).order_by(
+            desc(func.partial_token_set_ratio(str(Books), term))).all()
         for res in result:
             print(res[0])
         result_count = len(result)
@@ -979,8 +993,8 @@ class CalibreDB:
 
         if with_count:
             if not languages:
-                languages = self.session.query(Languages, func.count('books_languages_link.book'))\
-                    .join(books_languages_link).join(Books)\
+                languages = self.session.query(Languages, func.count('books_languages_link.book')) \
+                    .join(books_languages_link).join(Books) \
                     .filter(self.common_filters(return_all_languages=return_all_languages)) \
                     .group_by(text('books_languages_link.lang_code')).all()
             tags = list()
@@ -1089,6 +1103,7 @@ class Category:
         self.id = cat_id
         self.rating = rating
         self.count = 1
+
 
 '''class Count:
     count = None

--- a/cps/db.py
+++ b/cps/db.py
@@ -20,7 +20,6 @@
 import os
 import re
 import json
-import traceback
 from datetime import datetime
 from urllib.parse import quote
 import unidecode
@@ -33,7 +32,6 @@ from sqlalchemy.orm import relationship, sessionmaker, scoped_session
 from sqlalchemy.orm.collections import InstrumentedList
 from sqlalchemy.ext.declarative import DeclarativeMeta
 from sqlalchemy.exc import OperationalError
-
 try:
     # Compatibility with sqlalchemy 2.0
     from sqlalchemy.orm import declarative_base
@@ -42,7 +40,6 @@ except ImportError:
 from sqlalchemy.pool import StaticPool
 from sqlalchemy.sql.expression import and_, true, false, text, func, or_
 from sqlalchemy.ext.associationproxy import association_proxy
-from sqlalchemy import desc
 from flask_login import current_user
 from flask_babel import gettext as _
 from flask_babel import get_locale
@@ -52,7 +49,7 @@ from . import logger, ub, isoLanguages
 from .pagination import Pagination
 
 from weakref import WeakSet
-from thefuzz.fuzz import partial_ratio, partial_token_set_ratio, partial_token_sort_ratio, ratio
+from thefuzz.fuzz import partial_token_sort_ratio, ratio
 
 # %-level, 100 means exact match
 FUZZY_SEARCH_ACCURACY = 80
@@ -384,8 +381,8 @@ class Books(Base):
 
     def __repr__(self):
         return "<Books('{0},{1}{2}{3}{4}{5}{6}{7}{8}')>".format(self.title, self.sort, self.author_sort,
-                                                                self.timestamp, self.pubdate, self.series_index,
-                                                                self.last_modified, self.path, self.has_cover)
+                                                                 self.timestamp, self.pubdate, self.series_index,
+                                                                 self.last_modified, self.path, self.has_cover)
 
     def __str__(self):
         return "{0} {1} {2} {3} {4}".format(self.title, " ".join([tag.name for tag in self.tags]),
@@ -439,15 +436,13 @@ class CustomColumns(Base):
         content['category_sort'] = "value"
         content['is_csp'] = False
         content['is_editable'] = self.editable
-        content['rec_index'] = sequence + 22  # toDo why ??
+        content['rec_index'] = sequence + 22     # toDo why ??
         if isinstance(value, datetime):
-            content['#value#'] = {"__class__": "datetime.datetime",
-                                  "__value__": value.strftime("%Y-%m-%dT%H:%M:%S+00:00")}
+            content['#value#'] = {"__class__": "datetime.datetime", "__value__": value.strftime("%Y-%m-%dT%H:%M:%S+00:00")}
         else:
             content['#value#'] = value
         content['#extra#'] = extra
-        content['is_multiple2'] = {} if not self.is_multiple else {"cache_to_list": "|", "ui_to_list": ",",
-                                                                   "list_to_ui": ", "}
+        content['is_multiple2'] = {} if not self.is_multiple else {"cache_to_list": "|", "ui_to_list": ",", "list_to_ui": ", "}
         return json.dumps(content, ensure_ascii=False)
 
 
@@ -468,7 +463,7 @@ class AlchemyEncoder(json.JSONEncoder):
                         el = list()
                         # ele = None
                         for ele in data:
-                            if hasattr(ele, 'value'):  # converter for custom_column values
+                            if hasattr(ele, 'value'):       # converter for custom_column values
                                 el.append(str(ele.value))
                             elif ele.get:
                                 el.append(ele.get())
@@ -506,6 +501,7 @@ class CalibreDB:
         self.session = None
         if init:
             self.init_db(expire_on_commit)
+
 
     def init_db(self, expire_on_commit=True):
         if self._init:
@@ -678,13 +674,13 @@ class CalibreDB:
         if not read_column:
             bd = (self.session.query(Books, ub.ReadBook.read_status, ub.ArchivedBook.is_archived).select_from(Books)
                   .join(ub.ReadBook, and_(ub.ReadBook.user_id == int(current_user.id), ub.ReadBook.book_id == book_id),
-                        isouter=True))
+                  isouter=True))
         else:
             try:
                 read_column = cc_classes[read_column]
                 bd = (self.session.query(Books, read_column.value, ub.ArchivedBook.is_archived).select_from(Books)
                       .join(read_column, read_column.book == book_id,
-                            isouter=True))
+                      isouter=True))
             except (KeyError, AttributeError, IndexError):
                 log.error("Custom Column No.{} does not exist in calibre database".format(read_column))
                 # Skip linking read column and return None instead of read status
@@ -737,11 +733,11 @@ class CalibreDB:
                 pos_cc_list = current_user.allowed_column_value.split(',')
                 pos_content_cc_filter = true() if pos_cc_list == [''] else \
                     getattr(Books, 'custom_column_' + str(self.config.config_restricted_column)). \
-                        any(cc_classes[self.config.config_restricted_column].value.in_(pos_cc_list))
+                    any(cc_classes[self.config.config_restricted_column].value.in_(pos_cc_list))
                 neg_cc_list = current_user.denied_column_value.split(',')
                 neg_content_cc_filter = false() if neg_cc_list == [''] else \
                     getattr(Books, 'custom_column_' + str(self.config.config_restricted_column)). \
-                        any(cc_classes[self.config.config_restricted_column].value.in_(neg_cc_list))
+                    any(cc_classes[self.config.config_restricted_column].value.in_(neg_cc_list))
             except (KeyError, AttributeError, IndexError):
                 pos_content_cc_filter = false()
                 neg_content_cc_filter = true()
@@ -821,18 +817,18 @@ class CalibreDB:
         element = 0
         while indx:
             if indx >= 3:
-                query = query.outerjoin(join[element], join[element + 1]).outerjoin(join[element + 2])
+                query = query.outerjoin(join[element], join[element+1]).outerjoin(join[element+2])
                 indx -= 3
                 element += 3
             elif indx == 2:
-                query = query.outerjoin(join[element], join[element + 1])
+                query = query.outerjoin(join[element], join[element+1])
                 indx -= 2
                 element += 2
             elif indx == 1:
                 query = query.outerjoin(join[element])
                 indx -= 1
                 element += 1
-        query = query.filter(db_filter) \
+        query = query.filter(db_filter)\
             .filter(self.common_filters(allow_show_archived))
         entries = list()
         pagination = list()
@@ -1008,8 +1004,8 @@ class CalibreDB:
             return sorted(tags, key=lambda x: x[0].name.lower(), reverse=reverse_order)
         else:
             if not languages:
-                languages = self.session.query(Languages) \
-                    .join(books_languages_link) \
+                languages = self.session.query(Languages)\
+                    .join(books_languages_link)\
                     .join(Books) \
                     .filter(self.common_filters(return_all_languages=return_all_languages)) \
                     .group_by(text('books_languages_link.lang_code')).all()
@@ -1103,7 +1099,6 @@ class Category:
         self.id = cat_id
         self.rating = rating
         self.count = 1
-
 
 '''class Count:
     count = None

--- a/cps/db.py
+++ b/cps/db.py
@@ -959,7 +959,7 @@ class CalibreDB:
         order = order[0] if order else [Books.sort]
         pagination = None
         #result = self.search_query(term, config, *join).order_by(*order).all()#*order
-        result = self.search_query(term, config, *join).order_by(desc(func.partial_ratio(Books.title+" "+Books.author_sort,term))).all()
+        result = self.search_query(term, config, *join).order_by(desc(func.partial_ratio(Books.title.name+" "+Books.author_sort.name+" "+Books.tags.get(),term))).all()
         for row in result:
             print(row)
 

--- a/cps/db.py
+++ b/cps/db.py
@@ -53,7 +53,7 @@ from . import logger, ub, isoLanguages
 from .pagination import Pagination
 
 from weakref import WeakSet
-from thefuzz.fuzz import partial_ratio
+from thefuzz.fuzz import partial_ratio, partial_token_set_ratio
 
 # %-level, 100 means exact match
 FUZZY_SEARCH_ACCURACY=80
@@ -954,7 +954,7 @@ class CalibreDB:
 
     # read search results from calibre-database and return it (function is used for feed and simple search
     def get_search_results(self, term, config, offset=None, order=None, limit=None, *join):
-        self.session.connection().connection.connection.create_function("partial_ratio", 2, partial_ratio)
+        self.session.connection().connection.connection.create_function("partial_token_set_ratio", 2, partial_token_set_ratio)
         self.session.connection().connection.connection.create_function("sort", 1, lambda tags :print(f"<Book:  {tags} >") or 3)
         order = order[0] if order else [Books.sort]
         pagination = None

--- a/cps/db.py
+++ b/cps/db.py
@@ -23,6 +23,8 @@ import json
 import traceback
 from datetime import datetime
 from urllib.parse import quote
+
+import sqlalchemy
 import unidecode
 
 from sqlite3 import OperationalError as sqliteOperationalError
@@ -918,7 +920,7 @@ class CalibreDB:
                             'custom_column_' + str(c.id)).any(
                         func.lower(cc_classes[c.id].value).ilike("%" + term + "%")))
         # filter out multiple languages and archived books,
-        results=query.filter(self.common_filters(True))
+        results:sqlalchemy.orm.Query=query.filter(self.common_filters(True))
 
         #search tags, series and titles, also add author queries
         for word in words:
@@ -933,6 +935,10 @@ class CalibreDB:
             results=results.filter(or_(*filter_expression))
         #TODO sort
 
+        results.order_by(lambda Book:Book.title+Book.tags+Book.authors)
+        # v1
+        # results.order_by(desc(lambda Book:levenshtein(Book.title+Book.tags+Book.authors,term)))
+        # v2
         # score = 0
         # for word in words:
         #     score += max(

--- a/cps/templates/search.html
+++ b/cps/templates/search.html
@@ -5,6 +5,7 @@
     {% if entries|length < 1 %}
       <h2>{{_('No Results Found')}}</h2>
       <p>{{_('Search Term:')}} {{adv_searchterm}}</p>
+        <p>{{_('Words smaller than 3 letters are not considered')}}</p>
     {% else %}
       <h2>{{result_count}} {{_('Results for:')}} {{adv_searchterm}}</h2>
       {% if current_user.is_authenticated %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,9 +20,4 @@ advocate>=1.0.0,<1.1.0
 Flask-Limiter>=2.3.0,<3.4.0
 
 thefuzz~=0.19.0
-MarkupSafe~=2.1.1
-Jinja2~=3.1.2
 Levenshtein~=0.21.0
-greenlet~=1.1.3
-cryptography~=38.0.1
-setuptools~=57.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,11 @@ flask-wtf>=0.14.2,<1.2.0
 chardet>=3.0.0,<4.1.0
 advocate>=1.0.0,<1.1.0
 Flask-Limiter>=2.3.0,<3.4.0
+
+thefuzz~=0.19.0
+MarkupSafe~=2.1.1
+Jinja2~=3.1.2
+Levenshtein~=0.21.0
+greenlet~=1.1.3
+cryptography~=38.0.1
+setuptools~=57.0.0


### PR DESCRIPTION
Currently the quick search bar only allows searching for either title or author, not a combination or different word order.
With this pr, author and title can be searched together and word order does not matter anymore.

Ideally I want to implement a way to ignore typos as well.