### PR TITLE
fix bookmarks button for safari browser

### DIFF
--- a/cps/static/css/main.css
+++ b/cps/static/css/main.css
@@ -77,7 +77,6 @@ body {
 }
 
 #panels a {
-  visibility: hidden;
   width: 18px;
   height: 20px;
   overflow: hidden;


### PR DESCRIPTION
In the Safari browser, it was impossible for me to press the bookmarks button. After removing the `visibility: hidden`; property from `#panels a`, it started working again. 

Setting `visibility: hidden`; on the `#panels a` element makes the entire link (and all its content, including the` ::before` pseudo-element) invisible and not clickable.

I didn't have this problem on Chrome or firefox, and the modification didn't break anything for me.

 reference to  issue number #2839 
