### PR TITLE
Remove duplicated 'charset' in Content-Type header for Javascript files

### DIFF
--- a/cps/__init__.py
+++ b/cps/__init__.py
@@ -77,7 +77,7 @@ mimetypes.add_type('audio/ogg', '.ogg')
 mimetypes.add_type('application/ogg', '.oga')
 mimetypes.add_type('text/css', '.css')
 mimetypes.add_type('application/x-ms-reader', '.lit')
-mimetypes.add_type('text/javascript; charset=UTF-8', '.js')
+mimetypes.add_type('text/javascript', '.js')
 mimetypes.add_type('text/rtf', '.rtf')
 
 log = logger.create()


### PR DESCRIPTION
Javascript files are served over HTTP with an incorrect Content-Type header because the 'charset' option is duplicated:

    $ curl -I http://127.0.0.1:8083/static/js/table.js
    HTTP/1.1 200 OK
    Content-Disposition: inline; filename=table.js
    Content-Type: text/javascript; charset=UTF-8; charset=utf-8
    Content-Length: 35967
    Last-Modified: Sat, 16 Nov 2024 06:21:28 GMT
    Cache-Control: no-cache
    ETag: "1731738088.0-35967-471731799"
    Date: Sat, 08 Feb 2025 16:30:42 GMT
    Content-Security-Policy: default-src 'self' 'unsafe-inline' 'unsafe-eval'; font-src 'self' data:; img-src 'self' data:; object-src 'none';
    X-Content-Type-Options: nosniff
    X-Frame-Options: SAMEORIGIN
    X-XSS-Protection: 1; mode=block
    Strict-Transport-Security: max-age=31536000

This header is not RFC 1521 compliant and it's breaking some reverse proxy setups that perform compression. See this bug for reference:

https://github.com/crocodilestick/Calibre-Web-Automated/issues/217