### PR TITLE
Fix UI bug when book conversion enabled on mobile

### DIFF
--- a/cps/static/css/caliBlur.css
+++ b/cps/static/css/caliBlur.css
@@ -7153,22 +7153,17 @@ body.edituser.admin > div.container-fluid > div.row-fluid > div.col-sm-10 > div.
     }
 
     body.editbook > div.container-fluid > div.row-fluid > div.col-sm-10 > div.col-sm-3, body.upload > div.container-fluid > div.row-fluid > div.col-sm-10 > div.col-sm-3 {
-        max-width: 130px;
-        width: 130px;
-        height: 180px;
-        margin: 0;
+        position: relative;
+        max-width: unset;
+        width: 100%;
+        height: unset;
         padding: 15px;
-        position: absolute
     }
 
     body.editbook > div.container-fluid > div.row-fluid > div.col-sm-10 > form > div.col-sm-9, body.upload > div.container-fluid > div.row-fluid > div.col-sm-10 > form > div.col-sm-9 {
         padding: 15px;
         margin: 0 !important;
         width: 100%
-    }
-
-    body.editbook > div.container-fluid > div.row-fluid > div.col-sm-10 > form > div.col-sm-9 > .form-group:nth-child(1), body.editbook > div.container-fluid > div.row-fluid > div.col-sm-10 > form > div.col-sm-9 > .form-group:nth-child(2), body.upload > div.container-fluid > div.row-fluid > div.col-sm-10 > form > div.col-sm-9 > .form-group:nth-child(1), body.upload > div.container-fluid > div.row-fluid > div.col-sm-10 > form > div.col-sm-9 > .form-group:nth-child(2) {
-        padding-left: 120px
     }
 
     #deleteButton, body.editbook > div.container-fluid > div.row-fluid > div.col-sm-10 > div.col-sm-3 > div.text-center > #delete, body.upload > div.container-fluid > div.row-fluid > div.col-sm-10 > div.col-sm-3 > div.text-center > #delete {


### PR DESCRIPTION
On mobile, when book conversion is enabled and using the cabliBlur theme, the upload menu appears behind the description text area making it difficult (though not impossible with some careful guesswork around where the buttons should be).

This commit fixes the styling of this section so that it no longer appears behind the description text area.

![CleanShot 2025-01-04 at 11 43 36@2x](https://github.com/user-attachments/assets/b99b77cb-5c37-4115-8dfd-c00b2060f8ed)
![CleanShot 2025-01-04 at 11 44 05@2x](https://github.com/user-attachments/assets/b41bec0b-a8f8-4187-b883-8f802866b498)
