### PR TITLE
Add bulk delete button in books table page

### DIFF
--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -488,6 +488,28 @@ def simulate_merge_list_book():
             return json.dumps({'to': to_book, 'from': from_book})
     return ""
 
+@editbook.route("/ajax/simulatedeleteselectedbooks", methods=['POST'])
+@user_login_required
+@edit_required
+def simulate_delete_selected_books():
+    vals = request.get_json().get('selections')
+    books = []
+    if vals:
+        for book_id in vals:
+            books.append(calibre_db.get_book(book_id).title)
+        return json.dumps({'books': books})
+    return ""
+
+@editbook.route("/ajax/deleteselectedbooks", methods=['POST'])
+@user_login_required
+@edit_required
+def delete_selected_books():
+    vals = request.get_json().get('selections')
+    if vals:
+        for book_id in vals:
+            delete_book_from_table(book_id, "", True)
+        return json.dumps({'success': True})
+    return ""
 
 @editbook.route("/ajax/mergebooks", methods=['POST'])
 @user_login_required

--- a/cps/static/js/table.js
+++ b/cps/static/js/table.js
@@ -81,6 +81,14 @@ $(function() {
                 $("#merge_books").addClass("disabled");
                 $("#merge_books").attr("aria-disabled", true);
             }
+            if (selections.length >= 1) {
+                $("#delete_selected_books").removeClass("disabled");
+                $("#delete_selected_books").attr("aria-disabled", false);
+            } else {
+                $("#delete_selected_books").addClass("disabled");
+                $("#delete_selected_books").attr("aria-disabled", true);
+
+            }
             if (selections.length < 1) {
                 $("#delete_selection").addClass("disabled");
                 $("#delete_selection").attr("aria-disabled", true);
@@ -131,6 +139,42 @@ $(function() {
                 });
                 $("#merge_to").text("- " + booTitles.to);
 
+            }
+        });
+    });
+
+    $("#delete_selected_books").click(function(event) {
+        if ($(this).hasClass("disabled")) {
+            event.stopPropagation()
+        } else {
+            $('#delete_selected_modal').modal("show");
+        }
+        $.ajax({
+            method:"post",
+            contentType: "application/json; charset=utf-8",
+            dataType: "json",
+            url: window.location.pathname + "/../ajax/simulatedeleteselectedbooks",
+            data: JSON.stringify({"selections":selections}),
+            success: function success(booTitles) {
+                $('#selected-books').empty();
+                $.each(booTitles.books, function(i, item) {
+                    $("<span>- " + item + "</span><p></p>").appendTo("#selected-books");
+                });
+
+            }
+        });
+    });
+
+    $("#delete_selected_confirm").click(function(event) {
+        $.ajax({
+            method:"post",
+            contentType: "application/json; charset=utf-8",
+            dataType: "json",
+            url: window.location.pathname + "/../ajax/deleteselectedbooks",
+            data: JSON.stringify({"selections":selections}),
+            success: function success(booTitles) {
+                $("#books-table").bootstrapTable("refresh");
+                $("#books-table").bootstrapTable("uncheckAll");
             }
         });
     });

--- a/cps/templates/book_table.html
+++ b/cps/templates/book_table.html
@@ -35,6 +35,7 @@
       <div class="col-xs-12 col-sm-6">
         <div class="row form-group">
           <div class="btn btn-default disabled" id="merge_books" aria-disabled="true">{{_('Merge selected books')}}</div>
+          <div class="btn btn-default disabled" id="delete_selected_books" aria-disabled="true">{{_('Delete selected books')}}</div>
           <div class="btn btn-default disabled" id="delete_selection" aria-disabled="true">{{_('Remove Selections')}}</div>
         </div>
         <div class="row form-group">
@@ -125,6 +126,25 @@
       <div class="modal-footer">
         <input id="merge_confirm"  type="button" class="btn btn-danger" value="{{_('Merge')}}" name="merge_confirm" id="merge_confirm" data-dismiss="modal">
         <button id="merge_abort" type="button" class="btn btn-default" data-dismiss="modal">{{_('Cancel')}}</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="delete_selected_modal" role="dialog" aria-labelledby="metaDeleteSelectedLabel">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header bg-danger text-center">
+          <span>{{_('Are you really sure?')}}</span>
+      </div>
+      <div class="modal-body">
+        <p></p>
+            <div class="text-left">{{_('The following books will be deleted:')}}</div>
+        <p></p>
+            <div class="text-left" id="selected-books"></div>
+      <div class="modal-footer">
+        <input id="delete_selected_confirm" type="button" class="btn btn-danger" value="{{_('Delete')}}" name="delete_selected_confirm" id="delete_selected_confirm" data-dismiss="modal">
+        <button id="delete_selected_abort" type="button" class="btn btn-default" data-dismiss="modal">{{_('Cancel')}}</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR adds a button to delete selected books in the table page. Screenshots below show the workflow for end-users:


### **Select books**
![image](https://github.com/user-attachments/assets/169feee1-d84b-4967-b4f2-fcf53c297ae5)

### **Book deletion confirmation**
![image](https://github.com/user-attachments/assets/8cee6db1-880d-499f-96f0-0344fba220ee)

### **Result: Books deleted**
![image](https://github.com/user-attachments/assets/759599db-782e-46a6-acfe-e6cb420f44ba)

