### PR TITLE
Fix: Settings Modal Not Displaying Correctly on Mobile EPUB View

### DIFF
--- a/cps/static/css/main.css
+++ b/cps/static/css/main.css
@@ -511,12 +511,12 @@ input:-moz-placeholder { color: #454545; }
   position: fixed;
   top: 50%;
   left: 50%;
-  width: 630px;
+  transform: translate(-50%, -50%);
+  width: 100vw;
   height: auto;
+  max-width: 630px;
   z-index: 2000;
   visibility: hidden;
-  margin-left: -320px;
-  margin-top: -160px;
 }
 
 .overlay {


### PR DESCRIPTION
When opening an EPUB file on mobile devices, the settings modal did not display correctly. The modal was either not responsive, misaligned, or partially hidden, affecting the user experience.

How to reproduce:
1. Use a smartphone or smartphone view from the dev tools of your browser
2. Open an epub! 
3. Press settings on the top right corner.

Screenshot before the fix:  
<div align="center">
  <img src="https://github.com/user-attachments/assets/bf257477-8c03-4582-8b15-a84be9412589" width="300" />
</div>

Screenshot after the fix:  
<div align="center">
  <img src="https://github.com/user-attachments/assets/9301ab4a-8779-445a-99b1-6cf7ebc5bb2b" width="300" />
</div>