### PR TITLE
fix the the problem that metadata_provider/douban.py can't get tags info

### DIFF
--- a/cps/metadata_provider/douban.py
+++ b/cps/metadata_provider/douban.py
@@ -169,7 +169,8 @@ class Douban(Metadata):
             ),
         )
 
-        html = etree.HTML(r.content.decode("utf8"))
+        decode_content = r.content.decode("utf8")
+        html = etree.HTML(decode_content)
 
         match.title = html.xpath(self.TITTLE_XPATH)[0].text
         match.cover = html.xpath(
@@ -184,7 +185,7 @@ class Douban(Metadata):
         if len(tag_elements):
             match.tags = [tag_element.text for tag_element in tag_elements]
         else:
-            match.tags = self._get_tags(html.text)
+            match.tags = self._get_tags(decode_content)
 
         description_element = html.xpath(self.DESCRIPTION_XPATH)
         if len(description_element):


### PR DESCRIPTION
the way of getting douban tag is searching special key word in html str.
but original code pass in a wrong str, html.text is '\n'. so, tag list always none.
#2932 