### PR TITLE
remove attributes that are forbidden for send to kindle

### DIFF
--- a/cps/epub_kindle_fixer.py
+++ b/cps/epub_kindle_fixer.py
@@ -1,0 +1,42 @@
+import logging
+import os
+import tempfile
+from zipfile import ZipFile
+from xml.etree import ElementTree as ET
+
+
+def update_file(file,z:ZipFile):
+    """removes tags that are forbidden by amazon"""
+    if file.filename.endswith(".html"):
+        with z.open(file) as f:
+            for l in (lines := f.readlines()):
+                if "amzn" in l.decode("utf-8").lower():
+                    tree = ET.fromstringlist(lines)
+                    for x in tree.iter():
+                        if x.get("data-AmznRemoved"):
+                            del x.attrib["data-AmznRemoved"]
+                        if x.get("data-AmznRemoved-M8"):
+                            del x.attrib["data-AmznRemoved-M8"]
+
+                    return ET.tostring(tree)
+    return z.read(file)
+
+def fix_epub(filepath):
+    if not os.path.isfile(filepath):
+        print(f"invalid filepath: {filepath}")
+        return
+    # generate a temp file
+    tmpfd, tmpname = tempfile.mkstemp(dir=os.path.dirname(filepath))
+    os.close(tmpfd)
+
+    # create a temp copy of the archive without filename
+    with ZipFile(filepath, 'r') as zin:
+        with ZipFile(tmpname, 'w') as zout:
+            zout.comment = zin.comment  # preserve the comment
+            for item in zin.infolist():
+                zout.writestr(item, update_file(item,zin))
+
+    # replace with the temp archive
+    os.remove(filepath)
+    os.rename(tmpname, filepath)
+

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -60,7 +60,7 @@ from .services.worker import WorkerThread
 from .tasks.mail import TaskEmail
 from .tasks.thumbnail import TaskClearCoverThumbnailCache, TaskGenerateCoverThumbnails
 from .tasks.metadata_backup import TaskBackupMetadata
-
+from .epub_kindle_fixer import fix_epub
 log = logger.create()
 
 try:
@@ -218,6 +218,8 @@ def send_mail(book_id, book_format, convert, ereader_mail, calibrepath, user_id)
     for entry in iter(book.data):
         if entry.format.upper() == book_format.upper():
             converted_file_name = entry.name + '.' + book_format.lower()
+            if book_format.lower() == "epub":
+                fix_epub(os.path.join(calibrepath,book.path,converted_file_name))
             link = '<a href="{}">{}</a>'.format(url_for('web.show_book', book_id=book_id), escape(book.title))
             email_text = N_("%(book)s send to eReader", book=link)
             WorkerThread.add(user_id, TaskEmail(_("Send to eReader"), book.path, converted_file_name,


### PR DESCRIPTION
amazon does not allow epubs that contain certain attributes. this pr automatically removes these attributes from the book.
Since, to my knowledge, these attributes are not generated by the converter, this is only necessary for unconverted epubs.