### PR TITLE
[DRAFT] update metadata/covers on kobo sync

### DIFF
--- a/cps/helper.py
+++ b/cps/helper.py
@@ -28,7 +28,7 @@ import socket
 from datetime import datetime, timedelta, timezone
 import requests
 import unidecode
-from uuid import uuid4
+from uuid import uuid4, uuid3, NAMESPACE_DNS
 
 from flask import send_from_directory, make_response, abort, url_for, Response
 from flask_babel import gettext as _
@@ -741,12 +741,31 @@ def get_book_cover(book_id, resolution=None):
     return get_book_cover_internal(book, resolution=resolution)
 
 
-def get_book_cover_with_uuid(book_uuid, resolution=None):
-    book = calibre_db.get_book_by_uuid(book_uuid)
+def get_book_cover_with_uuid(uuid, resolution=None):
+    mapped_cover = ub.session.query(ub.KoboCoverMapping).filter(ub.KoboCoverMapping.cover_uuid == uuid).first()
+    if mapped_cover:
+        uuid = mapped_cover.book_uuid
+    book = calibre_db.get_book_by_uuid(uuid)
     if not book:
         return  # allows kobo.HandleCoverImageRequest to proxy request
     return get_book_cover_internal(book, resolution=resolution)
 
+def make_book_cover_uuid(book_uuid):
+    book = calibre_db.get_book_by_uuid(book_uuid)
+    cover_path = os.path.join(config.get_book_path(), book.path, "cover.jpg") # is it always correct that cover.jpg
+    if os.path.exists(cover_path):
+        with open(cover_path, "rb") as f:
+            data = f.read()
+        cover_uuid = str(uuid3(NAMESPACE_DNS, data))
+        is_present = ub.session.query(ub.KoboCoverMapping).filter(ub.KoboCoverMapping.book_uuid == book_uuid).filter(ub.KoboCoverMapping.cover_uuid == cover_uuid).count()
+        if not is_present:
+            cover_mapping = ub.KoboCoverMapping()
+            cover_mapping.book_uuid = book_uuid
+            cover_mapping.cover_uuid = cover_uuid
+            ub.session.add(cover_mapping)
+            ub.session_commit()
+        return cover_uuid
+    return book_uuid
 
 def get_book_cover_internal(book, resolution=None):
     if book and book.has_cover:

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -227,10 +227,8 @@ def HandleSyncRequest():
         except AttributeError:
             pass
 
-        if ts_created > sync_token.books_last_created:
-            sync_results.append({"NewEntitlement": entitlement})
-        else:
-            sync_results.append({"ChangedEntitlement": entitlement})
+        sync_results.append({"NewEntitlement": entitlement})
+        sync_results.append({"ChangedProductMetadata": get_metadata(book.Books)})
 
         new_books_last_modified = max(
             book.Books.last_modified.replace(tzinfo=None), new_books_last_modified
@@ -458,10 +456,11 @@ def get_metadata(book):
                 log.error(e)
 
     book_uuid = book.uuid
+    cover_uuid = helper.make_book_cover_uuid(book_uuid)
     metadata = {
         "Categories": ["00000000-0000-0000-0000-000000000001", ],
         # "Contributors": get_author(book),
-        "CoverImageId": book_uuid,
+        "CoverImageId": cover_uuid,
         "CrossRevisionId": book_uuid,
         "CurrentDisplayPrice": {"CurrencyCode": "USD", "TotalAmount": 0},
         "CurrentLoveDisplayPrice": {"TotalAmount": 0},

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -449,6 +449,11 @@ class KoboSyncedBooks(Base):
     user_id = Column(Integer, ForeignKey('user.id'))
     book_id = Column(Integer)
 
+class KoboCoverMapping(Base):
+    __tablename__ = 'kobo_cover_mappings'
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    book_uuid = Column(String)
+    cover_uuid = Column(String)
 # The Kobo ReadingState API keeps track of 4 timestamped entities:
 #   ReadingState, StatusInfo, Statistics, CurrentBookmark
 # Which we map to the following 4 tables:


### PR DESCRIPTION
I have initial support for updating metadata and covers on kobo sync. This is a draft and shouldn't be merged yet but I wanted to get a second pair of eyes on it. 

I have a few specific things I'd like thoughts on. 

- Current design for handling hashed covers is bad/wrong when two books share the same cover. We could store thumbnails in sqlite or maybe store path to the cover on disk? 
- What does ChangedEntitlement do? It didn't seem to do anything in my testing. 
- How should we handle removing a book from KoboSyncedBooks when it changes? It's easy to just remove it when modified through the UI but ideally we should support filesystem changes too. Calibre's last_modified metadata column could be used but seems generally likely to be spuriously true. We could store last sync in KoboSyncedBooks and compare against last modified time on disk? Could also add an API route to resync a calibre id. Thoughts? 

Thanks!