### PR TITLE
Add a title to OPDS links

### DIFF
--- a/cps/helper.py
+++ b/cps/helper.py
@@ -199,7 +199,7 @@ def check_send_to_ereader(entry):
 # Check if a reader is existing for any of the book formats, if not, return empty list, otherwise return
 # list with supported formats
 def check_read_formats(entry):
-    extensions_reader = {'TXT', 'PDF', 'EPUB', 'CBZ', 'CBT', 'CBR', 'DJVU', 'DJV'}
+    extensions_reader = {'TXT', 'PDF', 'EPUB', 'KEPUB', 'CBZ', 'CBT', 'CBR', 'DJVU', 'DJV'}
     book_formats = list()
     if len(entry.data):
         for ele in iter(entry.data):

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -88,7 +88,7 @@
                                 <ul class="dropdown-menu" aria-labelledby="read-in-browser">
                                     {% for format in entry.reader_list %}
                                         <li><a target="_blank"
-                                               href="{{ url_for('web.read_book', book_id=entry.id, book_format=format) }}">{{ format }}</a>
+                                               href="{{ url_for('web.read_book', book_id=entry.id, book_format=format) }}">{{ format }} ({{ entry.reader_list_sizes[format]|filesizeformat }})</a>
                                         </li>
                                     {% endfor %}
                                 </ul>
@@ -97,7 +97,7 @@
                                    href="{{ url_for('web.read_book', book_id=entry.id, book_format=entry.reader_list[0]) }}"
                                    id="readbtn" class="btn btn-primary" role="button"><span
                                         class="glyphicon glyphicon-book"></span> {{ _('Read in Browser') }}
-                                    - {{ entry.reader_list[0] }}</a>
+                                    - {{ entry.reader_list[0] }} ({{ entry.reader_list_sizes[entry.reader_list[0]]|filesizeformat }})</a>
                             {% endif %}
                         </div>
                     {% endif %}

--- a/cps/templates/feed.xml
+++ b/cps/templates/feed.xml
@@ -70,7 +70,7 @@
     {% endif %}
     {% for format in entry.Books.data %}
     <link rel="http://opds-spec.org/acquisition" href="{{ url_for('opds.opds_download_link', book_id=entry.Books.id, book_format=format.format|lower)}}"
-          length="{{format.uncompressed_size}}" mtime="{{entry.Books.atom_timestamp}}" type="{{format.format|lower|mimetype}}"/>
+          length="{{format.uncompressed_size}}" title="{{format.format}}" mtime="{{entry.Books.atom_timestamp}}" type="{{format.format|lower|mimetype}}"/>
     {% endfor %}
   </entry>
   {% endfor %}

--- a/cps/templates/read.html
+++ b/cps/templates/read.html
@@ -126,8 +126,8 @@
         window.calibre = {
             filePath: "{{ url_for('static', filename='js/libs/') }}",
             cssPath: "{{ url_for('static', filename='css/') }}",
-            bookmarkUrl: "{{ url_for('web.set_bookmark', book_id=bookid, book_format='EPUB') }}",
-            bookUrl: "{{ url_for('web.serve_book', book_id=bookid, book_format='epub', anyname='file.epub') }}",
+            bookmarkUrl: "{{ url_for('web.set_bookmark', book_id=bookid, book_format=book_format or 'EPUB') }}",
+            bookUrl: "{{ url_for('web.serve_book', book_id=bookid, book_format=book_format, anyname='file.epub') }}",
             bookmark: "{{ bookmark.bookmark_key if bookmark != None }}",
             useBookmarks: "{{ current_user.is_authenticated | tojson }}"
         };

--- a/cps/web.py
+++ b/cps/web.py
@@ -1581,9 +1581,10 @@ def read_book(book_id, book_format):
         bookmark = ub.session.query(ub.Bookmark).filter(and_(ub.Bookmark.user_id == int(current_user.id),
                                                              ub.Bookmark.book_id == book_id,
                                                              ub.Bookmark.format == book_format.upper())).first()
-    if book_format.lower() == "epub":
-        log.debug("Start epub reader for %d", book_id)
-        return render_title_template('read.html', bookid=book_id, title=book.title, bookmark=bookmark)
+    if book_format.lower() == "epub" or book_format.lower() == "kepub":
+        log.debug("Start [k]epub reader for %d", book_id)
+        return render_title_template('read.html', bookid=book_id, title=book.title, bookmark=bookmark,
+                                     book_format=book_format)
     elif book_format.lower() == "pdf":
         log.debug("Start pdf reader for %d", book_id)
         return render_title_template('readpdf.html', pdffile=book_id, title=book.title)
@@ -1643,6 +1644,11 @@ def show_book(book_id):
 
         entry.email_share_list = check_send_to_ereader(entry)
         entry.reader_list = check_read_formats(entry)
+
+        entry.reader_list_sizes = dict()
+        for data in entry.data:
+            if data.format.lower() in entry.reader_list:
+                entry.reader_list_sizes[data.format.lower()] = data.uncompressed_size
 
         entry.audio_entries = []
         for media_format in entry.data:


### PR DESCRIPTION
This allows the OPDS consumers to distinguish `epub` and `kepub` files as they have the same MIME-type.