### PR TITLE
feat: add handling for regional locales

### DIFF
--- a/cps/isoLanguages.py
+++ b/cps/isoLanguages.py
@@ -49,15 +49,24 @@ except ImportError:
 
 
 def get_language_names(locale):
-    return _LANGUAGE_NAMES.get(str(locale))
+    names = _LANGUAGE_NAMES.get(str(locale))
+    if names is None:
+        names = _LANGUAGE_NAMES.get(locale.language)
+    return names
 
 
 def get_language_name(locale, lang_code):
-    try:
-        return get_language_names(locale)[lang_code]
-    except KeyError:
-        log.error('Missing translation for language name: {}'.format(lang_code))
-        return "Unknown"
+    UNKNOWN_TRANSLATION = "Unknown"
+    names = get_language_names(locale)
+    if names is None:
+        log.error(f"Missing language names for locale: {str(locale)}/{locale.language}")
+        return UNKNOWN_TRANSLATION
+
+    name = names.get(lang_code, UNKNOWN_TRANSLATION)
+    if name == UNKNOWN_TRANSLATION:
+        log.error("Missing translation for language name: {}".format(lang_code))
+
+    return name
 
 
 def get_language_codes(locale, language_names, remainder=None):


### PR DESCRIPTION
## Issue

The default is to use American-style date formats in calibre-web. I live in Australia which uses a different date format. I have added a custom translation to my local install but this causes a crash if selected when viewing books as the code attempts to locate the "en_AU" translations of the [Calibre language names](https://github.com/janeczku/calibre-web/blob/fcc95bd8953c0b1c00c7af1dfd2f3bb3b3c9dbd0/cps/iso_language_names.py#L10550).

## The fix

In this code change, we look for the string representation of the locale i.e. en_AU, pt_BR. If no names are returned we look at just the language portion i.e. en_AU -> en, pt_BR -> pt.