### PR TITLE
Fix sync fails with error when "Synchronize Notebooks" enabled

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -955,7 +955,7 @@ def HandleBookDeletionRequest(book_uuid):
 
 # TODO: Implement the following routes
 @csrf.exempt
-@kobo.route("/v1/library/<dummy>", methods=["DELETE", "GET"])
+@kobo.route("/v1/library/<dummy>", methods=["DELETE", "GET", "POST"])
 def HandleUnimplementedRequest(dummy=None):
     log.debug("Unimplemented Library Request received: %s (request is forwarded to kobo if configured)",
               request.base_url)


### PR DESCRIPTION
Fixes #2849 

When notebook sync is enabled, Sync always fails with "synchronization error."

This PR implements POST method for the kobo endpoint.