### PR TITLE
fix for home button linking to server root instead of application root

### DIFF
--- a/cps/templates/http_error.html
+++ b/cps/templates/http_error.html
@@ -41,7 +41,7 @@
   {% if issue %}
     <div class="row">
     <div class="col errorlink">Please report this issue with all related information:
-        <a href="https://github.com/janeczku/calibre-web/issues/new/choose=">{{_('Create Issue')}}</a>
+        <a href="https://github.com/janeczku/calibre-web/issues/new/choose">{{_('Create Issue')}}</a>
     </div>
       </div>
     {% endif %}

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -37,7 +37,7 @@
           <a class="navbar-brand" href="{{url_for('web.index')}}">{{instance}}</a>
         </div>
         {% if g.current_theme == 1 %}
-            <div class="home-btn"><a class="home-btn-tooltip" href="/" data-toggle="tooltip" title="" data-placement="bottom" data-original-title="Home"></a></div>
+            <div class="home-btn"><a class="home-btn-tooltip" href="{{url_for("web.index",page=1)}}" data-toggle="tooltip" title="" data-placement="bottom" data-original-title="Home"></a></div>
             <div class="plexBack"><a href="{{url_for('web.index')}}"></a></div>
         {% endif %}
         {% if current_user.is_authenticated or g.allow_anonymous %}


### PR DESCRIPTION
I changed the link target of the home button so that it now always links to the calibre-web root. Before, if hosted on a server, it would link to the server root. Like if the app was on www.mypage.com/calibre-web it would link to www.mypage.com

Also, I fixed a typo in the github report link of http_error.html.