### PR TITLE
Add support for selecting which Kindle/eReader to send books to

### DIFF
--- a/cps/static/js/caliBlur.js
+++ b/cps/static/js/caliBlur.js
@@ -112,7 +112,7 @@ if ($("body.book").length > 0) {
     // If only one download type exists still put the items into a drop-drown list.
     downloads = $("a[id^=btnGroupDrop]").get();
     if ($(downloads).length === 1) {
-        $('<button id="btnGroupDrop1" type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span class="glyphicon glyphicon-download"></span>Download :<span class="caret"></span></button><ul class="dropdown-menu leramslist aria-labelledby="btnGroupDrop1"></ul>').insertBefore(downloads[downloads.length - 1]);
+        $('<button id="btnGroupDrop1" type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span class="glyphicon glyphicon-download"></span>Download<span class="caret"></span></button><ul class="dropdown-menu leramslist aria-labelledby="btnGroupDrop1"></ul>').insertBefore(downloads[downloads.length - 1]);
         $(downloads).detach();
         $.each(downloads, function (i, val) {
             $("<li>" + downloads[i].outerHTML + "</li>").appendTo(".leramslist");
@@ -154,7 +154,7 @@ if ($("body.book").length > 0) {
     // Move dropdown lists higher in dom, replace bootstrap toggle with own toggle.
     $('ul[aria-labelledby="read-in-browser"]').insertBefore(".blur-wrapper").addClass("readinbrowser-drop");
     $('ul[aria-labelledby="listen-in-browser"]').insertBefore(".blur-wrapper").addClass("readinbrowser-drop");
-    $('ul[aria-labelledby="send-to-kereader"]').insertBefore(".blur-wrapper").addClass("sendtoereader-drop");
+    $('ul[aria-labelledby="send-to-ereader"]').insertBefore(".blur-wrapper").addClass("sendtoereader-drop");
     $(".leramslist").insertBefore(".blur-wrapper");
     $('ul[aria-labelledby="btnGroupDrop1"]').insertBefore(".blur-wrapper").addClass("leramslist");
     $("#add-to-shelves").insertBefore(".blur-wrapper");
@@ -592,7 +592,7 @@ $('.btn-group[aria-label="Edit/Delete book"] a').attr({
 
 $("#sendbtn").attr({
     "data-toggle": "tooltip",
-    "title": $("#sendbtn").attr("data-text"),
+    "title": $("#sendbtn").text(),                  // "Send to eReader"
     "data-placement": "bottom",
     "data-viewport": ".btn-toolbar"
 })
@@ -712,4 +712,3 @@ $(window).on("resize", function () {
 //  id = setTimeout(mobileSupport, 500);
     mobileSupport();
 });
-

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -55,7 +55,7 @@
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                             {% if entry.email_share_list.__len__() == 1 %}
                                 <div class="btn-group" role="group">
-                                    <button id="sendbtn" class="btn btn-primary sendbtn-form" data-href="{{url_for('web.send_to_ereader', book_id=entry.id, book_format=entry.email_share_list[0]['format'], convert=entry.email_share_list[0]['convert'])}}">
+                                    <button id="sendbtn" class="btn btn-primary sendbtn-form" data-href="{{url_for('web.send_to_ereader', book_id=entry.id, book_format=entry.email_share_list[0]['format'], convert=entry.email_share_list[0]['convert'], ereader_email=entry.email_share_list[0]['ereader_email'])}}">
                                         <span class="glyphicon glyphicon-send"></span> {{entry.email_share_list[0]['text']}}
                                     </button>
                                 </div>
@@ -69,7 +69,7 @@
                                     <ul class="dropdown-menu" aria-labelledby="send-to-ereader">
                                         {% for format in entry.email_share_list %}
                                             <li>
-                                                <a class="sendbtn-form" data-href="{{url_for('web.send_to_ereader', book_id=entry.id, book_format=format['format'], convert=format['convert'])}}">{{ format['text'] }}</a>
+                                                <a class="sendbtn-form" data-href="{{url_for('web.send_to_ereader', book_id=entry.id, book_format=format['format'], convert=format['convert'], ereader_email=format['ereader_email'])}}">{{ format['text'] }}</a>
                                             </li>
                                         {% endfor %}
                                     </ul>

--- a/messages.pot
+++ b/messages.pot
@@ -731,12 +731,22 @@ msgstr ""
 msgid "Registration Email for user: %(name)s"
 msgstr ""
 
-#: cps/helper.py:157 cps/helper.py:163
+#: cps/helper.py:158
+#, python-format
+msgid "Convert %(orig)s to %(format)s and send to eReader (%(eReadermail)s)"
+msgstr ""
+
+#: cps/helper.py:161
 #, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
 msgstr ""
 
-#: cps/helper.py:182 cps/helper.py:186 cps/helper.py:190
+#: cps/helper.py:186
+#, python-format
+msgid "Send %(format)s to eReader (%(eReadermail)s)"
+msgstr ""
+
+#: cps/helper.py:189
 #, python-format
 msgid "Send %(format)s to eReader"
 msgstr ""
@@ -3715,4 +3725,3 @@ msgstr ""
 #: cps/templates/user_table.html:156
 msgid "Show Read/Unread Section"
 msgstr ""
-


### PR DESCRIPTION
If you have multiple eReader emails configured in your account profile, you used to only be able to send books to all destinations at once. This change allows you to select which eReader you send a book to using a dropdown in the Book Detail page.

The relevant code changes are in `helper.py`, `web.py`, and `detail.html`. Everything in `cps/translations/*` is a string change.

<img width="381" alt="image" src="https://github.com/user-attachments/assets/7b8b3f9f-d4c9-42a2-b1a3-fb93dfa824c6" />
