### PR TITLE
Allow using calibredb for upload processing

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -1763,6 +1763,7 @@ def _configuration_update_helper():
             return _configuration_result(_('Certfile Location is not Valid, Please Enter Correct Path'))
 
         _config_checkbox_int(to_save, "config_uploading")
+        _config_checkbox_int(to_save, "config_upload_with_calibredb")
         _config_checkbox_int(to_save, "config_unicode_filename")
         _config_checkbox_int(to_save, "config_embed_metadata")
         # Reboot on config_anonbrowse with enabled ldap, as decoraters are changed in this case

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -148,6 +148,7 @@ class _Settings(_Base):
     config_upload_formats = Column(String, default=','.join(constants.EXTENSIONS_UPLOAD))
     config_unicode_filename = Column(Boolean, default=False)
     config_embed_metadata = Column(Boolean, default=True)
+    config_upload_with_calibredb = Column(Boolean, default=False)
 
     config_updatechannel = Column(Integer, default=constants.UPDATE_STABLE)
 
@@ -504,7 +505,7 @@ def autodetect_calibre_binaries():
                         "C:\\program files(x86)\\calibre2\\",
                         "C:\\program files\\calibre2\\"]
     else:
-        calibre_path = ["/opt/calibre/"]
+        calibre_path = ["/opt/calibre/", "/app/calibre"]
     for element in calibre_path:
         supported_binary_paths = [os.path.join(element, binary)
                                   for binary in constants.SUPPORTED_CALIBRE_BINARIES.values()]

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -112,6 +112,10 @@
         <label for="config_uploading">{{_('Enable Uploads')}} {{_('(Please ensure that users also have upload permissions)')}}</label>
     </div>
     <div data-related="upload_settings">
+      <div class = "form-group">
+          <input type="checkbox" id="config_upload_with_calibredb" name="config_upload_with_calibredb" {% if config.config_upload_with_calibredb %}checked{% endif %}>
+          <label for="config_upload_with_calibredb">{{_('Upload with calibredb')}}</label>
+      </div>
       <div class="form-group">
         <label for="config_upload_formats">{{_('Allowed Upload Fileformats')}}</label>
         <input type="text" class="form-control" name="config_upload_formats" id="config_upload_formats" value="{% if config.config_upload_formats != None %}{{ config.config_upload_formats }}{% endif %}" autocomplete="off">

--- a/cps/uploader.py
+++ b/cps/uploader.py
@@ -265,7 +265,7 @@ def upload(uploadfile, rar_excecutable):
     filename = uploadfile.filename
     filename_root, file_extension = os.path.splitext(filename)
     md5 = hashlib.md5(filename.encode('utf-8')).hexdigest()  # nosec
-    tmp_file_path = os.path.join(tmp_dir, md5)
+    tmp_file_path = os.path.join(tmp_dir, md5) + file_extension
     log.debug("Temporary file: %s", tmp_file_path)
     uploadfile.save(tmp_file_path)
     return process(tmp_file_path, filename_root, file_extension, rar_excecutable)


### PR DESCRIPTION
Some things calibre is able to do via plugins that would be helpful to handle in calibre-web, but there's not much point in re-implementing those in calibre-web directly. Things like importing ACSM files and getting the resulting ebook directly, or importing KFX files that require extra processing. Currently, to keep the ability to use the Kobo sync service, the solution is to run both calibre-web and `calibre-server` and switch between them. Running `calibre-server` adds to smooth usability issues since using GUI calibre risks conflicting with `calibre-server` unless you remember to stop it every time you use GUI calibre. If your calibre library is stored on a shared folder, such as Google Drive or OneDrive or Dropbox, a conflict with `calibre-server` is guaranteed when using GUI calibre since the modified `metadata.db` is moved into place as a new file, with a new inode, causing `calibre-server` to be unable to continue using its existing database connection.

To accommodate using `calibredb` for uploads, avoiding conflicts between calibre and `calibre-server`, and allowing everything to happen in one interface instead of switching between calibre and calibre-web, this PR:

- Adds a new setting, linked to the main upload permission, to use calibredb for uploading files. Default value, or the behaviour if `calibredb` is not found, is to keep the existing behaviour of having calibre-web process the uploaded books and add them to the calibre database.
- Adds the location the linuxserver Docker image installs calibre to the list of paths searched for calibre binaries
- Adds the chunk of code to `upload()` in `editbooks.py` to shell out to `calibredb`
- Appends the original file extension to the temporary file path, since `calibredb` needs that for format detection