### PR TITLE
Clarify `Enable Uploads` text.

### DIFF
--- a/messages.pot
+++ b/messages.pot
@@ -2175,7 +2175,7 @@ msgid "Enable Uploads"
 msgstr ""
 
 #: cps/templates/config_edit.html:108
-msgid "(Please ensure users having also upload rights)"
+msgid "(Please ensure that users also have upload permissions.)"
 msgstr ""
 
 #: cps/templates/config_edit.html:112


### PR DESCRIPTION
The current English version of this setting help string is a little odd.

This update changes the sentence to clarify the English sentence structure.