### PR TITLE
Fix typo in messages.pot

### DIFF
--- a/messages.pot
+++ b/messages.pot
@@ -1388,7 +1388,7 @@ msgid "Wrong Username or Password"
 msgstr ""
 
 #: cps/web.py:1399
-msgid "New Password was send to your email address"
+msgid "New Password was sent to your email address"
 msgstr ""
 
 #: cps/web.py:1403


### PR DESCRIPTION
Fixed the message shown when a new password is sent to an account.

Just a small change to fix a typo a user on my instance pointed out to me.