### PR TITLE
Attempt pywin32 install only on Windows

### DIFF
--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -45,4 +45,4 @@ comicapi>=2.2.0,<3.3.0
 jsonschema>=3.2.0,<4.23.0
 
 # Hide console Window on Windows
-pywin32>=220,<310
+pywin32>=220,<310 ; sys_platform == 'win32'


### PR DESCRIPTION
Currently, doing a `pip install -r optional-requirements.txt` on a non-Windows platform results in an error due to pywin32 being a Windows only package.

We do this in Linuxserver docker images and the nightly tag builds are failing as a result:
https://ci.linuxserver.io/blue/organizations/jenkins/Docker-Pipeline-Builders%2Fdocker-calibre-web/detail/nightly/888/pipeline/#step-159-log-1130