### PR TITLE
Add support for user-provided Google Books API key to fix "429 Client Error: Too Many Requests"

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -1833,6 +1833,9 @@ def _configuration_update_helper():
             services.goodreads_support.connect(config.config_goodreads_api_key,
                                                config.config_use_goodreads)
 
+        # Google Books API configuration
+        _config_string(to_save, "config_googlebooks_api_key")
+        
         _config_int(to_save, "config_updatechannel")
 
         # Reverse proxy login configuration

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -117,6 +117,7 @@ class _Settings(_Base):
 
     config_use_goodreads = Column(Boolean, default=False)
     config_goodreads_api_key = Column(String)
+    config_googlebooks_api_key = Column(String, default='')
     config_register_email = Column(Boolean, default=False)
     config_login_type = Column(Integer, default=0)
 

--- a/cps/metadata_provider/google.py
+++ b/cps/metadata_provider/google.py
@@ -23,7 +23,7 @@ from datetime import datetime
 
 import requests
 
-from cps import logger
+from cps import logger, config
 from cps.isoLanguages import get_lang3, get_language_name
 from cps.services.Metadata import MetaRecord, MetaSourceInfo, Metadata
 
@@ -38,6 +38,7 @@ class Google(Metadata):
     BOOK_URL = "https://books.google.com/books?id="
     SEARCH_URL = "https://www.googleapis.com/books/v1/volumes?q="
     ISBN_TYPE = "ISBN_13"
+    API_KEY = "&key=" + config.config_googlebooks_api_key 
 
     def search(
         self, query: str, generic_cover: str = "", locale: str = "en"
@@ -50,7 +51,7 @@ class Google(Metadata):
                 tokens = [quote(t.encode("utf-8")) for t in title_tokens]
                 query = "+".join(tokens)
             try:
-                results = requests.get(Google.SEARCH_URL + query)
+                results = requests.get(Google.SEARCH_URL + query + Google.API_KEY)
                 results.raise_for_status()
             except Exception as e:
                 log.warning(e)

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -164,6 +164,10 @@
     </div>
     {% endif %}
     <div class="form-group">
+      <label for="config_googlebooks_api_key">{{_('Google Books API Key')}}</label>
+      <input type="text" class="form-control" id="config_googlebooks_api_key" name="config_googlebooks_api_key" value="{% if config.config_googlebooks_api_key != None %}{{ config.config_googlebooks_api_key }}{% endif %}" autocomplete="off">
+    </div>
+    <div class="form-group">
       <input type="checkbox" id="config_allow_reverse_proxy_header_login" name="config_allow_reverse_proxy_header_login" data-control="reverse-proxy-login-settings" {% if config.config_allow_reverse_proxy_header_login %}checked{% endif %}>
       <label for="config_allow_reverse_proxy_header_login">{{_('Allow Reverse Proxy Authentication')}}</label>
     </div>


### PR DESCRIPTION
Using the Google Books API without a key is limited to a hard cap of global daily requests. Once the quota is reached, all requests without a key return a 429 error. This can be worked around by using a free personal API key generated in the Google Cloud console. The key allows for 1000 requests a day, and users can request a limit increase for free from Google if that is not enough. API key can be added in Admin Panel -> Basic Settings -> Feature Configuration. 

Functionality for users that do not wish to use a personal API key remains unchanged.