### PR TITLE
allow creating users from reverse proxy headers

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -1846,6 +1846,8 @@ def _configuration_update_helper():
         # Reverse proxy login configuration
         _config_checkbox(to_save, "config_allow_reverse_proxy_header_login")
         _config_string(to_save, "config_reverse_proxy_login_header_name")
+        _config_checkbox(to_save, "config_reverse_proxy_create_users")
+        _config_string(to_save, "config_reverse_proxy_email_header_name")
 
         # OAuth configuration
         if config.config_login_type == constants.LOGIN_OAUTH:

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -154,6 +154,8 @@ class _Settings(_Base):
 
     config_reverse_proxy_login_header_name = Column(String)
     config_allow_reverse_proxy_header_login = Column(Boolean, default=False)
+    config_reverse_proxy_create_users = Column(Boolean, default=False)
+    config_reverse_proxy_email_header_name = Column(String)
 
     schedule_start_time = Column(Integer, default=4)
     schedule_duration = Column(Integer, default=10)

--- a/cps/templates/admin.html
+++ b/cps/templates/admin.html
@@ -154,6 +154,14 @@
             <div class="col-xs-6 col-sm-7">{{_('Reverse Proxy Header Name')}}</div>
             <div class="col-xs-6 col-sm-5">{{ config.config_reverse_proxy_login_header_name }}</div>
         </div>
+        <div class="row">
+            <div class="col-xs-6 col-sm-7">{{_('Create Reverse Proxy Users')}}</div>
+            <div class="col-xs-6 col-sm-5">{{ display_bool_setting(config.config_reverse_proxy_create_users) }}</div>
+        </div>
+        <div class="row">
+            <div class="col-xs-6 col-sm-7">{{_('Reverse Proxy Email Header Name')}}</div>
+            <div class="col-xs-6 col-sm-5">{{ config.config_reverse_proxy_email_header_name }}</div>
+        </div>
         {% endif %}
       </div>
       <a class="btn btn-default" id="db_config" href="{{url_for('admin.db_configuration')}}">{{_('Edit Calibre Database Configuration')}}</a>

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -176,6 +176,14 @@
         <label for="config_reverse_proxy_login_header_name">{{_('Reverse Proxy Header Name')}}</label>
         <input type="text" class="form-control" id="config_reverse_proxy_login_header_name" name="config_reverse_proxy_login_header_name" value="{% if config.config_reverse_proxy_login_header_name != None %}{{ config.config_reverse_proxy_login_header_name }}{% endif %}" autocomplete="off">
       </div>
+      <div class="form-group">
+        <input type="checkbox" id="config_reverse_proxy_create_users" name="config_reverse_proxy_create_users" {% if config.config_reverse_proxy_create_users %}checked{% endif %}>
+        <label for="config_reverse_proxy_create_users">{{_('Create Reverse Proxy Users')}}</label>
+      </div>
+      <div class="form-group">
+        <label for="config_reverse_proxy_email_header_name">{{_('Reverse Proxy Email Header Name')}}</label>
+        <input type="text" class="form-control" id="config_reverse_proxy_email_header_name" name="config_reverse_proxy_email_header_name" value="{% if config.config_reverse_proxy_email_header_name != None %}{{ config.config_reverse_proxy_email_header_name }}{% endif %}" autocomplete="off">
+      </div>
     </div>
     {% if not config.config_is_initial %}
     {% if feature_support['ldap'] or feature_support['oauth'] %}

--- a/messages.pot
+++ b/messages.pot
@@ -1726,6 +1726,14 @@ msgstr ""
 msgid "Reverse Proxy Header Name"
 msgstr ""
 
+#: cps/templates/admin.html:158 cps/templates/config_edit.html:178
+msgid "Create Reverse Proxy Users"
+msgstr ""
+
+#: cps/templates/admin.html:162 cps/templates/config_edit.html:181
+msgid "Reverse Proxy Email Header Name"
+msgstr ""
+
 #: cps/templates/admin.html:159
 msgid "Edit Calibre Database Configuration"
 msgstr ""


### PR DESCRIPTION
Currently, when authentication happens in the reverse proxy, the user must already be in `calibre-web`'s DB or else nothing happens. [Source](https://github.com/janeczku/calibre-web/wiki/Setup-Reverse-Proxy#login-via-header-from-upstream-authentication-source):

> If you pass a username that isn't present in the database, nothing will happen - the user must exist beforehand in order to login.

With this PR, we add an option to also create the user. User creation is modeled on how we do it in LDAP sync. If the user creation fails for whatever reason, still nothing happens, and the failure happens transparently to the user, exactly how it happens today if the user doesn't already exist in the DB.

This is a very-low code PR, but it makes authenticating with reverse proxies *much* easier. The alternatives to this PR are:
* use reverse-proxy auth, but create all users manually -- this is tedious, I doubt anyone does it
* use LDAP sync to create users, and then authenticate via the proxy -- this is the most sensible alternative, but is a lot of work since LDAP is a hot old mess.
* wait for, or resume, work on the oauth generic provider from #2211

i think for people using centralized auth (authentik/authelia) with a reverse proxy (traefik/caddy/nginx) this provides the biggest bang-for-buck without much code to maintain.

We don't do any group setting here, so users will likely be created non-admin. My recommended flow to set up auth:
* set up calibre-web using the docker images
* log in with the default admin user and set up reverse proxy auth settings
* create a user matching the name you'll get from your proxy, and make that user an admin
* enable auth in your proxy
* log in with your proxy auth provider. you should be an admin
* delete the default admin user