### PR TITLE
feat: base is_debug on effective level vs root log level

### DIFF
--- a/cps/logger.py
+++ b/cps/logger.py
@@ -43,13 +43,14 @@ logging.addLevelName(logging.CRITICAL, "CRIT")
 class _Logger(logging.Logger):
 
     def error_or_exception(self, message, stacklevel=2, *args, **kwargs):
+        is_debug = self.getEffectiveLevel() <= logging.DEBUG
         if sys.version_info > (3, 7):
-            if is_debug_enabled():
+            if is_debug:
                 self.exception(message, stacklevel=stacklevel, *args, **kwargs)
             else:
                 self.error(message, stacklevel=stacklevel, *args, **kwargs)
         else:
-            if is_debug_enabled():
+            if is_debug:
                 self.exception(message, stack_info=True, *args, **kwargs)
             else:
                 self.error(message, *args, **kwargs)


### PR DESCRIPTION
This change enables adding debug logging to calibre-web classes that will be output when debug is enabled in settings without enabling debug level for external modules