### PR TITLE
Fix http 500 error during pdf upload (NullObject object has no attribute 'split')

### DIFF
--- a/cps/uploader.py
+++ b/cps/uploader.py
@@ -39,20 +39,17 @@ except (ImportError, RuntimeError) as e:
 
 try:
     from pypdf import PdfReader
-    from pypdf.generic import NullObject
     use_pdf_meta = True
 except ImportError as ex:
     log.debug('PyPDF is recommended for best performance in metadata extracting from pdf files: %s', ex)
     try:
         from PyPDF2 import PdfReader
-        from pypdf.generic import NullObject
         use_pdf_meta = True
     except ImportError as ex:
         log.debug('PyPDF is recommended for best performance in metadata extracting from pdf files: %s', ex)
         log.debug('PyPdf2 is also possible for metadata extracting from pdf files, but not recommended anymore')
         try:
             from PyPDF3 import PdfFileReader as PdfReader
-            from pypdf.generic import NullObject
             use_pdf_meta = True
         except ImportError as e:
             log.debug('Cannot import PyPDF3/PyPDF2, extracting pdf metadata will not work: %s / %s', e)
@@ -209,7 +206,7 @@ def pdf_meta(tmp_file_path, original_file_name, original_file_extension, no_cove
             subject = doc_info.subject or ""
         if tags == '' and '/Keywords' in doc_info:
             keywords = doc_info['/Keywords']
-            if not isinstance(keywords, NullObject):
+            if str(keywords) != 'NullObject':
                 if isinstance(keywords, bytes):
                     tags = keywords.decode('utf-8')
                 else:

--- a/cps/uploader.py
+++ b/cps/uploader.py
@@ -39,17 +39,20 @@ except (ImportError, RuntimeError) as e:
 
 try:
     from pypdf import PdfReader
+    from pypdf.generic import NullObject
     use_pdf_meta = True
 except ImportError as ex:
     log.debug('PyPDF is recommended for best performance in metadata extracting from pdf files: %s', ex)
     try:
         from PyPDF2 import PdfReader
+        from pypdf.generic import NullObject
         use_pdf_meta = True
     except ImportError as ex:
         log.debug('PyPDF is recommended for best performance in metadata extracting from pdf files: %s', ex)
         log.debug('PyPdf2 is also possible for metadata extracting from pdf files, but not recommended anymore')
         try:
             from PyPDF3 import PdfFileReader as PdfReader
+            from pypdf.generic import NullObject
             use_pdf_meta = True
         except ImportError as e:
             log.debug('Cannot import PyPDF3/PyPDF2, extracting pdf metadata will not work: %s / %s', e)
@@ -205,10 +208,12 @@ def pdf_meta(tmp_file_path, original_file_name, original_file_extension, no_cove
         if subject == '':
             subject = doc_info.subject or ""
         if tags == '' and '/Keywords' in doc_info:
-            if isinstance(doc_info['/Keywords'], bytes):
-                tags = doc_info['/Keywords'].decode('utf-8')
-            else:
-                tags = doc_info['/Keywords']
+            keywords = doc_info['/Keywords']
+            if not isinstance(keywords, NullObject):
+                if isinstance(keywords, bytes):
+                    tags = keywords.decode('utf-8')
+                else:
+                    tags = keywords
     else:
         title = original_file_name
 


### PR DESCRIPTION
This fixes http 500 error during upload of some books that pass pdf 1.4 validation at https://www.pdf-online.com/osa/validate.aspx, but cause the error in calbre-web. The error message is:

```
File "/app/calibre-web/cps/editbooks.py", line 1001, in edit_book_tags
    input_tags = tags.split(',')
AttributeError: 'NullObject' object has no attribute 'split'
```

Example of a book (21MB) that causes the error: https://github.com/contributor/calibre-web/blob/test-case/test/dotnet-aspire_cropped.pdf

NullObject comes from parsing metadata by pypdf/pypdf2/pypdf3 package.

This PR fixes http 500 error by ignoring 'NullObject /Keywords' and contains two commits:

1. the first commit does it “the right way”
2. the second commit does it “the simple way”: it avoids importing  NullObject from three packages and localizes fix in single place

@OzzieIsaacs  thank you for all your work! If you prefer commit 1, I will drop commit 2. If you prefer commit 2, you can just squash the PR during merge