### PR TITLE
Adds configurable Kobo sync limit per operation

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -1799,6 +1799,7 @@ def _configuration_update_helper():
         _config_checkbox_int(to_save, "config_register_email")
         reboot_required |= _config_checkbox_int(to_save, "config_kobo_sync")
         _config_int(to_save, "config_external_port")
+        _config_int(to_save, "config_kobo_sync_limit")
         _config_checkbox_int(to_save, "config_kobo_proxy")
 
         if "config_upload_formats" in to_save:

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -75,6 +75,7 @@ class _Settings(_Base):
     config_calibre_split_dir = Column(String)
     config_port = Column(Integer, default=constants.DEFAULT_PORT)
     config_external_port = Column(Integer, default=constants.DEFAULT_PORT)
+    config_kobo_sync_limit = Column(Integer, default=constants.DEFAULT_KOBO_SYNC_LIMIT)
     config_certfile = Column(String)
     config_keyfile = Column(String)
     config_trustedhosts = Column(String, default='')

--- a/cps/constants.py
+++ b/cps/constants.py
@@ -143,6 +143,7 @@ except ValueError:
     print('Environment variable CALIBRE_PORT has invalid value (%s), faling back to default (8083)' % env_CALIBRE_PORT)
 del env_CALIBRE_PORT
 
+DEFAULT_KOBO_SYNC_LIMIT = 100
 
 EXTENSIONS_AUDIO = {'mp3', 'mp4', 'ogg', 'opus', 'wav', 'flac', 'm4a', 'm4b'}
 EXTENSIONS_CONVERT_FROM = ['pdf', 'epub', 'mobi', 'azw3', 'docx', 'rtf', 'fb2', 'lit', 'lrf',

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -57,8 +57,6 @@ KOBO_FORMATS = {"KEPUB": ["KEPUB"], "EPUB": ["EPUB3", "EPUB"]}
 KOBO_STOREAPI_URL = "https://storeapi.kobo.com"
 KOBO_IMAGEHOST_URL = "https://cdn.kobo.com/book-images"
 
-SYNC_ITEM_LIMIT = 100
-
 kobo = Blueprint("kobo", __name__, url_prefix="/kobo/<auth_token>")
 kobo_auth.disable_failed_auth_redirect_for_blueprint(kobo)
 kobo_auth.register_url_value_preprocessor(kobo)
@@ -202,8 +200,10 @@ def HandleSyncRequest():
                            .order_by(db.Books.id))
 
     reading_states_in_new_entitlements = []
-    books = changed_entries.limit(SYNC_ITEM_LIMIT)
-    log.debug("Books to Sync: {}".format(len(books.all())))
+    sync_item_limit = config.config_kobo_sync_limit
+    books = changed_entries.limit(sync_item_limit)
+    log.debug("Total Books to Sync: {}".format(len(changed_entries.all())))
+    log.debug("Max Batch Size to Sync: {}".format(sync_item_limit))
     for book in books:
         formats = [data.format for data in book.Books.data]
         if 'KEPUB' not in formats and config.config_kepubifypath and 'EPUB' in formats:
@@ -279,8 +279,8 @@ def HandleSyncRequest():
         and_(ub.KoboReadingState.user_id == current_user.id,
              ub.KoboReadingState.book_id.notin_(reading_states_in_new_entitlements)))\
         .order_by(ub.KoboReadingState.last_modified)
-    cont_sync |= bool(changed_reading_states.count() > SYNC_ITEM_LIMIT)
-    for kobo_reading_state in changed_reading_states.limit(SYNC_ITEM_LIMIT).all():
+    cont_sync |= bool(changed_reading_states.count() > sync_item_limit)
+    for kobo_reading_state in changed_reading_states.limit(sync_item_limit).all():
         book = calibre_db.session.query(db.Books).filter(db.Books.id == kobo_reading_state.book_id).one_or_none()
         if book:
             sync_results.append({

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -149,6 +149,10 @@
         <label for="config_external_port">{{_('Server External Port (for port forwarded API calls)')}}</label>
         <input type="number" min="1" max="65535" class="form-control" name="config_external_port" id="config_external_port" value="{% if config.config_external_port != None %}{{ config.config_external_port }}{% endif %}" autocomplete="off" required>
       </div>
+      <div class="form-group" style="margin-left:10px;">
+        <label for="config_kobo_sync_limit">{{_('Number of items to sync at once (lower this if experiencing sync issues)')}}</label>
+        <input type="number" min="1" max="65535" class="form-control" name="config_kobo_sync_limit" id="config_kobo_sync_limit" value="{% if config.config_external_port != None %}{{ config.config_kobo_sync_limit }}{% endif %}" autocomplete="off" required>
+      </div>
     </div>
     {% endif %}
     {% if feature_support['goodreads'] %}


### PR DESCRIPTION
Mitigates #1276 by allowing the user to specify how many items will be synced to a Kobo device in one batch.

This is important as Kobo devices have a non-configurable 30s timeout. When running calibre-web on slower servers, the default of 100 items per operation can result in sync errors which prevent any items from being transferred.