### PR TITLE
Add python-magic for validating mimetypes

### DIFF
--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -23,6 +23,7 @@
 import os
 from datetime import datetime
 import json
+import magic
 from shutil import copyfile
 from uuid import uuid4
 from markupsafe import escape, Markup  # dependency of flask
@@ -755,6 +756,10 @@ def file_handling_on_upload(requested_file):
     except (IOError, OSError):
         log.error("File %s could not saved to temp dir", requested_file.filename)
         flash(_("File %(filename)s could not saved to temp dir",
+                filename=requested_file.filename), category="error")
+        return None, Response(json.dumps({"location": url_for("web.index")}), mimetype='application/json')
+    except (Exception):
+        flash(_("File is not allowed to be uploaded to this server",
                 filename=requested_file.filename), category="error")
         return None, Response(json.dumps({"location": url_for("web.index")}), mimetype='application/json')
     return meta, None

--- a/cps/file_helper.py
+++ b/cps/file_helper.py
@@ -19,6 +19,9 @@
 from tempfile import gettempdir
 import os
 import shutil
+import magic
+import zipfile
+from . import constants
 
 def get_temp_dir():
     tmp_dir = os.path.join(gettempdir(), 'calibre_web')
@@ -30,3 +33,19 @@ def get_temp_dir():
 def del_temp_dir():
     tmp_dir = os.path.join(gettempdir(), 'calibre_web')
     shutil.rmtree(tmp_dir)
+
+def validate_mime_type(tmp_file_path):
+    mime = magic.Magic(mime=True)
+    tmp_mime_type = mime.from_file(tmp_file_path)
+    if any(mime_type in tmp_mime_type for mime_type in constants.EXTENSIONS_UPLOAD):
+        return True
+    # Some epubs show up as zip mimetypes
+    elif "zip" in tmp_mime_type:
+        try:
+            with zipfile.ZipFile(tmp_file_path, 'r') as epub:
+                if "mimetype" in epub.namelist():
+                    return True
+        except:
+            pass
+    
+    raise Exception("Forbidden MIME type to upload")

--- a/cps/uploader.py
+++ b/cps/uploader.py
@@ -23,7 +23,7 @@ from flask_babel import gettext as _
 from . import logger, comic, isoLanguages
 from .constants import BookMeta
 from .helper import split_authors
-from .file_helper import get_temp_dir
+from .file_helper import get_temp_dir, validate_mime_type
 
 log = logger.create()
 
@@ -91,7 +91,8 @@ def process(tmp_file_path, original_file_name, original_file_extension, rar_exec
         meta = meta._replace(title=original_file_name)
     if not meta.author.strip() or meta.author.lower() == 'unknown':
         meta = meta._replace(author=_('Unknown'))
-    return meta
+    if validate_mime_type(tmp_file_path):
+        return meta
 
 
 def default_meta(tmp_file_path, original_file_name, original_file_extension):

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ chardet>=3.0.0,<4.1.0
 advocate>=1.0.0,<1.1.0
 Flask-Limiter>=2.3.0,<3.6.0
 regex>=2022.3.2,<2024.2.25
+python-magic>=0.4.27


### PR DESCRIPTION
Potential solution for https://github.com/janeczku/calibre-web/issues/3044

This PR adds in mimetype checking to ensure that files being uploaded are not maliciously disguised.

Create a bash script:
```
# test.sh
#!/bin/bash
echo "Hello World!"
```

Rename the bash script: (Ensure that server allows `epub`)
```
mv test.sh test.epub
```

Upload the file to confirm that it is not possible as the mimetype is read differently.

<img width="1421" alt="Screen Shot 2024-05-31 at 5 52 26 PM" src="https://github.com/janeczku/calibre-web/assets/114264492/b77153d1-270c-47dc-b481-9394093bd95f">
<img width="577" alt="Screen Shot 2024-05-31 at 5 58 14 PM" src="https://github.com/janeczku/calibre-web/assets/114264492/0b1d1b0e-516e-4610-bc2b-3b65c30a060f">
<img width="1290" alt="Screen Shot 2024-05-31 at 5 53 42 PM" src="https://github.com/janeczku/calibre-web/assets/114264492/b45acfea-292a-475f-aefe-25a6fb5d78d8">
