### PR TITLE
Increase sqlite calibre metadata.db cache

### DIFF
--- a/cps/db.py
+++ b/cps/db.py
@@ -621,6 +621,7 @@ class CalibreDB:
                                          connect_args={'check_same_thread': False},
                                          poolclass=StaticPool)
             with check_engine.begin() as connection:
+                connection.execute(text('PRAGMA cache_size = 10000;'))
                 connection.execute(text("attach database '{}' as calibre;".format(dbpath)))
                 connection.execute(text("attach database '{}' as app_settings;".format(app_db_path)))
                 local_session = scoped_session(sessionmaker())
@@ -658,6 +659,7 @@ class CalibreDB:
                                        connect_args={'check_same_thread': False},
                                        poolclass=StaticPool)
             with cls.engine.begin() as connection:
+                connection.execute(text('PRAGMA cache_size = 10000;'))
                 connection.execute(text("attach database '{}' as calibre;".format(dbpath)))
                 connection.execute(text("attach database '{}' as app_settings;".format(app_db_path)))
 


### PR DESCRIPTION
Increase from the default `2000 pages` or 8MB of RAM to 10k pages or up to 40MB of memory, in a library with 15k books this reduce the initial load page from ~500ms to ~400ms, no further increase improved performance if the valu is bigger for a metadata.db of 28MB. Maybe in future consider convert this to ENV VAR or a feature flag to allow create one page by item in metadata.db.

ref.: https://www.sqlite.org/pragma.html

PS:

I tested changes on page size and another pragma with no better result, looks like if the total pages is bigger than the total size of metadata.db he will reside entirely on memory (40MB > 28MB). For libraries with size reduced the memory consumption don't change, only in the case the metadata.db is bigger than 8MB. Another way is change to use `kibibytes` when change this to use ENV VAR to allow user choose the better memory vs performance ratio.