### PR TITLE
Rework metadata scraping flow

### DIFF
--- a/cps/static/css/style.css
+++ b/cps/static/css/style.css
@@ -382,12 +382,101 @@ input.pill:not(:checked) + label .glyphicon { display: none; }
   overflow-y: scroll;
 }
 
-.media-list { padding-right: 15px; }
+#meta-info #book-list {
+  list-style-type: none;
+  padding: 0px 15px 0px 0px;
+}
 
-#meta-info img {
-  max-height: 150px;
-  max-width: 100px;
+#meta-info #book-list .media {
+  display: flex;
+  background-color: #f9f9f9;
+  margin-bottom: 20px;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+#meta-info #book-list .media .media-image {
+  width: 200px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+}
+
+#meta-info #book-list .media .media-image-wrapper {
+  position: relative;
+  width: 100%;
+}
+
+#meta-info #book-list .media .media-image img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 4px;
+  display: block;
+}
+#meta-info #book-list .media .media-image .image-dimensions {
+  position: absolute;
+  bottom: 5px;
+  right: 5px;
+  background-color: rgba(0, 0, 0, 0.7);
+  color: white;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+}
+#meta-info #book-list .media .media-image .image-dimensions.larger {
+  background-color: rgba(0, 160, 0, 0.7);
+}
+#meta-info #book-list .media .media-image .image-dimensions.smaller {
+  background-color: rgba(160, 0, 0, 0.7);
+}
+#meta-info #book-list .media .media-image input {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  width: 20px;
+  height: 20px;
+}
+
+#meta-info #book-list .media .media-image button {
+  margin-top: 10px;
+  /* padding: 8px 16px; */
   cursor: pointer;
+}
+
+#meta-info #book-list .media .media-image div {
+  margin-top: 10px;
+  font-size: 0.9em;
+  color: #666;
+  text-align: center;
+}
+
+#meta-info #book-list .media .media-body {
+  flex: 1;
+  padding: 20px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 10px;
+  align-content: start;
+}
+
+#meta-info #book-list .media .media-body dt {
+  font-weight: bold;
+  color: #333;
+  display: flex;
+  align-items: center;
+}
+
+#meta-info #book-list .media .media-body dt input {
+  margin-right: 5px;
+  margin-top: 0px;
+}
+
+#meta-info #book-list .media .media-body dd {
+  margin: 0;
+  color: #666;
 }
 
 .padded-bottom { margin-bottom: 15px; }

--- a/cps/static/js/get_meta.js
+++ b/cps/static/js/get_meta.js
@@ -37,27 +37,43 @@ $(function () {
         return presentArray
     }
 
-    function populateForm (book) {
-        tinymce.get("comments").setContent(book.description);
-        var uniqueTags = getUniqueValues('tags', book)
+    function populateForm (book, idx) {
+        var updateItems = Object.fromEntries(Array.from(document.querySelectorAll(`[data-meta-index="${idx}"]`)).map((value)=>[value.dataset.metaValue, value.checked]))
+        if (updateItems.description){
+            tinymce.get("comments").setContent(book.description);
+        }
+        if (updateItems.tags){
+            var uniqueTags = getUniqueValues('tags', book)
+            $("#tags").val(uniqueTags.join(", "));
+        }
         var uniqueLanguages = getUniqueValues('languages', book)
-        var ampSeparatedAuthors = (book.authors || []).join(" & ");
-        $("#authors").val(ampSeparatedAuthors);
-        $("#title").val(book.title);
-        $("#tags").val(uniqueTags.join(", "));
+        if (updateItems.authors){
+            var ampSeparatedAuthors = (book.authors || []).join(" & ");
+            $("#authors").val(ampSeparatedAuthors);
+        }
+        if (updateItems.titles){
+            $("#title").val(book.title);
+        }
         $("#languages").val(uniqueLanguages.join(", "));
         $("#rating").data("rating").setValue(Math.round(book.rating));
-        if(book.cover && $("#cover_url").length){
+    
+        if(updateItems.cover && book.cover && $("#cover_url").length){
             $(".cover img").attr("src", book.cover);
             $("#cover_url").val(book.cover);
         }
-        $("#pubdate").val(book.publishedDate);
-        $("#publisher").val(book.publisher);
-        if (typeof book.series !== "undefined") {
+        if (updateItems.pubDate){
+            $("#pubdate").val(book.publishedDate);
+        }
+        if (updateItems.publisher){
+            $("#publisher").val(book.publisher);
+        }
+        if (updateItems.series && typeof book.series !== "undefined") {
             $("#series").val(book.series);
+        }
+        if (updateItems.series_index && typeof book.series_index !== "undefined"){
             $("#series_index").val(book.series_index);
         }
-        if (typeof book.identifiers !== "undefined") {
+        if (updateItems.identifiers && typeof book.identifiers !== "undefined") {
             populateIdentifiers(book.identifiers)
         }
     }
@@ -94,10 +110,10 @@ $(function () {
                 success: function success(data) {
                     if (data.length) {
                         $("#meta-info").html("<ul id=\"book-list\" class=\"media-list\"></ul>");
-                        data.forEach(function(book) {
-                            var $book = $(templates.bookResult(book));
-                            $book.find("img").on("click", function () {
-                                populateForm(book);
+                        data.forEach(function(book,idx) {
+                            var $book = $(templates.bookResult({"book":book,"index":idx}));
+                            $book.find("button").on("click", function () {
+                                populateForm(book,idx);
                             });
                             $("#book-list").append($book);
                         });
@@ -150,10 +166,10 @@ $(function () {
             data: JSON.stringify(params),
             success: function success(data) {
                 element.data("initial", "true");
-                data.forEach(function(book) {
-                    var $book = $(templates.bookResult(book));
-                    $book.find("img").on("click", function () {
-                        populateForm(book);
+                data.forEach(function(book,idx) {
+                    var $book = $(templates.bookResult({"book":book,"index":idx}));
+                    $book.find("button").on("click", function () {
+                        populateForm(book,idx);
                     });
                     $("#book-list").append($book);
                 });

--- a/cps/templates/book_edit.html
+++ b/cps/templates/book_edit.html
@@ -263,28 +263,56 @@
 
 {% block js %}
 <script type="text/template" id="template-book-result">
-  <li class="media" data-related="<%= source.id %>">
-    <img class="pull-left img-responsive"
-         data-toggle="modal"
-         data-target="#metaModal"
-         src="<%= cover || "{{ url_for('static', filename='img/academicpaper.svg') }}" %>"
-         alt="Cover"
-    >
-    <div class="media-body">
-      <h4 class="media-heading">
-        <a class="meta_title" href="<%= url %>" target="_blank" rel="noopener"><%= title %></a>
-      </h4>
-      <p class="meta_author">{{_('Author')}}：<%= authors.join(" & ") %></p>
-      <% if (publisher) { %>
-        <p class="meta_publisher">{{_('Publisher')}}：<%= publisher %></p>
-      <% } %>
-      <% if (description) { %>
-        <p class="meta_description">{{_('Description')}}: <%= description %></p>
-      <% } %>
-      <p>{{_('Source')}}:
-        <a class="meta_source" href="<%= source.link %>" target="_blank" rel="noopener"><%= source.description %></a>
-      </p>
+  <li class="media" data-related="<%= book.source.id %>">
+    <div class="media-image">
+      <div class="media-image-wrapper">
+        <img
+          onload="coverDimensions(this)"
+          src="<%= book.cover || "{{ url_for('static', filename='img/academicpaper.svg') }}" %>"
+          alt="Cover"
+        >
+        <div class="image-dimensions"></div>
+        <input type="checkbox" data-meta-index="<%= index %>" data-meta-value="cover">
+      </div>
+      <button class="btn btn-default">Save</button>
+      <div><a class="meta_source" href="<%= book.source.link %>" target="_blank" rel="noopener"><%= book.source.description %></a></div>
     </div>
+    <dl class="media-body">
+      <dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="title">Title:</dt>
+      <dd><a class="meta_title" href="<%= book.url %>" target="_blank" rel="noopener"><%= book.title %></a></dd>
+      <dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="authors">Author:</dt>
+      <dd class="meta_author"><%= book.authors.join(" & ") %></dd>
+      <% if (book.publisher) { %>
+        <dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="publisher">Publisher:</dt>
+        <dd class="meta_publisher"><%= book.publisher %></dd>
+      <% } %>
+      <% if (book.publishedDate) { %>
+        <dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="pubDate">Published Date:</dt>
+        <dd class="meta_publishedDate"><%= book.publishedDate %></dd>
+      <% } %>
+      <% if (book.series) { %>
+        <dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="series">Series:</dt>
+        <dd class="meta_publishedDate"><%= book.series %></dd>
+      <% } %>
+      <% if (book.series_index) { %>
+        <dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="seriesIndex">Series Index:</dt>
+        <dd class="meta_publishedDate"><%= book.series_index %></dd>
+      <% } %>
+      <% if (book.description) { %>
+        <dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="description">Description:</dt>
+        <dd class="meta_description"><%= book.description %></dd>
+      <% } %>
+      <% if (book.tags.length !== 0) { %>
+        <dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="tags">Tags:</dt>
+        <dd class="meta_author"><%= book.tags.join(", ") %></dd>
+      <% } %>
+      <% if (Object.keys(book.identifiers).length !== 0 ) { %>
+        <% for (const key in book.identifiers) { %>
+          <dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="identifiers">Identifier</dt>
+          <dd class="meta_description"><%= key %>:<%= book.identifiers[key] %></dd>
+        <% } %>
+      <% } %>
+    </dl>
   </li>
 </script>
 <script>
@@ -312,7 +340,15 @@
   function removeIdentifierLine(el) {
     $(el).parent().parent().remove();
   }
-
+  function coverDimensions(el) {
+    var existing_cover = document.querySelector("#detailcover")
+    el.nextElementSibling.innerText = el.naturalWidth + 'x' + el.naturalHeight
+    if (existing_cover.naturalHeight*existing_cover.naturalWidth >  el.naturalWidth * el.naturalHeight){
+      el.nextElementSibling.classList.add("smaller")
+    } else if (existing_cover.naturalHeight*existing_cover.naturalWidth < el.naturalWidth * el.naturalHeight){
+      el.nextElementSibling.classList.add("larger")
+    }
+  }
 </script>
 <script src="{{ url_for('static', filename='js/libs/typeahead.bundle.js') }}"></script>
 <script src="{{ url_for('static', filename='js/libs/bootstrap-rating-input.min.js') }}"></script>


### PR DESCRIPTION
Recreate PR due to repo mishap to rework metadata scraping.
UI rework allows metadata fields to be selected for update, so users can choose which data to import.
Also adds a size comparison of current cover vs incoming cover and displays the incoming resolution with a green background for larger covers, red for smaller.
Modal doesn't close when saving so metadata can be imported from multiple sources without hitting APIs twice.
This is loosely tied to issue #2165
![image](https://github.com/user-attachments/assets/1fe981c1-d4e7-46ac-99e0-f892be1d30dc)