### PR TITLE
don't mutate meta into a str, keep it a namedtuple

### DIFF
--- a/cps/uploader.py
+++ b/cps/uploader.py
@@ -88,7 +88,7 @@ def process(tmp_file_path, original_file_name, original_file_extension, rarExecu
         log.warning('cannot parse metadata, using default: %s', ex)
 
     if not meta.title.strip():
-        meta = original_file_name
+        meta = meta._replace(title=original_file_name)
     if not meta.author.strip() or meta.author.lower() == 'unknown':
         meta = meta._replace(author=_('Unknown'))
     return meta


### PR DESCRIPTION
I had a PDF to upload where its title (`xmp_info.dc_title['x-default']`) was read in as `' '`. This caused the condition `if not meta.title.strip()` to match and #L91then mutated the variable `meta` from a `namedtuple`/`BookMeta` into a `str`. Any further access of that variable that assumed `meta` to be `BookMeta` (such as in #L92) raised an error. This change should fix that.