### PR TITLE
cps: Make --with-library optionally work with a Content Server

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -1114,8 +1114,8 @@ def _config_checkbox_int(to_save, x):
     return config.set_from_dictionary(to_save, x, lambda y: 1 if (y == "on") else 0, 0)
 
 
-def _config_string(to_save, x):
-    return config.set_from_dictionary(to_save, x, lambda y: strip_whitespaces(y) if y else y)
+def _config_string(to_save, x, strip=True):
+    return config.set_from_dictionary(to_save, x, lambda y: strip_whitespaces(y) if y and strip else y)
 
 
 def _configuration_gdrive_helper(to_save):
@@ -1737,6 +1737,11 @@ def _db_configuration_update_helper():
             return _db_configuration_result(_("Books path not valid"), gdrive_error)
         else:
             _config_string(to_save, "config_calibre_split_dir")
+    _config_checkbox_int(to_save, "config_calibre_db_use_content_server_for_updates")
+    if config.config_calibre_db_use_content_server_for_updates:
+        _config_string(to_save, "config_calibre_db_content_server_url")
+        _config_string(to_save, "config_calibre_db_content_server_username")
+        _config_string(to_save, "config_calibre_db_content_server_password_e", strip=False)
 
     if db_change or not db_valid or not config.db_configured \
       or config.config_calibre_dir != to_save["config_calibre_dir"]:

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -73,6 +73,10 @@ class _Settings(_Base):
     config_calibre_uuid = Column(String)
     config_calibre_split = Column(Boolean, default=False)
     config_calibre_split_dir = Column(String)
+    config_calibre_db_use_content_server_for_updates = Column(Boolean, default=False)
+    config_calibre_db_content_server_url = Column(String)
+    config_calibre_db_content_server_username = Column(String)
+    config_calibre_db_content_server_password_e = Column(String)
     config_port = Column(Integer, default=constants.DEFAULT_PORT)
     config_external_port = Column(Integer, default=constants.DEFAULT_PORT)
     config_certfile = Column(String)
@@ -403,6 +407,19 @@ class ConfigSQL(object):
 
     def get_book_path(self):
         return self.config_calibre_split_dir if self.config_calibre_split_dir else self.config_calibre_dir
+
+    def get_with_library_args(self, write=False):
+        args = ["--with-library"]
+        if write and self.config.config_calibre_db_use_content_server_for_updates:
+            args.append(self.config_calibre_db_content_server_url)
+            if self.config_calibre_db_content_server_username:
+                args.append("--username")
+                args.append(self.config_calibre_db_content_server_username)
+                args.append("--password")
+                args.append(self.config_calibre_db_content_server_password_e)
+        else:
+            args.append(self.get_book_path())
+        return args
 
     def store_calibre_uuid(self, calibre_db, Library_table):
         try:

--- a/cps/embed_helper.py
+++ b/cps/embed_helper.py
@@ -36,7 +36,7 @@ def do_calibre_export(book_id, book_format):
         if config.config_calibre_split:
             my_env['CALIBRE_OVERRIDE_DATABASE_PATH'] = os.path.join(config.config_calibre_dir, "metadata.db")
         library_path = config.get_book_path()
-        opf_command = [calibredb_binarypath, 'export', '--dont-write-opf', '--with-library', library_path,
+        opf_command = [calibredb_binarypath, 'export', '--dont-write-opf', *config.get_with_library_args(write=False),
                        '--to-dir', tmp_dir, '--formats', book_format, "--template", "{}".format(temp_file_name),
                        str(book_id)]
         p = process_open(opf_command, quotes, my_env)

--- a/cps/tasks/convert.py
+++ b/cps/tasks/convert.py
@@ -262,12 +262,9 @@ class TaskConvert(CalibreTask):
                 my_env = os.environ.copy()
                 if config.config_calibre_split:
                     my_env['CALIBRE_OVERRIDE_DATABASE_PATH'] = os.path.join(config.config_calibre_dir, "metadata.db")
-                    library_path = config.config_calibre_split_dir
-                else:
-                    library_path = config.config_calibre_dir
 
                 opf_command = [calibredb_binarypath, 'show_metadata', '--as-opf', str(self.book_id),
-                               '--with-library', library_path]
+                               *config.get_with_library_args(write=True)]
                 p = process_open(opf_command, quotes, my_env, newlines=False)
                 lines = list()
                 while p.poll() is None:

--- a/cps/templates/config_db.html
+++ b/cps/templates/config_db.html
@@ -61,6 +61,20 @@
         {% endif %}
       {% endif %}
     {% endif %}
+      <div class="form-group required">
+        <input type="checkbox" id="config_calibre_db_use_content_server_for_updates" name="config_calibre_db_use_content_server_for_updates" data-control="ccs_settings" data-t ="{{ config.config_calibre_db_content_server_url  }}" {% if config.config_calibre_db_use_content_server_for_updates %}checked{% endif %} >
+        <label for="config_calibre_db_use_content_server_for_updates">{{_('Use Calibre Content Server for DB updates')}}</label>
+      </div>
+      <div data-related="ccs_settings">
+       <div class="form-group required">
+        <label for="config_calibre_db_content_server_url">{{_('Calibre Content Server URL')}}</label>
+        <input type="text" class="form-control" id="config_calibre_db_content_server_url" name="config_calibre_db_content_server_url" value="{% if config.config_calibre_db_content_server_url %}{{ config.config_calibre_db_content_server_url }}{% endif %}" autocomplete="off">
+        <label for="config_calibre_db_content_server_username">{{_('Username')}}</label>
+        <input type="text" class="form-control" id="config_calibre_db_content_server_username" name="config_calibre_db_content_server_username" value="{% if config.config_calibre_db_content_server_username %}{{ config.config_calibre_db_content_server_username }}{% endif %}">
+        <label for="config_calibre_db_content_server_password_e">{{_('Password')}}</label>
+        <input type="password" class="form-control" id="config_calibre_db_content_server_password_e" name="config_calibre_db_content_server_password_e" value="{% if config.config_calibre_db_content_server_password_e %}{{ config.config_calibre_db_content_server_password_e }}{% endif %}">
+      </div>
+      </div>
     <div class="col-sm-12">
       <div id="db_submit" name="submit" class="btn btn-default">{{_('Save')}}</div>
       <a href="{{ url_for('admin.admin') }}" id="config_back" class="btn btn-default">{{_('Cancel')}}</a>


### PR DESCRIPTION
This makes it possible to use the ebook conversion feature when an instance of Calibre is running, by allowing the user to specify the content server URL and credentials to perform updates with. Previously this action would make calibredb error out and fail the conversion job with an unknown error.

Ideally we'd also use this (if configured of course) to implement the book editing/upload/etc stuff, but those aren't broken for me currently :P