### PR TITLE
Correct a typo on config_password_character

### DIFF
--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -411,7 +411,7 @@
               </div>
               <div class="form-group" style="margin-left:10px;">
                 <input type="checkbox" id="config_password_character" name="config_password_character"  {% if config.config_password_character %}checked{% endif %}>
-                <label for="config_password_lower">{{_('Enforce characters (needed For Chinese/Japanese/Korean Characters)')}}</label>
+                <label for="config_password_character">{{_('Enforce characters (needed For Chinese/Japanese/Korean Characters)')}}</label>
               </div>
               <div class="form-group" style="margin-left:10px;">
                 <input type="checkbox" id="config_password_special" name="config_password_special"  {% if config.config_password_special %}checked{% endif %}>


### PR DESCRIPTION
While configuring a Calibre web instance, I realized that in "Basic configuration", clicking on the label of "Enforce characters (needed For Chinese/Japanese/Korean Characters)" toggles "Enforce lowercase characters" instead.

It seems to be due to a wrong target in "<label for ...>".