### PR TITLE
Reconnect to calibre database on SIGHUP

### DIFF
--- a/cps/main.py
+++ b/cps/main.py
@@ -42,6 +42,7 @@ def main():
     from .tasks_status import tasks
     from .error_handler import init_errorhandler
     from .remotelogin import remotelogin
+    from .signal import register_signals
     try:
         from .kobo import kobo, get_kobo_activated
         from .kobo_auth import kobo_auth
@@ -60,6 +61,7 @@ def main():
 
     from . import web_server
     init_errorhandler()
+    register_signals()
 
     app.register_blueprint(search)
     app.register_blueprint(tasks)

--- a/cps/signal.py
+++ b/cps/signal.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+#  This file is part of the Calibre-Web (https://github.com/janeczku/calibre-web)
+#    Copyright (C) 2024 quantum5
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import signal
+
+from . import calibre_db, config, logger, ub
+
+log = logger.create()
+
+
+def sighup_handler(_signum, _frame):
+    log.warning('received SIGHUP; reconnecting to calibre database')
+    calibre_db.reconnect_db(config, ub.app_DB_path)
+
+
+def register_signals():
+    if hasattr(signal, 'SIGHUP'):
+        signal.signal(signal.SIGHUP, sighup_handler)


### PR DESCRIPTION
This PR hooks the "Reconnect Calibre Database" feature in the admin page to `SIGHUP`. This allows the database to be reloaded by running a command, which is extremely useful when using synchronization tools with the calibre `metadata.db`.

For example, Syncthing would delete `metadata.db` and recreate a new file in its place when the database is modified on a different machine, and  `inotifywait` can be used to send `SIGHUP` when this happens.