### PR TITLE
Feature: Sync custom column read state with kobo

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -246,8 +246,11 @@ def db_configuration():
 @user_login_required
 @admin_required
 def configuration():
+    all_user = ub.session.query(ub.User)
+    all_user = all_user.filter(ub.User.role.op('&')(constants.ROLE_ANONYMOUS) != constants.ROLE_ANONYMOUS)
     return render_title_template("config_edit.html",
                                  config=config,
+                                 users=all_user.all(),
                                  provider=oauthblueprints,
                                  feature_support=feature_support,
                                  title=_("Basic Configuration"), page="config")
@@ -1773,6 +1776,7 @@ def _configuration_update_helper():
         reboot_required |= _config_checkbox_int(to_save, "config_kobo_sync")
         _config_int(to_save, "config_external_port")
         _config_checkbox_int(to_save, "config_kobo_proxy")
+        _config_int(to_save, "config_kobo_read_column_sync_user")
 
         if "config_upload_formats" in to_save:
             to_save["config_upload_formats"] = ','.join(

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -121,6 +121,7 @@ class _Settings(_Base):
     config_login_type = Column(Integer, default=0)
 
     config_kobo_proxy = Column(Boolean, default=False)
+    config_kobo_read_column_sync_user = Column(Integer, default=1)
 
     config_ldap_provider_url = Column(String, default='example.org')
     config_ldap_port = Column(SmallInteger, default=389)

--- a/cps/db.py
+++ b/cps/db.py
@@ -784,7 +784,7 @@ class CalibreDB:
         else:
             try:
                 read_column = cc_classes[config_read_column]
-                query = (self.session.query(database, ub.ArchivedBook.is_archived, read_column.value)
+                query = (self.session.query(database, ub.ArchivedBook.is_archived, read_column.value.label("read_status"))
                          .select_from(Books)
                          .outerjoin(read_column, read_column.book == Books.id))
             except (KeyError, AttributeError, IndexError):

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -796,6 +796,15 @@ def HandleStateRequest(book_uuid):
                         and new_book_read_status != book_read.read_status:
                     book_read.times_started_reading += 1
                     book_read.last_time_started_reading = datetime.now(timezone.utc)
+                if current_user.id == config.config_kobo_read_column_sync_user:
+                    if new_book_read_status == ub.ReadBook.STATUS_FINISHED:
+                        log.info(f"Syncing new read status to Calibre: Book \
+                                 ({calibre_db.get_book(book.id).title}) -> Finished")
+                        helper.edit_book_read_status(book.id, True)
+                    elif new_book_read_status == ub.ReadBook.STATUS_UNREAD:
+                        log.info(f"Syncing new read status to Calibre: Book \
+                                 ({calibre_db.get_book(book.id).title}) -> Unread")
+                        helper.edit_book_read_status(book.id, False)
                 book_read.read_status = new_book_read_status
                 update_results_response["StatusInfoResult"] = {"Result": "Success"}
         except (KeyError, TypeError, ValueError, StatementError):
@@ -841,6 +850,23 @@ def get_or_create_reading_state(book_id):
         kobo_reading_state.current_bookmark = ub.KoboBookmark()
         kobo_reading_state.statistics = ub.KoboStatistics()
         book_read.kobo_reading_state = kobo_reading_state
+
+    # While the custom read column is set, the read_status field can be outdated so update it now
+    if config.config_read_column and current_user.id == config.config_kobo_read_column_sync_user:
+        read_column_table = db.cc_classes[config.config_read_column]
+        query = calibre_db.session.query(read_column_table.value).filter(read_column_table.book == book_id).one_or_none()
+        if query:
+            calibre_read_status = query.value
+            # Reading state cant be repr in the custom col so only update the unread and finished status
+            if not calibre_read_status and book_read.read_status == ub.ReadBook.STATUS_FINISHED:
+                log.info(f"Syncing new read status to Kobo: Book ({calibre_db.get_book(book_id).title}) -> Unread")
+                book_read.read_status = ub.ReadBook.STATUS_UNREAD
+                book_read.kobo_reading_state.last_modified = datetime.now(timezone.utc)
+            elif calibre_read_status and book_read.read_status == ub.ReadBook.STATUS_UNREAD:
+                log.info(f"Syncing new read status to Kobo: Book ({calibre_db.get_book(book_id).title}) -> Finished")
+                book_read.read_status = ub.ReadBook.STATUS_FINISHED
+                book_read.kobo_reading_state.last_modified = datetime.now(timezone.utc)
+
     ub.session.add(book_read)
     ub.session_commit()
     return book_read.kobo_reading_state

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -150,6 +150,16 @@
         <input type="number" min="1" max="65535" class="form-control" name="config_external_port" id="config_external_port" value="{% if config.config_external_port != None %}{{ config.config_external_port }}{% endif %}" autocomplete="off" required>
       </div>
     </div>
+    <div data-related="kobo-settings">
+      <div class="form-group" style="margin-left:10px;">
+        <label for="config_kobo_read_column_sync_user">{{_('User for Calibre Read Column')}}</label>
+        <select name="config_kobo_read_column_sync_user" id="config_kobo_read_column_sync_user" class="form-control">
+          {% for user in users %}
+            <option value="{{user.id}}" {% if user.id == config.config_kobo_read_column_sync_user %}selected{% endif %}>{{user.name}}</option>"
+          {% endfor %}
+        </select>
+      </div>
+    </div>
     {% endif %}
     {% if feature_support['goodreads'] %}
     <div class="form-group">


### PR DESCRIPTION
Currently, the read state when books are synced with Kobo is not correctly synced when the "Link Read/Unread Status to Calibre Column" option is used.

This change makes it so that changing read state on either Calibre or the Kobo e-reader should sync the read state correctly. Note that the Kobo reading state has a third state - reading - that cannot be represented in the Calibre column and so gets ignored.

This also adds an additional configuration option "User for Calibre Read Column" so that only the specified user's syncing will update or be updated by the column in Calibre. By default, it is configured to be the Admin user (id 1).

![image](https://github.com/janeczku/calibre-web/assets/49935800/b494b759-6dd2-4fdf-a617-320002044855)

resolves #2740 