### PR TITLE
Add share details metadata

### DIFF
--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -8,6 +8,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta property="og:type" content="book" />
+    {% if entry %}
+      <meta property="og:title" content="{{ entry.title|truncate(35) }}" />
+      {% if entry.comments|length > 0 and entry.comments[0].text|length > 0 %}
+        <meta property="og:description" content="{{ entry.comments[0].text|striptags|truncate(65) }}" />
+      {% endif %}
+      <meta property="og:image" content="{{url_for('web.get_cover', book_id=entry.id, resolution='og', c=entry|last_modified)}}" />
+    {% endif %}
     {% if g.google_site_verification|length > 0 %}
       <meta name="google-site-verification" content="{{g.google_site_verification}}">
     {% endif %}


### PR DESCRIPTION
This change allow share details on whatsapp and another app if 'Enable Anonymous Browsing' is enabled based on https://ogp.me/:

Before:

![image](https://github.com/user-attachments/assets/2c6a8459-7123-4ef6-a5e6-19f14e19a9f2)

After:

![image](https://github.com/user-attachments/assets/1f115c39-28f8-4cf8-a759-e887861c45d1)
