### PR TITLE
Adding ISBN, word count, and page count to Kobo sync

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -246,8 +246,11 @@ def db_configuration():
 @user_login_required
 @admin_required
 def configuration():
+    wordspages_columns = calibre_db.session.query(db.CustomColumns) \
+        .filter(and_(db.CustomColumns.datatype == 'int', db.CustomColumns.mark_for_delete == 0)).all()
     return render_title_template("config_edit.html",
                                  config=config,
+                                 wordsPagesColumns=wordspages_columns,
                                  provider=oauthblueprints,
                                  feature_support=feature_support,
                                  title=_("Basic Configuration"), page="config")
@@ -1796,6 +1799,8 @@ def _configuration_update_helper():
         reboot_required |= _config_checkbox_int(to_save, "config_kobo_sync")
         _config_int(to_save, "config_external_port")
         _config_checkbox_int(to_save, "config_kobo_proxy")
+        _config_int(to_save, "config_kobo_pages_cc")
+        _config_int(to_save, "config_kobo_words_cc")
 
         if "config_upload_formats" in to_save:
             to_save["config_upload_formats"] = ','.join(
@@ -2099,7 +2104,7 @@ def _handle_edit_user(to_save, content, languages, translations, kobo_support):
 
 
 def extract_user_data_from_field(user, field):
-    match = re.search(field + r"=(.*?)($|(?<!\\),)", user, re.IGNORECASE | re.UNICODE)    
+    match = re.search(field + r"=(.*?)($|(?<!\\),)", user, re.IGNORECASE | re.UNICODE)
     if match:
         return match.group(1)
     else:

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -121,6 +121,8 @@ class _Settings(_Base):
     config_login_type = Column(Integer, default=0)
 
     config_kobo_proxy = Column(Boolean, default=False)
+    config_kobo_pages_cc = Column(SmallInteger, default=0)
+    config_kobo_words_cc = Column(SmallInteger, default=0)
 
     config_ldap_provider_url = Column(String, default='example.org')
     config_ldap_port = Column(SmallInteger, default=389)
@@ -499,7 +501,7 @@ def autodetect_calibre_binaries():
             if all(values):
                 version = values[0].group(1)
                 log.debug("calibre version %s", version)
-                return element 
+                return element
     return ""
 
 

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -463,6 +463,16 @@ def get_metadata(book):
                 log.error(e)
 
     book_uuid = book.uuid
+    book_isbn = None
+    book_pages = None
+    book_words = None
+    for i in book.identifiers:
+        if i.format_type() == "ISBN":
+            book_isbn = i.val
+    if config.config_kobo_pages_cc:
+        book_pages = getattr(book, "custom_column_"+str(config.config_kobo_pages_cc))[0].value
+    if config.config_kobo_words_cc:
+        book_words = getattr(book, "custom_column_"+str(config.config_kobo_words_cc))[0].value
     metadata = {
         "Categories": ["00000000-0000-0000-0000-000000000001", ],
         # "Contributors": get_author(book),
@@ -486,6 +496,9 @@ def get_metadata(book):
         "RevisionId": book_uuid,
         "Title": book.title,
         "WorkId": book_uuid,
+        "ISBN": book_isbn,
+        "StorePages" : book_pages,
+        "StoreWordCount" : book_words,
     }
     metadata.update(get_author(book))
 

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -469,10 +469,12 @@ def get_metadata(book):
     for i in book.identifiers:
         if i.format_type() == "ISBN":
             book_isbn = i.val
-    if config.config_kobo_pages_cc:
-        book_pages = getattr(book, "custom_column_"+str(config.config_kobo_pages_cc))[0].value
-    if config.config_kobo_words_cc:
-        book_words = getattr(book, "custom_column_"+str(config.config_kobo_words_cc))[0].value
+    pages = getattr(book, "custom_column_"+str(config.config_kobo_pages_cc))
+    if config.config_kobo_pages_cc and len(pages):
+        book_pages = pages[0].value
+    words = getattr(book, "custom_column_"+str(config.config_kobo_words_cc))
+    if config.config_kobo_words_cc and len(words):
+        book_words = words[0].value
     metadata = {
         "Categories": ["00000000-0000-0000-0000-000000000001", ],
         # "Contributors": get_author(book),

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -149,6 +149,24 @@
         <label for="config_external_port">{{_('Server External Port (for port forwarded API calls)')}}</label>
         <input type="number" min="1" max="65535" class="form-control" name="config_external_port" id="config_external_port" value="{% if config.config_external_port != None %}{{ config.config_external_port }}{% endif %}" autocomplete="off" required>
       </div>
+      <div class="form-group" style="margin-left:10px;">
+        <label for="config_kobo_pages_cc">{{_('Pages Custom Column')}}</label>
+          <select name="config_kobo_pages_cc" id="config_kobo_pages_cc" class="form-control">
+            <option value="0" {% if config.config_kobo_pages_cc == 0 %}selected{% endif %}>{{ _('None') }}</option>
+            {%  for wordsPagesColumn in wordsPagesColumns %}
+            <option value="{{ wordsPagesColumn.id }}" {% if wordsPagesColumn.id == config.config_kobo_pages_cc %}selected{% endif %}>{{ wordsPagesColumn.name }}</option>
+            {% endfor %}
+          </select>
+      </div>
+      <div class="form-group" style="margin-left:10px;">
+        <label for="config_kobo_words_cc">{{_('Words Custom Column')}}</label>
+          <select name="config_kobo_words_cc" id="config_kobo_words_cc" class="form-control">
+            <option value="0" {% if config.config_kobo_words_cc == 0 %}selected{% endif %}>{{ _('None') }}</option>
+            {%  for wordsPagesColumn in wordsPagesColumns %}
+            <option value="{{ wordsPagesColumn.id }}" {% if wordsPagesColumn.id == config.config_kobo_words_cc %}selected{% endif %}>{{ wordsPagesColumn.name }}</option>
+            {% endfor %}
+          </select>
+      </div>
     </div>
     {% endif %}
     {% if feature_support['goodreads'] %}

--- a/messages.pot
+++ b/messages.pot
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-30 15:55+0200\n"
+"POT-Creation-Date: 2025-04-28 12:17-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.15.0\n"
+"Generated-By: Babel 2.17.0\n"
 
 #: cps/about.py:85
 msgid "Statistics"
@@ -51,247 +51,249 @@ msgstr ""
 msgid "Admin page"
 msgstr ""
 
-#: cps/admin.py:253
+#: cps/admin.py:256
 msgid "Basic Configuration"
 msgstr ""
 
-#: cps/admin.py:291
+#: cps/admin.py:294
 msgid "UI Configuration"
 msgstr ""
 
-#: cps/admin.py:315 cps/admin.py:996 cps/db.py:793 cps/search.py:150
+#: cps/admin.py:318 cps/admin.py:999 cps/db.py:793 cps/search.py:150
 #: cps/web.py:753
 #, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
 msgstr ""
 
-#: cps/admin.py:333 cps/templates/admin.html:51
+#: cps/admin.py:336 cps/templates/admin.html:51
 msgid "Edit Users"
 msgstr ""
 
-#: cps/admin.py:377 cps/opds.py:540 cps/templates/grid.html:14
+#: cps/admin.py:380 cps/opds.py:540 cps/templates/grid.html:14
 #: cps/templates/list.html:13
 msgid "All"
 msgstr ""
 
-#: cps/admin.py:401 cps/admin.py:1426
+#: cps/admin.py:404 cps/admin.py:1429
 msgid "User not found"
 msgstr ""
 
-#: cps/admin.py:415
+#: cps/admin.py:418
+#, python-brace-format
 msgid "{} users deleted successfully"
 msgstr ""
 
-#: cps/admin.py:438 cps/templates/config_view_edit.html:133
+#: cps/admin.py:441 cps/templates/config_view_edit.html:133
 #: cps/templates/user_edit.html:45 cps/templates/user_table.html:81
 msgid "Show All"
 msgstr ""
 
-#: cps/admin.py:459 cps/admin.py:465
+#: cps/admin.py:462 cps/admin.py:468
 msgid "Malformed request"
 msgstr ""
 
-#: cps/admin.py:477 cps/admin.py:2069
+#: cps/admin.py:480 cps/admin.py:2074
 msgid "Guest Name can't be changed"
 msgstr ""
 
-#: cps/admin.py:489
+#: cps/admin.py:492
 msgid "Guest can't have this role"
 msgstr ""
 
-#: cps/admin.py:501 cps/admin.py:2023
+#: cps/admin.py:504 cps/admin.py:2028
 msgid "No admin user remaining, can't remove admin role"
 msgstr ""
 
-#: cps/admin.py:505 cps/admin.py:519
+#: cps/admin.py:508 cps/admin.py:522
 msgid "Value has to be true or false"
 msgstr ""
 
-#: cps/admin.py:507
+#: cps/admin.py:510
 msgid "Invalid role"
 msgstr ""
 
-#: cps/admin.py:511
+#: cps/admin.py:514
 msgid "Guest can't have this view"
 msgstr ""
 
-#: cps/admin.py:521
+#: cps/admin.py:524
 msgid "Invalid view"
 msgstr ""
 
-#: cps/admin.py:524
+#: cps/admin.py:527
 msgid "Guest's Locale is determined automatically and can't be set"
 msgstr ""
 
-#: cps/admin.py:528
+#: cps/admin.py:531
 msgid "No Valid Locale Given"
 msgstr ""
 
-#: cps/admin.py:539
+#: cps/admin.py:542
 msgid "No Valid Book Language Given"
 msgstr ""
 
-#: cps/admin.py:541 cps/editbooks.py:292
+#: cps/admin.py:544 cps/editbooks.py:292
 msgid "Parameter not found"
 msgstr ""
 
-#: cps/admin.py:578
+#: cps/admin.py:581
 msgid "Invalid Read Column"
 msgstr ""
 
-#: cps/admin.py:584
+#: cps/admin.py:587
 msgid "Invalid Restricted Column"
 msgstr ""
 
-#: cps/admin.py:604 cps/admin.py:1894
+#: cps/admin.py:607 cps/admin.py:1899
 msgid "Calibre-Web configuration updated"
 msgstr ""
 
-#: cps/admin.py:616
+#: cps/admin.py:619
 msgid "Do you really want to delete the Kobo Token?"
 msgstr ""
 
-#: cps/admin.py:618
+#: cps/admin.py:621
 msgid "Do you really want to delete this domain?"
 msgstr ""
 
-#: cps/admin.py:620
+#: cps/admin.py:623
 msgid "Do you really want to delete this user?"
 msgstr ""
 
-#: cps/admin.py:622
+#: cps/admin.py:625
 msgid "Are you sure you want to delete this shelf?"
 msgstr ""
 
-#: cps/admin.py:624
+#: cps/admin.py:627
 msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr ""
 
-#: cps/admin.py:626
+#: cps/admin.py:629
 msgid "Are you sure you want to change visible book languages for selected user(s)?"
 msgstr ""
 
-#: cps/admin.py:628
+#: cps/admin.py:631
 msgid "Are you sure you want to change the selected role for the selected user(s)?"
 msgstr ""
 
-#: cps/admin.py:630
+#: cps/admin.py:633
 msgid "Are you sure you want to change the selected restrictions for the selected user(s)?"
 msgstr ""
 
-#: cps/admin.py:632
+#: cps/admin.py:635
 msgid "Are you sure you want to change the selected visibility restrictions for the selected user(s)?"
 msgstr ""
 
-#: cps/admin.py:635
+#: cps/admin.py:638
 msgid "Are you sure you want to change shelf sync behavior for the selected user(s)?"
 msgstr ""
 
-#: cps/admin.py:637
+#: cps/admin.py:640
 msgid "Are you sure you want to change Calibre library location?"
 msgstr ""
 
-#: cps/admin.py:639
+#: cps/admin.py:642
 msgid "Calibre-Web will search for updated Covers and update Cover Thumbnails, this may take a while?"
 msgstr ""
 
-#: cps/admin.py:642
+#: cps/admin.py:645
 msgid "Are you sure you want delete Calibre-Web's sync database to force a full sync with your Kobo Reader?"
 msgstr ""
 
-#: cps/admin.py:885 cps/admin.py:891 cps/admin.py:901 cps/admin.py:911
+#: cps/admin.py:888 cps/admin.py:894 cps/admin.py:904 cps/admin.py:914
 #: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
 #: cps/templates/user_table.html:58
 msgid "Deny"
 msgstr ""
 
-#: cps/admin.py:887 cps/admin.py:893 cps/admin.py:903 cps/admin.py:913
+#: cps/admin.py:890 cps/admin.py:896 cps/admin.py:906 cps/admin.py:916
 #: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
 #: cps/templates/user_table.html:61
 msgid "Allow"
 msgstr ""
 
-#: cps/admin.py:946
+#: cps/admin.py:949
+#, python-brace-format
 msgid "{} sync entries deleted"
 msgstr ""
 
-#: cps/admin.py:987
+#: cps/admin.py:990
 msgid "Tag not found"
 msgstr ""
 
-#: cps/admin.py:1005
+#: cps/admin.py:1008
 msgid "Invalid Action"
 msgstr ""
 
-#: cps/admin.py:1132
+#: cps/admin.py:1135
 msgid "client_secrets.json Is Not Configured For Web Application"
 msgstr ""
 
-#: cps/admin.py:1177
+#: cps/admin.py:1180
 msgid "Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:1183
+#: cps/admin.py:1186
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:1217
+#: cps/admin.py:1220
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
 msgstr ""
 
-#: cps/admin.py:1223
+#: cps/admin.py:1226
 msgid "Please Enter a LDAP Service Account and Password"
 msgstr ""
 
-#: cps/admin.py:1226
+#: cps/admin.py:1229
 msgid "Please Enter a LDAP Service Account"
 msgstr ""
 
-#: cps/admin.py:1231
+#: cps/admin.py:1234
 #, python-format
 msgid "LDAP Group Object Filter Needs to Have One \"%s\" Format Identifier"
 msgstr ""
 
-#: cps/admin.py:1233
+#: cps/admin.py:1236
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
 msgstr ""
 
-#: cps/admin.py:1237
+#: cps/admin.py:1240
 #, python-format
 msgid "LDAP User Object Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 
-#: cps/admin.py:1239
+#: cps/admin.py:1242
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
 msgstr ""
 
-#: cps/admin.py:1246
+#: cps/admin.py:1249
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
 msgstr ""
 
-#: cps/admin.py:1248
+#: cps/admin.py:1251
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
 msgstr ""
 
-#: cps/admin.py:1255
+#: cps/admin.py:1258
 msgid "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:1286 cps/templates/admin.html:53
+#: cps/admin.py:1289 cps/templates/admin.html:53
 msgid "Add New User"
 msgstr ""
 
-#: cps/admin.py:1295 cps/templates/admin.html:100
+#: cps/admin.py:1298 cps/templates/admin.html:100
 msgid "Edit Email Server Settings"
 msgstr ""
 
-#: cps/admin.py:1314
+#: cps/admin.py:1317
 msgid "Success! Gmail Account Verified."
 msgstr ""
 
-#: cps/admin.py:1334 cps/admin.py:1337 cps/admin.py:1722 cps/admin.py:1878
-#: cps/admin.py:1976 cps/admin.py:2097 cps/editbooks.py:168
+#: cps/admin.py:1337 cps/admin.py:1340 cps/admin.py:1725 cps/admin.py:1883
+#: cps/admin.py:1981 cps/admin.py:2102 cps/editbooks.py:168
 #: cps/editbooks.py:561 cps/editbooks.py:1256 cps/shelf.py:90 cps/shelf.py:150
 #: cps/shelf.py:193 cps/shelf.py:243 cps/shelf.py:280 cps/shelf.py:354
 #: cps/shelf.py:476 cps/tasks/convert.py:160 cps/web.py:1535
@@ -299,219 +301,220 @@ msgstr ""
 msgid "Oops! Database Error: %(error)s."
 msgstr ""
 
-#: cps/admin.py:1344
+#: cps/admin.py:1347
 #, python-format
 msgid "Test e-mail queued for sending to %(email)s, please check Tasks for result"
 msgstr ""
 
-#: cps/admin.py:1347
+#: cps/admin.py:1350
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
 msgstr ""
 
-#: cps/admin.py:1349
+#: cps/admin.py:1352
 msgid "Please configure your e-mail address first..."
 msgstr ""
 
-#: cps/admin.py:1351
+#: cps/admin.py:1354
 msgid "Email Server Settings updated"
 msgstr ""
 
-#: cps/admin.py:1374 cps/templates/admin.html:195
+#: cps/admin.py:1377 cps/templates/admin.html:195
 msgid "Edit Scheduled Tasks Settings"
 msgstr ""
 
-#: cps/admin.py:1386
+#: cps/admin.py:1389
 msgid "Invalid start time for task specified"
 msgstr ""
 
-#: cps/admin.py:1391
+#: cps/admin.py:1394
 msgid "Invalid duration for task specified"
 msgstr ""
 
-#: cps/admin.py:1401
+#: cps/admin.py:1404
 msgid "Scheduled tasks settings updated"
 msgstr ""
 
-#: cps/admin.py:1411 cps/admin.py:1460 cps/admin.py:2093 cps/web.py:1325
+#: cps/admin.py:1414 cps/admin.py:1463 cps/admin.py:2098 cps/web.py:1325
 msgid "Oops! An unknown error occurred. Please try again later."
 msgstr ""
 
-#: cps/admin.py:1415
+#: cps/admin.py:1418
 msgid "Settings DB is not Writeable"
 msgstr ""
 
-#: cps/admin.py:1445 cps/admin.py:2085
+#: cps/admin.py:1448 cps/admin.py:2090
 #, python-format
 msgid "Edit User %(nick)s"
 msgstr ""
 
-#: cps/admin.py:1457
+#: cps/admin.py:1460
 #, python-format
 msgid "Success! Password for user %(user)s reset"
 msgstr ""
 
-#: cps/admin.py:1463
+#: cps/admin.py:1466
 msgid "Oops! Please configure the SMTP mail settings."
 msgstr ""
 
-#: cps/admin.py:1474
+#: cps/admin.py:1477
 msgid "Logfile viewer"
 msgstr ""
 
-#: cps/admin.py:1540
+#: cps/admin.py:1543
 msgid "Requesting update package"
 msgstr ""
 
-#: cps/admin.py:1541
+#: cps/admin.py:1544
 msgid "Downloading update package"
 msgstr ""
 
-#: cps/admin.py:1542
+#: cps/admin.py:1545
 msgid "Unzipping update package"
 msgstr ""
 
-#: cps/admin.py:1543
+#: cps/admin.py:1546
 msgid "Replacing files"
 msgstr ""
 
-#: cps/admin.py:1544
+#: cps/admin.py:1547
 msgid "Database connections are closed"
 msgstr ""
 
-#: cps/admin.py:1545
+#: cps/admin.py:1548
 msgid "Stopping server"
 msgstr ""
 
-#: cps/admin.py:1546
+#: cps/admin.py:1549
 msgid "Update finished, please press okay and reload page"
 msgstr ""
 
-#: cps/admin.py:1547 cps/admin.py:1548 cps/admin.py:1549 cps/admin.py:1550
-#: cps/admin.py:1551 cps/admin.py:1552
+#: cps/admin.py:1550 cps/admin.py:1551 cps/admin.py:1552 cps/admin.py:1553
+#: cps/admin.py:1554 cps/admin.py:1555
 msgid "Update failed:"
 msgstr ""
 
-#: cps/admin.py:1547 cps/updater.py:391 cps/updater.py:626 cps/updater.py:628
+#: cps/admin.py:1550 cps/updater.py:391 cps/updater.py:626 cps/updater.py:628
 msgid "HTTP Error"
 msgstr ""
 
-#: cps/admin.py:1548 cps/updater.py:393 cps/updater.py:630
+#: cps/admin.py:1551 cps/updater.py:393 cps/updater.py:630
 msgid "Connection error"
 msgstr ""
 
-#: cps/admin.py:1549 cps/updater.py:395 cps/updater.py:632
+#: cps/admin.py:1552 cps/updater.py:395 cps/updater.py:632
 msgid "Timeout while establishing connection"
 msgstr ""
 
-#: cps/admin.py:1550 cps/updater.py:397 cps/updater.py:634
+#: cps/admin.py:1553 cps/updater.py:397 cps/updater.py:634
 msgid "General error"
 msgstr ""
 
-#: cps/admin.py:1551
+#: cps/admin.py:1554
 msgid "Update file could not be saved in temp dir"
 msgstr ""
 
-#: cps/admin.py:1552
+#: cps/admin.py:1555
 msgid "Files could not be replaced during update"
 msgstr ""
 
-#: cps/admin.py:1576
+#: cps/admin.py:1579
 msgid "Failed to extract at least One LDAP User"
 msgstr ""
 
-#: cps/admin.py:1621
+#: cps/admin.py:1624
 msgid "Failed to Create at Least One LDAP User"
 msgstr ""
 
-#: cps/admin.py:1634
+#: cps/admin.py:1637
 #, python-format
 msgid "Error: %(ldaperror)s"
 msgstr ""
 
-#: cps/admin.py:1638
+#: cps/admin.py:1641
 msgid "Error: No user returned in response of LDAP server"
 msgstr ""
 
-#: cps/admin.py:1674
+#: cps/admin.py:1677
 msgid "At Least One LDAP User Not Found in Database"
 msgstr ""
 
-#: cps/admin.py:1676
+#: cps/admin.py:1679
+#, python-brace-format
 msgid "{} User Successfully Imported"
 msgstr ""
 
-#: cps/admin.py:1734
+#: cps/admin.py:1737
 msgid "Books path not valid"
 msgstr ""
 
-#: cps/admin.py:1740
+#: cps/admin.py:1743
 msgid "DB Location is not Valid, Please Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:1768
+#: cps/admin.py:1771
 msgid "DB is not Writeable"
 msgstr ""
 
-#: cps/admin.py:1782
+#: cps/admin.py:1785
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:1786
+#: cps/admin.py:1789
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
 msgstr ""
 
-#: cps/admin.py:1863
+#: cps/admin.py:1868
 msgid "Password length has to be between 1 and 40"
 msgstr ""
 
-#: cps/admin.py:1917
+#: cps/admin.py:1922
 msgid "Database Settings updated"
 msgstr ""
 
-#: cps/admin.py:1925
+#: cps/admin.py:1930
 msgid "Database Configuration"
 msgstr ""
 
-#: cps/admin.py:1940 cps/web.py:1299
+#: cps/admin.py:1945 cps/web.py:1299
 msgid "Oops! Please complete all fields."
 msgstr ""
 
-#: cps/admin.py:1949
+#: cps/admin.py:1954
 msgid "E-mail is not from valid domain"
 msgstr ""
 
-#: cps/admin.py:1955
+#: cps/admin.py:1960
 msgid "Add new user"
 msgstr ""
 
-#: cps/admin.py:1966
+#: cps/admin.py:1971
 #, python-format
 msgid "User '%(user)s' created"
 msgstr ""
 
-#: cps/admin.py:1972
+#: cps/admin.py:1977
 msgid "Oops! An account already exists for this Email. or name."
 msgstr ""
 
-#: cps/admin.py:2002
+#: cps/admin.py:2007
 #, python-format
 msgid "User '%(nick)s' deleted"
 msgstr ""
 
-#: cps/admin.py:2005
+#: cps/admin.py:2010
 msgid "Can't delete Guest User"
 msgstr ""
 
-#: cps/admin.py:2008
+#: cps/admin.py:2013
 msgid "No admin user remaining, can't delete user"
 msgstr ""
 
-#: cps/admin.py:2063 cps/web.py:1484
+#: cps/admin.py:2068 cps/web.py:1484
 msgid "Email can't be empty and has to be a valid Email"
 msgstr ""
 
-#: cps/admin.py:2089
+#: cps/admin.py:2094
 #, python-format
 msgid "User '%(nick)s' updated"
 msgstr ""
@@ -532,7 +535,8 @@ msgstr ""
 msgid "Execution permissions missing"
 msgstr ""
 
-#: cps/db.py:1038 cps/templates/config_edit.html:203
+#: cps/db.py:1038 cps/templates/config_edit.html:155
+#: cps/templates/config_edit.html:164 cps/templates/config_edit.html:221
 #: cps/templates/config_view_edit.html:62 cps/templates/email_edit.html:41
 #: cps/web.py:568 cps/web.py:602 cps/web.py:647 cps/web.py:687 cps/web.py:714
 #: cps/web.py:995 cps/web.py:1025 cps/web.py:1070 cps/web.py:1098
@@ -582,6 +586,7 @@ msgid "Metadata successfully updated"
 msgstr ""
 
 #: cps/editbooks.py:566
+#, python-brace-format
 msgid "Error editing book: {}"
 msgstr ""
 
@@ -665,12 +670,12 @@ msgstr ""
 msgid "%(format)s format not found for book id: %(book)d"
 msgstr ""
 
-#: cps/helper.py:94 cps/tasks/convert.py:93
+#: cps/helper.py:93 cps/tasks/convert.py:91
 #, python-format
 msgid "%(format)s not found on Google Drive: %(fn)s"
 msgstr ""
 
-#: cps/helper.py:99
+#: cps/helper.py:98
 #, python-format
 msgid "%(format)s not found: %(fn)s"
 msgstr ""
@@ -720,6 +725,7 @@ msgid "The requested file could not be read. Maybe wrong permissions?"
 msgstr ""
 
 #: cps/helper.py:352
+#, python-brace-format
 msgid "Read status could not set: {}"
 msgstr ""
 
@@ -738,7 +744,7 @@ msgstr ""
 msgid "Deleting book %(id)s from database only, book path in database not valid: %(path)s"
 msgstr ""
 
-#: cps/helper.py:439
+#: cps/helper.py:438
 #, python-format
 msgid "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
@@ -748,7 +754,7 @@ msgstr ""
 msgid "File %(file)s not found on Google Drive"
 msgstr ""
 
-#: cps/helper.py:559
+#: cps/helper.py:558
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
 msgstr ""
@@ -915,6 +921,7 @@ msgid "GitHub Oauth error, please retry later."
 msgstr ""
 
 #: cps/oauth_bb.py:338
+#, python-brace-format
 msgid "GitHub Oauth error: {}"
 msgstr ""
 
@@ -923,10 +930,12 @@ msgid "Google Oauth error, please retry later."
 msgstr ""
 
 #: cps/oauth_bb.py:362
+#, python-brace-format
 msgid "Google Oauth error: {}"
 msgstr ""
 
 #: cps/opds.py:299
+#, python-brace-format
 msgid "{} Stars"
 msgstr ""
 
@@ -1272,7 +1281,7 @@ msgstr ""
 msgid "No update available. You already have the latest version installed"
 msgstr ""
 
-#: cps/updater.py:458
+#: cps/updater.py:459
 msgid "A new update is available. Click on the button below to update to the latest version."
 msgstr ""
 
@@ -1280,7 +1289,7 @@ msgstr ""
 msgid "Could not fetch update information"
 msgstr ""
 
-#: cps/updater.py:486
+#: cps/updater.py:487
 msgid "Click on the button below to update to the latest stable version."
 msgstr ""
 
@@ -1491,7 +1500,7 @@ msgstr ""
 msgid "Kepubify-converter failed: %(error)s"
 msgstr ""
 
-#: cps/tasks/convert.py:255
+#: cps/tasks/convert.py:254
 #, python-format
 msgid "Converted file not found or more than one file in folder %(folder)s"
 msgstr ""
@@ -1533,6 +1542,7 @@ msgid "Cover Thumbnails"
 msgstr ""
 
 #: cps/tasks/thumbnail.py:294
+#, python-brace-format
 msgid "Generated {0} series thumbnails"
 msgstr ""
 
@@ -1681,7 +1691,7 @@ msgstr ""
 msgid "Reverse Proxy Login"
 msgstr ""
 
-#: cps/templates/admin.html:154 cps/templates/config_edit.html:172
+#: cps/templates/admin.html:154 cps/templates/config_edit.html:190
 msgid "Reverse Proxy Header Name"
 msgstr ""
 
@@ -1786,7 +1796,7 @@ msgstr ""
 
 #: cps/templates/admin.html:259 cps/templates/admin.html:273
 #: cps/templates/book_edit.html:220 cps/templates/book_table.html:127
-#: cps/templates/config_db.html:66 cps/templates/config_edit.html:427
+#: cps/templates/config_db.html:66 cps/templates/config_edit.html:445
 #: cps/templates/config_view_edit.html:175 cps/templates/detail.html:350
 #: cps/templates/modal_dialogs.html:64 cps/templates/modal_dialogs.html:99
 #: cps/templates/modal_dialogs.html:117 cps/templates/modal_dialogs.html:135
@@ -2040,7 +2050,7 @@ msgid "Fetch Metadata"
 msgstr ""
 
 #: cps/templates/book_edit.html:219 cps/templates/config_db.html:65
-#: cps/templates/config_edit.html:426 cps/templates/config_view_edit.html:174
+#: cps/templates/config_edit.html:444 cps/templates/config_view_edit.html:174
 #: cps/templates/email_edit.html:65 cps/templates/schedule_edit.html:44
 #: cps/templates/shelf_edit.html:25 cps/templates/shelf_order.html:41
 #: cps/templates/user_edit.html:142
@@ -2326,226 +2336,234 @@ msgstr ""
 msgid "Server External Port (for port forwarded API calls)"
 msgstr ""
 
-#: cps/templates/config_edit.html:157
+#: cps/templates/config_edit.html:153
+msgid "Pages Custom Column"
+msgstr ""
+
+#: cps/templates/config_edit.html:162
+msgid "Words Custom Column"
+msgstr ""
+
+#: cps/templates/config_edit.html:175
 msgid "Use Goodreads"
 msgstr ""
 
-#: cps/templates/config_edit.html:161
+#: cps/templates/config_edit.html:179
 msgid "Goodreads API Key"
 msgstr ""
 
-#: cps/templates/config_edit.html:168
+#: cps/templates/config_edit.html:186
 msgid "Allow Reverse Proxy Authentication"
 msgstr ""
 
-#: cps/templates/config_edit.html:179
+#: cps/templates/config_edit.html:197
 msgid "Login type"
 msgstr ""
 
-#: cps/templates/config_edit.html:181
+#: cps/templates/config_edit.html:199
 msgid "Use Standard Authentication"
 msgstr ""
 
-#: cps/templates/config_edit.html:183
+#: cps/templates/config_edit.html:201
 msgid "Use LDAP Authentication"
 msgstr ""
 
-#: cps/templates/config_edit.html:186
+#: cps/templates/config_edit.html:204
 msgid "Use OAuth"
 msgstr ""
 
-#: cps/templates/config_edit.html:193
+#: cps/templates/config_edit.html:211
 msgid "LDAP Server Host Name or IP Address"
 msgstr ""
 
-#: cps/templates/config_edit.html:197
+#: cps/templates/config_edit.html:215
 msgid "LDAP Server Port"
 msgstr ""
 
-#: cps/templates/config_edit.html:201
+#: cps/templates/config_edit.html:219
 msgid "LDAP Encryption"
 msgstr ""
 
-#: cps/templates/config_edit.html:204
+#: cps/templates/config_edit.html:222
 msgid "TLS"
 msgstr ""
 
-#: cps/templates/config_edit.html:205
+#: cps/templates/config_edit.html:223
 msgid "SSL"
 msgstr ""
 
-#: cps/templates/config_edit.html:209
+#: cps/templates/config_edit.html:227
 msgid "LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 
-#: cps/templates/config_edit.html:216
+#: cps/templates/config_edit.html:234
 msgid "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 
-#: cps/templates/config_edit.html:223
+#: cps/templates/config_edit.html:241
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
 msgstr ""
 
-#: cps/templates/config_edit.html:232
+#: cps/templates/config_edit.html:250
 msgid "LDAP Authentication"
 msgstr ""
 
-#: cps/templates/config_edit.html:234
+#: cps/templates/config_edit.html:252
 msgid "Anonymous"
 msgstr ""
 
-#: cps/templates/config_edit.html:235
+#: cps/templates/config_edit.html:253
 msgid "Unauthenticated"
 msgstr ""
 
-#: cps/templates/config_edit.html:236
+#: cps/templates/config_edit.html:254
 msgid "Simple"
 msgstr ""
 
-#: cps/templates/config_edit.html:241
+#: cps/templates/config_edit.html:259
 msgid "LDAP Administrator Username"
 msgstr ""
 
-#: cps/templates/config_edit.html:247
+#: cps/templates/config_edit.html:265
 msgid "LDAP Administrator Password"
 msgstr ""
 
-#: cps/templates/config_edit.html:252
+#: cps/templates/config_edit.html:270
 msgid "LDAP Distinguished Name (DN)"
 msgstr ""
 
-#: cps/templates/config_edit.html:256
+#: cps/templates/config_edit.html:274
 msgid "LDAP User Object Filter"
 msgstr ""
 
-#: cps/templates/config_edit.html:261
+#: cps/templates/config_edit.html:279
 msgid "LDAP Server is OpenLDAP?"
 msgstr ""
 
-#: cps/templates/config_edit.html:263
+#: cps/templates/config_edit.html:281
 msgid "Following Settings are Needed For User Import"
 msgstr ""
 
-#: cps/templates/config_edit.html:265
+#: cps/templates/config_edit.html:283
 msgid "LDAP Group Object Filter"
 msgstr ""
 
-#: cps/templates/config_edit.html:269
+#: cps/templates/config_edit.html:287
 msgid "LDAP Group Name"
 msgstr ""
 
-#: cps/templates/config_edit.html:273
+#: cps/templates/config_edit.html:291
 msgid "LDAP Group Members Field"
 msgstr ""
 
-#: cps/templates/config_edit.html:277
+#: cps/templates/config_edit.html:295
 msgid "LDAP Member User Filter Detection"
 msgstr ""
 
-#: cps/templates/config_edit.html:279
+#: cps/templates/config_edit.html:297
 msgid "Autodetect"
 msgstr ""
 
-#: cps/templates/config_edit.html:280
+#: cps/templates/config_edit.html:298
 msgid "Custom Filter"
 msgstr ""
 
-#: cps/templates/config_edit.html:285
+#: cps/templates/config_edit.html:303
 msgid "LDAP Member User Filter"
 msgstr ""
 
-#: cps/templates/config_edit.html:296
+#: cps/templates/config_edit.html:314
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
 msgstr ""
 
-#: cps/templates/config_edit.html:299
+#: cps/templates/config_edit.html:317
 #, python-format
 msgid "%(provider)s OAuth Client Id"
 msgstr ""
 
-#: cps/templates/config_edit.html:303
+#: cps/templates/config_edit.html:321
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
 msgstr ""
 
-#: cps/templates/config_edit.html:319
+#: cps/templates/config_edit.html:337
 msgid "External binaries"
 msgstr ""
 
-#: cps/templates/config_edit.html:325
+#: cps/templates/config_edit.html:343
 msgid "Path to Calibre Binaries"
 msgstr ""
 
-#: cps/templates/config_edit.html:333
+#: cps/templates/config_edit.html:351
 msgid "Calibre E-Book Converter Settings"
 msgstr ""
 
-#: cps/templates/config_edit.html:336
+#: cps/templates/config_edit.html:354
 msgid "Path to Kepubify E-Book Converter"
 msgstr ""
 
-#: cps/templates/config_edit.html:344
+#: cps/templates/config_edit.html:362
 msgid "Location of Unrar binary"
 msgstr ""
 
-#: cps/templates/config_edit.html:360
+#: cps/templates/config_edit.html:378
 msgid "Security Settings"
 msgstr ""
 
-#: cps/templates/config_edit.html:368
+#: cps/templates/config_edit.html:386
 msgid "Limit failed login attempts"
 msgstr ""
 
-#: cps/templates/config_edit.html:372
+#: cps/templates/config_edit.html:390
 msgid "Configure Backend for Limiter"
 msgstr ""
 
-#: cps/templates/config_edit.html:376
+#: cps/templates/config_edit.html:394
 msgid "Options for Limiter Backend"
 msgstr ""
 
-#: cps/templates/config_edit.html:382
+#: cps/templates/config_edit.html:400
 msgid "Check if file extensions matches file content on upload"
 msgstr ""
 
-#: cps/templates/config_edit.html:385
+#: cps/templates/config_edit.html:403
 msgid "Session protection"
 msgstr ""
 
-#: cps/templates/config_edit.html:387
+#: cps/templates/config_edit.html:405
 msgid "Basic"
 msgstr ""
 
-#: cps/templates/config_edit.html:388
+#: cps/templates/config_edit.html:406
 msgid "Strong"
 msgstr ""
 
-#: cps/templates/config_edit.html:393
+#: cps/templates/config_edit.html:411
 msgid "User Password policy"
 msgstr ""
 
-#: cps/templates/config_edit.html:397
+#: cps/templates/config_edit.html:415
 msgid "Minimum password length"
 msgstr ""
 
-#: cps/templates/config_edit.html:402
+#: cps/templates/config_edit.html:420
 msgid "Enforce number"
 msgstr ""
 
-#: cps/templates/config_edit.html:406
+#: cps/templates/config_edit.html:424
 msgid "Enforce lowercase characters"
 msgstr ""
 
-#: cps/templates/config_edit.html:410
+#: cps/templates/config_edit.html:428
 msgid "Enforce uppercase characters"
 msgstr ""
 
-#: cps/templates/config_edit.html:414
+#: cps/templates/config_edit.html:432
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
 msgstr ""
 
-#: cps/templates/config_edit.html:418
+#: cps/templates/config_edit.html:436
 msgid "Enforce special characters"
 msgstr ""
 


### PR DESCRIPTION
Kobo devices can show the ISBN, word count, and page count on the "details" tab of the "view details" book page.

This change syncs the ISBN from the ISBN identifier to this field, and allows the user to link custom columns to the pages and word count fields.