### PR TITLE
Hardcover.app intergration

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -63,6 +63,7 @@ feature_support = {
     'ldap': bool(services.ldap),
     'goodreads': bool(services.goodreads_support),
     'kobo': bool(services.kobo),
+    'hardcover' : bool(services.hardcover),
     'updater': constants.UPDATER_AVAILABLE,
     'gmail': bool(services.gmail),
     'scheduler': schedule.use_APScheduler,
@@ -1801,6 +1802,7 @@ def _configuration_update_helper():
         reboot_required |= _config_checkbox_int(to_save, "config_kobo_sync")
         _config_int(to_save, "config_external_port")
         _config_checkbox_int(to_save, "config_kobo_proxy")
+        _config_checkbox_int(to_save, "config_hardcover_sync")
 
         if "config_upload_formats" in to_save:
             to_save["config_upload_formats"] = ','.join(

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -98,6 +98,7 @@ class _Settings(_Base):
     config_public_reg = Column(SmallInteger, default=0)
     config_remote_login = Column(Boolean, default=False)
     config_kobo_sync = Column(Boolean, default=False)
+    config_hardcover_sync = Column(Boolean, default=False)
 
     config_default_role = Column(SmallInteger, default=0)
     config_default_show = Column(SmallInteger, default=constants.ADMIN_USER_SIDEBAR)

--- a/cps/db.py
+++ b/cps/db.py
@@ -155,6 +155,8 @@ class Identifiers(Base):
             return "Lubimyczytac"
         if format_type == "databazeknih":
             return "Databáze knih"
+        if format_type == "hardcover-slug":
+            return "Hardcover"
         else:
             return self.type
 
@@ -194,6 +196,8 @@ class Identifiers(Base):
             return "http://www.isfdb.org/cgi-bin/pl.cgi?{0}".format(self.val)
         elif format_type == "databazeknih":
             return "https://www.databazeknih.cz/knihy/{0}".format(self.val)
+        elif format_type == "hardcover-slug":
+            return "https://hardcover.app/books/{0}".format(self.val)
         elif self.val.lower().startswith("javascript:"):
             return quote(self.val)
         elif self.val.lower().startswith("data:"):

--- a/cps/metadata_provider/amazon.py
+++ b/cps/metadata_provider/amazon.py
@@ -53,7 +53,7 @@ class Amazon(Metadata):
     session.headers=headers
 
     def search(
-        self, query: str, generic_cover: str = "", locale: str = "en"
+        self, query: str, generic_cover: str = "", locale: str = "en",**kwargs
     ) -> Optional[List[MetaRecord]]:
         def inner(link, index) -> [dict, int]:
             with self.session as session:

--- a/cps/metadata_provider/comicvine.py
+++ b/cps/metadata_provider/comicvine.py
@@ -41,7 +41,7 @@ class ComicVine(Metadata):
     HEADERS = {"User-Agent": "Not Evil Browser"}
 
     def search(
-        self, query: str, generic_cover: str = "", locale: str = "en"
+        self, query: str, generic_cover: str = "", locale: str = "en",**kwargs
     ) -> Optional[List[MetaRecord]]:
         val = list()
         if self.active:

--- a/cps/metadata_provider/douban.py
+++ b/cps/metadata_provider/douban.py
@@ -71,7 +71,7 @@ class Douban(Metadata):
     def search(self,
                query: str,
                generic_cover: str = "",
-               locale: str = "en") -> List[MetaRecord]:
+               locale: str = "en",**kwargs) -> List[MetaRecord]:
         val = []
         if self.active:
             log.debug(f"start searching {query} on douban")

--- a/cps/metadata_provider/google.py
+++ b/cps/metadata_provider/google.py
@@ -40,7 +40,7 @@ class Google(Metadata):
     ISBN_TYPE = "ISBN_13"
 
     def search(
-        self, query: str, generic_cover: str = "", locale: str = "en"
+        self, query: str, generic_cover: str = "", locale: str = "en",**kwargs
     ) -> Optional[List[MetaRecord]]:
         val = list()    
         if self.active:

--- a/cps/metadata_provider/hardcover.py
+++ b/cps/metadata_provider/hardcover.py
@@ -1,0 +1,255 @@
+# -*- coding: utf-8 -*-
+
+#  This file is part of the Calibre-Web (https://github.com/janeczku/calibre-web)
+#    Copyright (C) 2021 OzzieIsaacs
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+# Hardcover api document: https://Hardcover.gamespot.com/api/documentation
+from typing import Dict, List, Optional
+from urllib.parse import quote
+
+import requests
+from cps import logger
+from cps.services.Metadata import MetaRecord, MetaSourceInfo, Metadata
+from importlib import reload
+
+from flask import g
+
+log = logger.create()
+
+
+class Hardcover(Metadata):
+    __name__ = "Hardcover"
+    __id__ = "hardcover"
+    DESCRIPTION = "Hardcover Books"
+    META_URL = "https://hardcover.app"
+    BASE_URL = "https://api.hardcover.app/v1/graphql"
+    # SEARCH_QUERY = """{
+    #     books(
+    #       where: {title: {_eq: "%s"}}
+    #       limit: 10
+    #       order_by: {users_read_count: desc}
+    #     ) {
+    #       title
+    #       book_series {
+    #         series {
+    #           name
+    #         }
+    #         position
+    #       }
+    #       cached_contributors
+    #       id
+    #       cached_image
+    #       slug
+    #       description
+    #       release_date
+    #       cached_tags
+    #     }
+    # }"""
+    SEARCH_QUERY = """query Search($query: String!) {
+        search(query: $query, query_type: "Book", per_page: 50) {
+            results
+        }
+    }
+    """
+    EDITION_QUERY = """query getEditions($query: Int!) {
+        books(
+            where: { id: { _eq: $query } }
+            order_by: { users_read_count: desc_nulls_last }
+        ) {
+            title
+            slug
+            id
+            
+            book_series {
+                series {
+                    name
+                }
+                position
+            }
+            rating
+            editions(
+                where: {
+                    _or: [{ reading_format_id: { _neq: 2 } }, { edition_format: { _is_null: true } }]
+                }
+                order_by: [{ reading_format_id: desc_nulls_last },{users_count: desc_nulls_last }]
+            ) {
+                id
+                isbn_13
+                isbn_10
+                title
+                reading_format_id
+                contributions {
+                    author {
+                        name
+                    }
+                }
+                image {
+                    url
+                }
+                language {
+                    code3
+                }
+                publisher {
+                    name
+                }
+                release_date
+                
+            }
+            description
+            cached_tags(path: "Genre")
+        }
+    }
+    """
+    HEADERS = {
+        "Content-Type": "application/json",
+    }
+    FORMATS = ["","Physical Book","","","E-Book"] # Map reading_format_id to text equivelant.
+
+    def search(
+        self, query: str, generic_cover: str = "", locale: str = "en", **kwargs
+    ) -> Optional[List[MetaRecord]]:
+        token = kwargs.get("token")
+        if not token:
+            log.warning("Hardcover token not set for user")
+            return None
+        val = list()
+        if self.active:
+            try:
+                if (token == ""):
+                    raise Exception("Current user does not have Hardcover API token")
+                else:
+                    edition_seach = query.split(":")[0] == "hardcover-id"
+                    Hardcover.HEADERS["Authorization"] = "Bearer %s" % token
+                    result = requests.post(
+                        Hardcover.BASE_URL,
+                        json={
+                            "query":Hardcover.SEARCH_QUERY if not edition_seach else Hardcover.EDITION_QUERY,
+                            "variables":{"query":query if not edition_seach else query.split(":")[1]}
+                        },
+                        headers=Hardcover.HEADERS,
+                    )
+                    result.raise_for_status()
+            except Exception as e:
+                log.warning(e)
+                return None
+            if edition_seach:
+                result = result.json()["data"]["books"][0]
+                log.debug(result)
+                val = self._parse_edition_results(result=result, generic_cover=generic_cover, locale=locale)
+            else:
+                for result in result.json()["data"]["search"]["results"]["hits"]:
+                    match = self._parse_title_result(
+                        result=result, generic_cover=generic_cover, locale=locale
+                    )
+                    val.append(match)
+        return val
+    
+    def _parse_title_result(
+        self, result: Dict, generic_cover: str, locale: str
+    ) -> MetaRecord:
+        series = result["document"].get("featured_series",{}).get("series_name", "")
+        series_index = result["document"].get("featured_series",{}).get("position", "")
+        match = MetaRecord(
+            id=result["document"].get("id",""),
+            title=result["document"].get("title",""),
+            authors=result["document"].get("author_names", []),
+            url=self._parse_title_url(result, ""),
+            source=MetaSourceInfo(
+                id=self.__id__,
+                description=Hardcover.DESCRIPTION,
+                link=Hardcover.META_URL,
+            ),
+            series=series,
+        )
+        # TODO Add parse cover function to get better size
+        match.cover = result["document"]["image"].get("url", generic_cover)
+        
+        match.description = result["document"].get("description","")
+        match.publishedDate = result["document"].get(
+            "release_date", "")
+        match.series_index = series_index
+        match.tags = result["document"].get("genres",[])
+        match.identifiers = {
+            "hardcover-id": match.id,
+            "hardcover-slug": result["document"].get("slug", "")
+        }
+        return match
+
+    def _parse_edition_results(
+        self, result: Dict, generic_cover: str, locale: str
+    ) -> MetaRecord:
+        editions = list()
+        id = result.get("id","")
+        for edition in result["editions"]:
+            match = MetaRecord(    
+                id=id,
+                title=edition.get("title",""),       
+                authors=self._parse_edition_authors(edition,[]),
+                url=self._parse_edition_url(edition, ""),
+                source=MetaSourceInfo(
+                    id=self.__id__,
+                    description=Hardcover.DESCRIPTION,
+                    link=Hardcover.META_URL,
+                ),
+                series=result.get("book_series",[{}])[0].get("series",{}).get("name", ""),
+            )
+            # TODO Add parse cover function to get better size
+            match.cover = (edition.get("image") or {}).get("url", generic_cover)
+            match.description = result.get("description","")
+            match.publisher = (edition.get("publisher") or {}).get("name","")
+            match.publishedDate = edition.get("release_date", "")
+            match.series_index = result.get("book_series",[{}])[0].get("position", "")
+            match.tags = self._parse_tags(result,[])
+            match.languages = (edition.get("language") or {}).get("code3","")
+            match.identifiers = {
+                "hardcover-id": id,
+                "hardcover-slug": result.get("slug", ""),
+                "hardcover-edition": edition.get("id",""),
+                "isbn": (edition.get("isbn_13",edition.get("isbn_10")) or "")
+            }
+            match.format = Hardcover.FORMATS[edition.get("reading_format_id",0)]
+            editions.append(match)
+        return editions
+    
+    @staticmethod
+    def _parse_title_url(result: Dict, url: str) -> str:
+        hardcover_slug = result["document"].get("slug", "")
+        if hardcover_slug:
+            return f"https://hardcover.app/books/{hardcover_slug}"
+        return url
+
+    @staticmethod
+    def _parse_edition_url(edition: Dict, url: str) -> str:
+        hardcover_edition = edition.get("id", "")
+        if hardcover_edition:
+            return f"https://hardcover.app/books/jurassic-park/editions/{hardcover_edition}"
+        return url
+    
+    @staticmethod
+    def _parse_edition_authors(edition: Dict, authors: List[str]) -> List[str]:
+        try:
+            return [author["author"]["name"] for author in edition.get("contributions",[]) if "author" in author and "name" in author["author"]]
+        except Exception as e:
+            log.warning(e)
+            return authors
+
+    @staticmethod
+    def _parse_tags(result: Dict, tags: List[str]) -> List[str]:
+        try:
+            return [item["tag"] for item in result["cached_tags"] if "tag" in item]
+        except Exception as e:
+            log.warning(e)
+            return tags

--- a/cps/metadata_provider/lubimyczytac.py
+++ b/cps/metadata_provider/lubimyczytac.py
@@ -114,7 +114,7 @@ class LubimyCzytac(Metadata):
     SUMMARY = "//script[@type='application/ld+json']//text()"
 
     def search(
-        self, query: str, generic_cover: str = "", locale: str = "en"
+        self, query: str, generic_cover: str = "", locale: str = "en",**kwargs
     ) -> Optional[List[MetaRecord]]:
         if self.active:
             try:

--- a/cps/metadata_provider/scholar.py
+++ b/cps/metadata_provider/scholar.py
@@ -40,7 +40,7 @@ class scholar(Metadata):
     META_URL = "https://scholar.google.com/"
 
     def search(
-        self, query: str, generic_cover: str = "", locale: str = "en"
+        self, query: str, generic_cover: str = "", locale: str = "en",**kwargs
     ) -> Optional[List[MetaRecord]]:
         val = list()
         if self.active:

--- a/cps/search_metadata.py
+++ b/cps/search_metadata.py
@@ -130,7 +130,7 @@ def metadata_search():
         # ret = cl[0].search(query, static_cover, locale)
         with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
             meta = {
-                executor.submit(c.search, query, static_cover, locale): c
+                executor.submit(c.search, query, static_cover, locale, token=getattr(current_user,f'{c.__id__}_token',None)): c
                 for c in cl
                 if active.get(c.__id__, True)
             }

--- a/cps/services/Metadata.py
+++ b/cps/services/Metadata.py
@@ -48,6 +48,7 @@ class MetaRecord:
     rating: Optional[int] = 0
     languages: Optional[List[str]] = dataclasses.field(default_factory=list)
     tags: Optional[List[str]] = dataclasses.field(default_factory=list)
+    format: Optional[str] = None
 
 
 class Metadata:

--- a/cps/services/__init__.py
+++ b/cps/services/__init__.py
@@ -48,3 +48,9 @@ try:
 except ImportError as err:
     log.debug("Cannot import gmail, sending books via Gmail Oauth2 Verification will not work: %s", err)
     gmail = None
+
+try:
+    from . import hardcover
+except ImportError as err:
+    log.debug("Cannot import hardcover, syncing Kobo read progress to Hardcover will not work: %s", err)
+    hardcover = None

--- a/cps/services/hardcover.py
+++ b/cps/services/hardcover.py
@@ -1,0 +1,232 @@
+# -*- coding: utf-8 -*-
+
+#  This file is part of the Calibre-Web (https://github.com/janeczku/calibre-web)
+#    Copyright (C) 2018-2019 OzzieIsaacs, pwr
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+from datetime import datetime
+import requests
+
+from .. import logger
+
+log = logger.create()
+
+GRAPHQL_ENDPOINT = "https://api.hardcover.app/v1/graphql"
+
+USER_BOOK_FRAGMENT = """
+    fragment userBookFragment on user_books {
+        id
+        status_id
+        book_id
+        book {
+            slug
+            title
+        }
+        edition  {
+            id
+            pages
+        }
+        user_book_reads(order_by: {started_at: desc}, limit: 1) {
+            id
+            started_at
+            finished_at
+            edition_id
+            progress_pages
+        }
+    }"""
+
+class HardcoverClient:
+    def __init__(self, token):
+        self.endpoint = GRAPHQL_ENDPOINT
+        self.headers = {
+            "Content-Type": "application/json",
+            "Authorization" : f"Bearer {token}"
+        }
+        self.privacy = self.get_privacy()
+        
+    def get_privacy(self):
+        query = """
+            {
+                me {
+                    account_privacy_setting_id
+                }
+            }"""
+        response = self.execute(query)
+        return (response.get("me")[0] or [{}]).get("account_privacy_setting_id",1)
+
+    def get_user_book(self, ids):
+        query = ""
+        variables={}
+        if "hardcover-edition" in ids: 
+            query = """
+                query ($query: Int) {
+                    me {
+                        user_books(where:  {edition_id: {_eq: $query}}) {
+                            ...userBookFragment
+                        }
+                    }
+                }"""
+            variables["query"] = ids["hardcover-edition"]
+        elif "hardcover-id" in ids:
+            query = """
+                query ($query: Int) {
+                    me {
+                        user_books(where: {book: {id: {_eq: $query}}}) {
+                            ...userBookFragment
+                        }
+                    }
+                }"""
+            variables["query"] = ids["hardcover-id"]
+        elif "hardcover-slug" in ids:
+            query = """
+                query ($slug: String!) {
+                    me {
+                        user_books(where: {book: {slug: {_eq: $query}}}) {
+                            ...userBookFragment
+                        }
+                    }
+                }"""
+            variables["query"] = ids["hardcover-slug"]
+        query += USER_BOOK_FRAGMENT
+        response = self.execute(query,variables)
+        return next(iter(response.get("me")[0].get("user_books")),None)
+        
+
+    # TODO Add option for autocreate of missing books instead of forcing it.
+    def update_reading_progress(self, identifiers, progress_percent):
+        ids = self.parse_identifiers(identifiers)
+        book = self.get_user_book(ids)
+        if not book:
+            book = self.add_book(ids, status=2)
+        if book.get("status_id") is not 2:
+            book = self.change_book_status(book, 2)
+        pages = round(book.get("edition",{}).get("pages",0) * (progress_percent / 100))
+        log.debug(pages)
+        read = next(iter(book.get("user_book_reads")),None)
+        if not read:
+            read = self.add_read(book, pages) 
+        log.debug(read)
+        mutation = """
+        mutation ($readId: Int!, $pages: Int, $editionId: Int, $startedAt: date, $finishedAt: date) {
+            update_user_book_read(id: $readId, object: {
+                progress_pages: $pages,
+                edition_id: $editionId,
+                started_at: $startedAt,
+                finished_at: $finishedAt
+            }) {
+                id
+            }
+        }""" 
+        variables = {
+            "readId": int(read.get("id")),
+            "pages": pages,
+            "editionId": int(book.get("edition").get("id")),
+            "startedAt":read.get("started_at",datetime.now().strftime("%Y-%m-%d")),
+            "finishedAt": datetime.now().strftime("%Y-%m-%d") if progress_percent is 100 else None
+        }
+        if progress_percent is 100:
+            self.change_book_status(book, 3)
+        return self.execute(query=mutation, variables=variables)
+    
+    def change_book_status(self, book, status):
+        mutation = """
+            mutation ($id:Int!, $status_id: Int!) {
+                update_user_book(id: $id, object: {status_id: $status_id}) {
+                    error
+                    user_book {
+                        ...userBookFragment
+                    }
+                }
+            }""" + USER_BOOK_FRAGMENT
+        variables = {
+            "id":book.get("id"),
+            "status_id":status
+        }
+        response = self.execute(query=mutation, variables=variables)
+        return response.get("update_user_book",{}).get("user_book",{})
+    
+    def add_book(self, identifiers, status=1):
+        ids = self.parse_identifiers(identifiers)
+        mutation = """     
+            mutation ($object: UserBookCreateInput!) {
+                insert_user_book(object: $object) {
+                    error
+                    user_book {
+                        ...userBookFragment
+                    }
+                }
+            }""" + USER_BOOK_FRAGMENT
+        variables = {
+            "object": {
+                "book_id":int(ids.get("hardcover-id")),
+                "edition_id":int(ids.get("hardcover-edition")) if ids.get("hardcover-edition") else None,
+                "status_id": status,
+                "privacy_setting_id": self.privacy
+            }
+        }
+        response = self.execute(query=mutation, variables=variables)
+        return response.get("insert_user_book",{}).get("user_book",{})
+
+    def add_read(self, book, pages=0):
+        mutation = """     
+            mutation ($id: Int!, $pages: Int, $editionId: Int, $startedAt: date) {
+                insert_user_book_read(user_book_id: $id, user_book_read: {
+                    progress_pages: $pages,
+                    edition_id: $editionId,
+                    started_at: $startedAt,
+                }) {
+                    error
+                    user_book_read {
+                        id
+                        started_at
+                        finished_at
+                        edition_id
+                        progress_pages
+                    }
+                }
+            }""" 
+        variables = {
+            "id":int(book.get("id")),
+            "editionId":int(book.get("edition").get("id")) if book.get("edition").get("id") else None,
+            "pages": pages,
+            "startedAt": datetime.now().strftime("%Y-%m-%d")
+        }
+        response = self.execute(query=mutation, variables=variables)
+        return response.get("insert_user_book_read").get("user_book_read")
+        
+    def parse_identifiers(self, identifiers):
+        if type(identifiers) != dict:
+            return {id.type:id.val for id in identifiers if "hardcover" in id.type}
+        return identifiers
+    
+    def execute(self, query, variables=None):
+        payload = {
+            "query": query,
+            "variables": variables or {}
+        }
+
+
+        response = requests.post(self.endpoint, json=payload, headers=self.headers)
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            raise Exception(f"HTTP error occurred: {e}")
+
+        result = response.json()
+        log.debug(result)
+        if "errors" in result:
+            raise Exception(f"GraphQL error: {result['errors']}")
+
+        return result.get("data", {})

--- a/cps/shelf.py
+++ b/cps/shelf.py
@@ -32,7 +32,7 @@ from sqlalchemy.sql.expression import func, true
 from . import calibre_db, config, db, logger, ub
 from .render_template import render_title_template
 from .usermanagement import login_required_if_no_ano, user_login_required
-
+from .services import hardcover
 log = logger.create()
 
 shelf = Blueprint('shelf', __name__)
@@ -71,7 +71,8 @@ def add_to_shelf(shelf_id, book_id):
     else:
         maxOrder = maxOrder[0]
 
-    if not calibre_db.session.query(db.Books).filter(db.Books.id == book_id).one_or_none():
+    book = calibre_db.session.query(db.Books).filter(db.Books.id == book_id).one_or_none()
+    if not book:
         log.error("Invalid Book Id: %s. Could not be added to shelf %s", book_id, shelf.name)
         if not xhr:
             flash(_("%(book_id)s is a invalid Book Id. Could not be added to Shelf", book_id=book_id),
@@ -99,6 +100,9 @@ def add_to_shelf(shelf_id, book_id):
             return redirect(request.environ["HTTP_REFERER"])
         else:
             return redirect(url_for('web.index'))
+    if shelf.kobo_sync and config.config_hardcover_sync and bool(hardcover):
+        hardcoverClient = hardcover.HardcoverClient(current_user.hardcover_token)
+        hardcoverClient.add_book(book.identifiers)
     return "", 204
 
 

--- a/cps/static/css/style.css
+++ b/cps/static/css/style.css
@@ -382,12 +382,101 @@ input.pill:not(:checked) + label .glyphicon { display: none; }
   overflow-y: scroll;
 }
 
-.media-list { padding-right: 15px; }
+#meta-info #book-list {
+  list-style-type: none;
+  padding: 0px 15px 0px 0px;
+}
 
-#meta-info img {
-  max-height: 150px;
-  max-width: 100px;
+#meta-info #book-list .media {
+  display: flex;
+  background-color: #f9f9f9;
+  margin-bottom: 20px;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+#meta-info #book-list .media .media-image {
+  width: 200px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+}
+
+#meta-info #book-list .media .media-image-wrapper {
+  position: relative;
+  width: 100%;
+}
+
+#meta-info #book-list .media .media-image img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 4px;
+  display: block;
+}
+#meta-info #book-list .media .media-image .image-dimensions {
+  position: absolute;
+  bottom: 5px;
+  right: 5px;
+  background-color: rgba(0, 0, 0, 0.7);
+  color: white;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+}
+#meta-info #book-list .media .media-image .image-dimensions.larger {
+  background-color: rgba(0, 160, 0, 0.7);
+}
+#meta-info #book-list .media .media-image .image-dimensions.smaller {
+  background-color: rgba(160, 0, 0, 0.7);
+}
+#meta-info #book-list .media .media-image input {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  width: 20px;
+  height: 20px;
+}
+
+#meta-info #book-list .media .media-image button {
+  margin-top: 10px;
+  /* padding: 8px 16px; */
   cursor: pointer;
+}
+
+#meta-info #book-list .media .media-image div {
+  margin-top: 10px;
+  font-size: 0.9em;
+  color: #666;
+  text-align: center;
+}
+
+#meta-info #book-list .media .media-body {
+  flex: 1;
+  padding: 20px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 10px;
+  align-content: start;
+}
+
+#meta-info #book-list .media .media-body dt {
+  font-weight: bold;
+  color: #333;
+  display: flex;
+  align-items: center;
+}
+
+#meta-info #book-list .media .media-body dt input {
+  margin-right: 5px;
+  margin-top: 0px;
+}
+
+#meta-info #book-list .media .media-body dd {
+  margin: 0;
+  color: #666;
 }
 
 .padded-bottom { margin-bottom: 15px; }

--- a/cps/static/js/get_meta.js
+++ b/cps/static/js/get_meta.js
@@ -37,27 +37,43 @@ $(function () {
         return presentArray
     }
 
-    function populateForm (book) {
-        tinymce.get("comments").setContent(book.description);
-        var uniqueTags = getUniqueValues('tags', book)
+    function populateForm (book, idx) {
+        var updateItems = Object.fromEntries(Array.from(document.querySelectorAll(`[data-meta-index="${idx}"]`)).map((value)=>[value.dataset.metaValue, value.checked]))
+        if (updateItems.description){
+            tinymce.get("comments").setContent(book.description);
+        }
+        if (updateItems.tags){
+            var uniqueTags = getUniqueValues('tags', book)
+            $("#tags").val(uniqueTags.join(", "));
+        }
         var uniqueLanguages = getUniqueValues('languages', book)
-        var ampSeparatedAuthors = (book.authors || []).join(" & ");
-        $("#authors").val(ampSeparatedAuthors);
-        $("#title").val(book.title);
-        $("#tags").val(uniqueTags.join(", "));
+        if (updateItems.authors){
+            var ampSeparatedAuthors = (book.authors || []).join(" & ");
+            $("#authors").val(ampSeparatedAuthors);
+        }
+        if (updateItems.titles){
+            $("#title").val(book.title);
+        }
         $("#languages").val(uniqueLanguages.join(", "));
         $("#rating").data("rating").setValue(Math.round(book.rating));
-        if(book.cover && $("#cover_url").length){
+    
+        if(updateItems.cover && book.cover && $("#cover_url").length){
             $(".cover img").attr("src", book.cover);
             $("#cover_url").val(book.cover);
         }
-        $("#pubdate").val(book.publishedDate);
-        $("#publisher").val(book.publisher);
-        if (typeof book.series !== "undefined") {
+        if (updateItems.pubDate){
+            $("#pubdate").val(book.publishedDate);
+        }
+        if (updateItems.publisher){
+            $("#publisher").val(book.publisher);
+        }
+        if (updateItems.series && typeof book.series !== "undefined") {
             $("#series").val(book.series);
+        }
+        if (updateItems.series_index && typeof book.series_index !== "undefined"){
             $("#series_index").val(book.series_index);
         }
-        if (typeof book.identifiers !== "undefined") {
+        if (updateItems.identifiers && typeof book.identifiers !== "undefined") {
             populateIdentifiers(book.identifiers)
         }
     }
@@ -94,10 +110,10 @@ $(function () {
                 success: function success(data) {
                     if (data.length) {
                         $("#meta-info").html("<ul id=\"book-list\" class=\"media-list\"></ul>");
-                        data.forEach(function(book) {
-                            var $book = $(templates.bookResult(book));
-                            $book.find("img").on("click", function () {
-                                populateForm(book);
+                        data.forEach(function(book,idx) {
+                            var $book = $(templates.bookResult({"book":book,"index":idx}));
+                            $book.find("button").on("click", function () {
+                                populateForm(book,idx);
                             });
                             $("#book-list").append($book);
                         });
@@ -150,10 +166,10 @@ $(function () {
             data: JSON.stringify(params),
             success: function success(data) {
                 element.data("initial", "true");
-                data.forEach(function(book) {
-                    var $book = $(templates.bookResult(book));
-                    $book.find("img").on("click", function () {
-                        populateForm(book);
+                data.forEach(function(book,idx) {
+                    var $book = $(templates.bookResult({"book":book,"index":idx}));
+                    $book.find("button").on("click", function () {
+                        populateForm(book,idx);
                     });
                     $("#book-list").append($book);
                 });

--- a/cps/static/js/get_meta.js
+++ b/cps/static/js/get_meta.js
@@ -18,112 +18,160 @@
 
 $(function () {
     var msg = i18nMsg;
-    var keyword = ""
+    var keyword = "";
 
     var templates = {
-        bookResult: _.template(
-            $("#template-book-result").html()
-       )
+        bookResult: _.template($("#template-book-result").html()),
     };
 
-    function getUniqueValues(attribute_name, book){
-        var presentArray = $.map($("#"+attribute_name).val().split(","), $.trim);
-        if ( presentArray.length === 1 && presentArray[0] === "") {
+    function getUniqueValues(attribute_name, book) {
+        var presentArray = $.map(
+            $("#" + attribute_name)
+                .val()
+                .split(","),
+            $.trim
+        );
+        if (presentArray.length === 1 && presentArray[0] === "") {
             presentArray = [];
         }
-        $.each(book[attribute_name], function(i, el) {
+        $.each(book[attribute_name], function (i, el) {
             if ($.inArray(el, presentArray) === -1) presentArray.push(el);
         });
-        return presentArray
+        return presentArray;
     }
 
-    function populateForm (book, idx) {
-        var updateItems = Object.fromEntries(Array.from(document.querySelectorAll(`[data-meta-index="${idx}"]`)).map((value)=>[value.dataset.metaValue, value.checked]))
-        if (updateItems.description){
+    function populateForm(book, idx) {
+        var updateItems = Object.fromEntries(
+            Array.from(
+                document.querySelectorAll(`[data-meta-index="${idx}"]`)
+            ).map((value) => [value.dataset.metaValue, value.checked])
+        );
+        if (updateItems.description) {
             tinymce.get("comments").setContent(book.description);
         }
-        if (updateItems.tags){
-            var uniqueTags = getUniqueValues('tags', book)
+        if (updateItems.tags) {
+            var uniqueTags = getUniqueValues("tags", book);
             $("#tags").val(uniqueTags.join(", "));
         }
-        var uniqueLanguages = getUniqueValues('languages', book)
-        if (updateItems.authors){
+        var uniqueLanguages = getUniqueValues("languages", book);
+        if (updateItems.authors) {
             var ampSeparatedAuthors = (book.authors || []).join(" & ");
             $("#authors").val(ampSeparatedAuthors);
         }
-        if (updateItems.titles){
+        if (updateItems.titles) {
             $("#title").val(book.title);
         }
         $("#languages").val(uniqueLanguages.join(", "));
         $("#rating").data("rating").setValue(Math.round(book.rating));
-    
-        if(updateItems.cover && book.cover && $("#cover_url").length){
+
+        if (updateItems.cover && book.cover && $("#cover_url").length) {
             $(".cover img").attr("src", book.cover);
             $("#cover_url").val(book.cover);
         }
-        if (updateItems.pubDate){
+        if (updateItems.pubDate) {
             $("#pubdate").val(book.publishedDate);
         }
-        if (updateItems.publisher){
+        if (updateItems.publisher) {
             $("#publisher").val(book.publisher);
         }
         if (updateItems.series && typeof book.series !== "undefined") {
             $("#series").val(book.series);
         }
-        if (updateItems.series_index && typeof book.series_index !== "undefined"){
+        if (
+            updateItems.series_index &&
+            typeof book.series_index !== "undefined"
+        ) {
             $("#series_index").val(book.series_index);
         }
-        if (updateItems.identifiers && typeof book.identifiers !== "undefined") {
-            populateIdentifiers(book.identifiers)
+        if (
+            updateItems.identifiers &&
+            typeof book.identifiers !== "undefined"
+        ) {
+            populateIdentifiers(book.identifiers);
         }
     }
 
-    function populateIdentifiers(identifiers){
-       for (const property in identifiers) {
-          console.log(`${property}: ${identifiers[property]}`);
-          if ($('input[name="identifier-type-'+property+'"]').length) {
-              $('input[name="identifier-val-'+property+'"]').val(identifiers[property])
-          }
-          else {
-              addIdentifier(property, identifiers[property])
-          }
+    function populateIdentifiers(identifiers) {
+        for (const property in identifiers) {
+            if (identifiers[property].length !== 0) {
+                console.log(`${property}: ${identifiers[property]}`);
+                if (
+                    $('input[name="identifier-type-' + property + '"]').length
+                ) {
+                    $('input[name="identifier-val-' + property + '"]').val(
+                        identifiers[property]
+                    );
+                } else {
+                    addIdentifier(property, identifiers[property]);
+                }
+            }
         }
     }
 
-    function addIdentifier(name, value){
-        var line = '<tr>';
-        line += '<td><input type="text" class="form-control" name="identifier-type-'+ name +'" required="required" placeholder="' + _("Identifier Type") +'" value="'+ name +'"></td>';
-        line += '<td><input type="text" class="form-control" name="identifier-val-'+ name +'" required="required" placeholder="' + _("Identifier Value") +'" value="'+ value +'"></td>';
-        line += '<td><a class="btn btn-default" onclick="removeIdentifierLine(this)">'+_("Remove")+'</a></td>';
-        line += '</tr>';
+    function addIdentifier(name, value) {
+        var line = "<tr>";
+        line +=
+            '<td><input type="text" class="form-control" name="identifier-type-' +
+            name +
+            '" required="required" placeholder="' +
+            _("Identifier Type") +
+            '" value="' +
+            name +
+            '"></td>';
+        line +=
+            '<td><input type="text" class="form-control" name="identifier-val-' +
+            name +
+            '" required="required" placeholder="' +
+            _("Identifier Value") +
+            '" value="' +
+            value +
+            '"></td>';
+        line +=
+            '<td><a class="btn btn-default" onclick="removeIdentifierLine(this)">' +
+            _("Remove") +
+            "</a></td>";
+        line += "</tr>";
         $("#identifier-table").append(line);
     }
 
-    function doSearch (keyword) {
+    function doSearch(keyword) {
         if (keyword) {
             $("#meta-info").text(msg.loading);
             $.ajax({
                 url: getPath() + "/metadata/search",
                 type: "POST",
-                data: {"query": keyword},
+                data: { query: keyword },
                 dataType: "json",
                 success: function success(data) {
                     if (data.length) {
-                        $("#meta-info").html("<ul id=\"book-list\" class=\"media-list\"></ul>");
-                        data.forEach(function(book,idx) {
-                            var $book = $(templates.bookResult({"book":book,"index":idx}));
+                        $("#meta-info").html(
+                            '<ul id="book-list" class="media-list"></ul>'
+                        );
+                        data.forEach(function (book, idx) {
+                            var $book = $(
+                                templates.bookResult({ book: book, index: idx })
+                            );
                             $book.find("button").on("click", function () {
-                                populateForm(book,idx);
+                                populateForm(book, idx);
                             });
                             $("#book-list").append($book);
                         });
-                    }
-                    else {
-                        $("#meta-info").html("<p class=\"text-danger\">" + msg.no_result + "!</p>" + $("#meta-info")[0].innerHTML)
+                    } else {
+                        $("#meta-info").html(
+                            '<p class="text-danger">' +
+                                msg.no_result +
+                                "!</p>" +
+                                $("#meta-info")[0].innerHTML
+                        );
                     }
                 },
                 error: function error() {
-                    $("#meta-info").html("<p class=\"text-danger\">" + msg.search_error + "!</p>" + $("#meta-info")[0].innerHTML);
+                    $("#meta-info").html(
+                        '<p class="text-danger">' +
+                            msg.search_error +
+                            "!</p>" +
+                            $("#meta-info")[0].innerHTML
+                    );
                 },
             });
         }
@@ -136,12 +184,25 @@ $(function () {
             type: "get",
             dataType: "json",
             success: function success(data) {
-                data.forEach(function(provider) {
+                data.forEach(function (provider) {
                     var checked = "";
                     if (provider.active) {
                         checked = "checked";
                     }
-                    var $provider_button = '<input type="checkbox" id="show-' + provider.name + '" class="pill" data-initial="' + provider.initial + '" data-control="' + provider.id + '" ' + checked + '><label for="show-' + provider.name + '">' + provider.name + ' <span class="glyphicon glyphicon-ok"></span></label>'
+                    var $provider_button =
+                        '<input type="checkbox" id="show-' +
+                        provider.name +
+                        '" class="pill" data-initial="' +
+                        provider.initial +
+                        '" data-control="' +
+                        provider.id +
+                        '" ' +
+                        checked +
+                        '><label for="show-' +
+                        provider.name +
+                        '">' +
+                        provider.name +
+                        ' <span class="glyphicon glyphicon-ok"></span></label>';
                     $("#metadata_provider").append($provider_button);
                 });
             },
@@ -152,36 +213,38 @@ $(function () {
         var element = $(this);
         var id = element.data("control");
         var initial = element.data("initial");
-        var val = element.prop('checked');
-        var params = {id : id, value: val};
+        var val = element.prop("checked");
+        var params = { id: id, value: val };
         if (!initial) {
-            params['initial'] = initial;
-            params['query'] = keyword;
+            params["initial"] = initial;
+            params["query"] = keyword;
         }
         $.ajax({
-            method:"post",
+            method: "post",
             contentType: "application/json; charset=utf-8",
             dataType: "json",
             url: getPath() + "/metadata/provider/" + id,
             data: JSON.stringify(params),
             success: function success(data) {
                 element.data("initial", "true");
-                data.forEach(function(book,idx) {
-                    var $book = $(templates.bookResult({"book":book,"index":idx}));
+                data.forEach(function (book, idx) {
+                    var $book = $(
+                        templates.bookResult({ book: book, index: idx })
+                    );
                     $book.find("button").on("click", function () {
-                        populateForm(book,idx);
+                        populateForm(book, idx);
                     });
                     $("#book-list").append($book);
                 });
-            }
+            },
         });
     });
 
     $("#meta-search").on("submit", function (e) {
         e.preventDefault();
         keyword = $("#keyword").val();
-        $('.pill').each(function(){
-            $(this).data("initial", $(this).prop('checked'));
+        $(".pill").each(function () {
+            $(this).data("initial", $(this).prop("checked"));
         });
         doSearch(keyword);
     });
@@ -193,8 +256,8 @@ $(function () {
         keyword = bookTitle;
         doSearch(bookTitle);
     });
-    $("#metaModal").on("show.bs.modal", function(e) {
-        $(e.relatedTarget).one('focus', function (e) {
+    $("#metaModal").on("show.bs.modal", function (e) {
+        $(e.relatedTarget).one("focus", function (e) {
             $(this).blur();
         });
     });

--- a/cps/templates/book_edit.html
+++ b/cps/templates/book_edit.html
@@ -276,6 +276,9 @@
       </div>
       <button class="btn btn-default">Save</button>
       <div><a class="meta_source" href="<%= book.source.link %>" target="_blank" rel="noopener"><%= book.source.description %></a></div>
+      <% if(book.format !== "") { %>
+      <div>Format: <%= book.format %></div>
+      <% } %>
     </div>
     <dl class="media-body">
       <dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="title">Title:</dt>
@@ -308,8 +311,10 @@
       <% } %>
       <% if (Object.keys(book.identifiers).length !== 0 ) { %>
         <% for (const key in book.identifiers) { %>
-          <dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="identifiers">Identifier</dt>
-          <dd class="meta_description"><%= key %>:<%= book.identifiers[key] %></dd>
+          <% if (book.identifiers[key] !== "") { %>
+            <dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="identifiers">Identifier</dt>
+            <dd class="meta_description"><%= key %>:<%= book.identifiers[key] %></dd>
+          <% } %>
         <% } %>
       <% } %>
     </dl>

--- a/cps/templates/book_edit.html
+++ b/cps/templates/book_edit.html
@@ -263,28 +263,56 @@
 
 {% block js %}
 <script type="text/template" id="template-book-result">
-  <li class="media" data-related="<%= source.id %>">
-    <img class="pull-left img-responsive"
-         data-toggle="modal"
-         data-target="#metaModal"
-         src="<%= cover || "{{ url_for('static', filename='img/academicpaper.svg') }}" %>"
-         alt="Cover"
-    >
-    <div class="media-body">
-      <h4 class="media-heading">
-        <a class="meta_title" href="<%= url %>" target="_blank" rel="noopener"><%= title %></a>
-      </h4>
-      <p class="meta_author">{{_('Author')}}：<%= authors.join(" & ") %></p>
-      <% if (publisher) { %>
-        <p class="meta_publisher">{{_('Publisher')}}：<%= publisher %></p>
-      <% } %>
-      <% if (description) { %>
-        <p class="meta_description">{{_('Description')}}: <%= description %></p>
-      <% } %>
-      <p>{{_('Source')}}:
-        <a class="meta_source" href="<%= source.link %>" target="_blank" rel="noopener"><%= source.description %></a>
-      </p>
+  <li class="media" data-related="<%= book.source.id %>">
+    <div class="media-image">
+      <div class="media-image-wrapper">
+        <img
+          onload="coverDimensions(this)"
+          src="<%= book.cover || "{{ url_for('static', filename='img/academicpaper.svg') }}" %>"
+          alt="Cover"
+        >
+        <div class="image-dimensions"></div>
+        <input type="checkbox" data-meta-index="<%= index %>" data-meta-value="cover">
+      </div>
+      <button class="btn btn-default">Save</button>
+      <div><a class="meta_source" href="<%= book.source.link %>" target="_blank" rel="noopener"><%= book.source.description %></a></div>
     </div>
+    <dl class="media-body">
+      <dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="title">Title:</dt>
+      <dd><a class="meta_title" href="<%= book.url %>" target="_blank" rel="noopener"><%= book.title %></a></dd>
+      <dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="authors">Author:</dt>
+      <dd class="meta_author"><%= book.authors.join(" & ") %></dd>
+      <% if (book.publisher) { %>
+        <dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="publisher">Publisher:</dt>
+        <dd class="meta_publisher"><%= book.publisher %></dd>
+      <% } %>
+      <% if (book.publishedDate) { %>
+        <dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="pubDate">Published Date:</dt>
+        <dd class="meta_publishedDate"><%= book.publishedDate %></dd>
+      <% } %>
+      <% if (book.series) { %>
+        <dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="series">Series:</dt>
+        <dd class="meta_publishedDate"><%= book.series %></dd>
+      <% } %>
+      <% if (book.series_index) { %>
+        <dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="seriesIndex">Series Index:</dt>
+        <dd class="meta_publishedDate"><%= book.series_index %></dd>
+      <% } %>
+      <% if (book.description) { %>
+        <dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="description">Description:</dt>
+        <dd class="meta_description"><%= book.description %></dd>
+      <% } %>
+      <% if (book.tags.length !== 0) { %>
+        <dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="tags">Tags:</dt>
+        <dd class="meta_author"><%= book.tags.join(", ") %></dd>
+      <% } %>
+      <% if (Object.keys(book.identifiers).length !== 0 ) { %>
+        <% for (const key in book.identifiers) { %>
+          <dt><input type="checkbox" data-meta-index="<%= index %>" data-meta-value="identifiers">Identifier</dt>
+          <dd class="meta_description"><%= key %>:<%= book.identifiers[key] %></dd>
+        <% } %>
+      <% } %>
+    </dl>
   </li>
 </script>
 <script>
@@ -312,7 +340,15 @@
   function removeIdentifierLine(el) {
     $(el).parent().parent().remove();
   }
-
+  function coverDimensions(el) {
+    var existing_cover = document.querySelector("#detailcover")
+    el.nextElementSibling.innerText = el.naturalWidth + 'x' + el.naturalHeight
+    if (existing_cover.naturalHeight*existing_cover.naturalWidth >  el.naturalWidth * el.naturalHeight){
+      el.nextElementSibling.classList.add("smaller")
+    } else if (existing_cover.naturalHeight*existing_cover.naturalWidth < el.naturalWidth * el.naturalHeight){
+      el.nextElementSibling.classList.add("larger")
+    }
+  }
 </script>
 <script src="{{ url_for('static', filename='js/libs/typeahead.bundle.js') }}"></script>
 <script src="{{ url_for('static', filename='js/libs/bootstrap-rating-input.min.js') }}"></script>

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -149,6 +149,10 @@
         <label for="config_external_port">{{_('Server External Port (for port forwarded API calls)')}}</label>
         <input type="number" min="1" max="65535" class="form-control" name="config_external_port" id="config_external_port" value="{% if config.config_external_port != None %}{{ config.config_external_port }}{% endif %}" autocomplete="off" required>
       </div>
+      <div class="form-group" style="margin-left:10px;">
+        <input type="checkbox" id="config_hardcover_sync" name="config_hardcover_sync"  {% if config.config_hardcover_sync %}checked{% endif %}>
+        <label for="config_hardcover_sync">{{_('Sync Kobo read progress to Hardcover (Requires API key per user)')}}</label>
+      </div>
     </div>
     {% endif %}
     {% if feature_support['goodreads'] %}

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -171,7 +171,7 @@
                 <div class="identifiers">
                     <p>
                         <span class="glyphicon glyphicon-link"></span>
-                        {% for identifier in entry.identifiers %}
+                        {% for identifier in entry.identifiers if identifier.__repr__() != identifier.val %}
                             <a href="{{ identifier|escape }}" target="_blank" class="btn btn-xs btn-success"
                                role="button">{{ identifier.format_type() }}</a>
                         {% endfor %}

--- a/cps/templates/user_edit.html
+++ b/cps/templates/user_edit.html
@@ -60,6 +60,12 @@
       {% endfor %}
     </div>
     {% endif %}
+    {% if kobo_support and hardcover_support and not new_user %}
+    <div class="form-group">
+      <label for="hardcover_token">{{_('Hardcover API token')}}</label>
+      <input type="text" class="form-control" name="hardcover_token" id="hardcover_token" value="{{ content.hardcover_token if content.hardcover_token != None }}">
+    </div>
+    {% endif %}
     {% if kobo_support and not new_user %}
     <label>{{ _('Kobo Sync Token')}}</label>
     <div class="form-group col">

--- a/cps/web.py
+++ b/cps/web.py
@@ -65,7 +65,8 @@ from .string_helper import strip_whitespaces
 feature_support = {
     'ldap': bool(services.ldap),
     'goodreads': bool(services.goodreads_support),
-    'kobo': bool(services.kobo)
+    'kobo': bool(services.kobo),
+    'hardcover' : bool(services.hardcover)
 }
 
 try:
@@ -1465,7 +1466,7 @@ def logout():
 
 
 # ################################### Users own configuration #########################################################
-def change_profile(kobo_support, local_oauth_check, oauth_status, translations, languages):
+def change_profile(kobo_support, hardcover_support, local_oauth_check, oauth_status, translations, languages):
     to_save = request.form.to_dict()
     current_user.random_books = 0
     try:
@@ -1493,6 +1494,7 @@ def change_profile(kobo_support, local_oauth_check, oauth_status, translations, 
         current_user.kobo_only_shelves_sync = int(to_save.get("kobo_only_shelves_sync") == "on") or 0
         if old_state == 0 and current_user.kobo_only_shelves_sync == 1:
             kobo_sync_status.update_on_sync_shelfs(current_user.id)
+        current_user.hardcover_token = to_save.get("hardcover_token","").replace("Bearer ","")
 
     except Exception as ex:
         flash(str(ex), category="error")
@@ -1505,6 +1507,7 @@ def change_profile(kobo_support, local_oauth_check, oauth_status, translations, 
                                      title=_("%(name)s's Profile", name=current_user.name),
                                      page="me",
                                      kobo_support=kobo_support,
+                                     hardcover_support=hardcover_support,
                                      registered_oauth=local_oauth_check,
                                      oauth_status=oauth_status)
 
@@ -1536,6 +1539,7 @@ def profile():
     languages = calibre_db.speaking_language()
     translations = get_available_locale()
     kobo_support = feature_support['kobo'] and config.config_kobo_sync
+    hardcover_support = feature_support['hardcover'] and config.config_hardcover_sync
     if feature_support['oauth'] and config.config_login_type == 2:
         oauth_status = get_oauth_status()
         local_oauth_check = oauth_check
@@ -1544,7 +1548,7 @@ def profile():
         local_oauth_check = {}
 
     if request.method == "POST":
-        change_profile(kobo_support, local_oauth_check, oauth_status, translations, languages)
+        change_profile(kobo_support, hardcover_support, local_oauth_check, oauth_status, translations, languages)
     return render_title_template("user_edit.html",
                                  translations=translations,
                                  profile=1,
@@ -1552,6 +1556,7 @@ def profile():
                                  content=current_user,
                                  config=config,
                                  kobo_support=kobo_support,
+                                 hardcover_support=hardcover_support,
                                  title=_("%(name)s's Profile", name=current_user.name),
                                  page="me",
                                  registered_oauth=local_oauth_check,


### PR DESCRIPTION
Creating a draft pull request to gauge interest in such an option.
This PR adds Hardcover.app as a metadata provider.
Metadata can scraped from the first result, or a search with format "hardcover-id:123456" will allow edition selection.
![image](https://github.com/user-attachments/assets/327735ae-838c-4702-a236-75517f83cf4a)
![image](https://github.com/user-attachments/assets/524da2b9-bc96-4104-a941-bc42df0ea7b1)

If appropriate hardcover-* identifiers are added to a book it enables Kobo Sync to push status to Hardcover.
If a properly identified book is added to a Kobo Sync shelf, the book is added to the users 'Want To Read' section in Hardcover.
Once a book is being read, when the Kobo syncs state to Calibre-web the status is also pushed to the users Read Progress on Hardcover.
![image](https://github.com/user-attachments/assets/cfc8a538-126d-4126-b11a-b08356e475fd)
![image](https://github.com/user-attachments/assets/904fd4bc-e8e8-4b77-86ce-6554966a6390)
![image](https://github.com/user-attachments/assets/f7d2184f-f20a-43f3-9b6b-2a1b139423bd)