### PR TITLE
Add POST method to /v1/library/<dummy> redirect route

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -955,7 +955,7 @@ def HandleBookDeletionRequest(book_uuid):
 
 # TODO: Implement the following routes
 @csrf.exempt
-@kobo.route("/v1/library/<dummy>", methods=["DELETE", "GET"])
+@kobo.route("/v1/library/<dummy>", methods=["DELETE", "GET", "POST"])
 def HandleUnimplementedRequest(dummy=None):
     log.debug("Unimplemented Library Request received: %s (request is forwarded to kobo if configured)",
               request.base_url)

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -955,7 +955,7 @@ def HandleBookDeletionRequest(book_uuid):
 
 # TODO: Implement the following routes
 @csrf.exempt
-@kobo.route("/v1/library/<dummy>", methods=["DELETE", "GET", "POST"])
+@kobo.route("/v1/library/<dummy>", methods=["DELETE", "GET"])
 def HandleUnimplementedRequest(dummy=None):
     log.debug("Unimplemented Library Request received: %s (request is forwarded to kobo if configured)",
               request.base_url)


### PR DESCRIPTION

[ANONYMIZED_KOBOPLUSPurchase-DefaultCWA-250219-1509h39.log](https://github.com/user-attachments/files/18875002/ANONYMIZED_KOBOPLUSPurchase-DefaultCWA-250219-1509h39.log)
Adding POST method to /v1/library/<dummy> redirect implementation allows for syncing of notebooks on pen-enabled devices.

EDIT 1: Upon reverting the change, syncing of notebooks persists. I'm missing something...

EDIT 2: This change also fixes an issue where clicking "Read with Kobo Plus" silently fails to add a Kobo Plus book to a users account from the Kobo Store on device. (Device tested: Libra Colour). The following log is relevant to the error that lead me to open this PR.

```
Feb 19 15:09:44 nickel: (  1826.473 @ 0x2571038 / packetdump.debug) -------------------------- REQUEST --------------------------- 
Feb 19 15:09:44 nickel: (  1826.473 @ 0x2571038 / packetdump.debug) "POST" > To:  "https://CWDOMAIN.TLD/kobo/PERSONALAPI/v1/library/055ce5dd-9fe5-442e-a49b-8a754db0a6bf?BookSubId=416bfce4-e4ae-4730-8314-5857dece58a6" 
...
Feb 19 15:09:44 nickel: (  1826.474 @ 0x2571038 / packetdump.debug) 	---------------------- BODY --------------------------- 
Feb 19 15:09:44 nickel: (  1826.474 @ 0x2571038 / packetdump.debug) "" 
Feb 19 15:09:44 nickel: (  1826.474 @ 0x2571038 / packetdump.debug) -------------------------- END OF REQUEST --------------------------- 
Feb 19 15:09:44 nickel: (  1826.571 @ 0x2571038 / packetdump.warning) "https://CWDOMAIN.TLD/kobo/PERSONALAPI/v1/library/055ce5dd-9fe5-442e-a49b-8a754db0a6bf?BookSubId=416bfce4-e4ae-4730-8314-5857dece58a6" => "Error downloading https://CWDOMAIN.TLD/kobo/PERSONALAPI/v1/library/055ce5dd-9fe5-442e-a49b-8a754db0a6bf?BookSubId=416bfce4-e4ae-4730-8314-5857dece58a6 - server replied: METHOD NOT ALLOWED" 
Feb 19 15:09:44 nickel: (  1826.572 @ 0x2571038 / packetdump.warning) HTTP Status Code: 405 
Feb 19 15:09:44 nickel: (  1826.572 @ 0x2571038 / packetdump.warning) Error: 202
```

By adding the POST method to the /v1/library/<dummy> route, Calibre-Web correctly redirects the request generated by the "Read with Kobo Plus" button via the store on-device along with similar requests generated the addition of new notebooks.