### PR TITLE
fix: change bytes-encoded token to unicode string

### DIFF
--- a/cps/services/SyncToken.py
+++ b/cps/services/SyncToken.py
@@ -30,7 +30,7 @@ log = logger.create()
 
 
 def b64encode_json(json_data):
-    return b64encode(json.dumps(json_data).encode())
+    return b64encode(json.dumps(json_data).encode()).decode("utf-8")
 
 
 # Python3 has a timestamp() method we could be calling, however it's not avaiable in python2.


### PR DESCRIPTION
`b64encode` returns a `bytes` object, meaning that `SyncToken.build_sync_token` returns something like `b'eyrestOfToken'`. When we later set it as a header, Flask (or something else internally) calls `str` on whatever was passed. A `str`'d `bytes` object wraps it in quotes in its repr'd form, so we get `"b'eyrestOfToken"` which is not base64-decodable.

This fixes an issue where sync tokens can never be read and endlessly loop, causing every sync to fail.