### PR TITLE
Rename CACHE_DIR env var to CACHE_DIRECTORY (#3343)

### DIFF
--- a/cps/constants.py
+++ b/cps/constants.py
@@ -37,9 +37,12 @@ STATIC_DIR          = os.path.join(BASE_DIR, 'cps', 'static')
 TEMPLATES_DIR       = os.path.join(BASE_DIR, 'cps', 'templates')
 TRANSLATIONS_DIR    = os.path.join(BASE_DIR, 'cps', 'translations')
 
-# Cache dir - use CACHE_DIR environment variable, otherwise use the default directory: cps/cache
+# Cache dir - use CACHE_DIRECTORY environment variable, otherwise CACHE_DIR (for backwards compatibility),
+# otherwise use the default directory: cps/cache
 DEFAULT_CACHE_DIR   = os.path.join(BASE_DIR, 'cps', 'cache')
-CACHE_DIR           = os.environ.get('CACHE_DIR', DEFAULT_CACHE_DIR)
+CACHE_DIRECTORY = os.environ.get(
+    'CACHE_DIRECTORY', os.environ.get('CACHE_DIR', DEFAULT_CACHE_DIR)
+)
 
 if HOME_CONFIG:
     home_dir = os.path.join(os.path.expanduser("~"), ".calibre-web")

--- a/cps/fs.py
+++ b/cps/fs.py
@@ -17,7 +17,7 @@
 #   along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 from . import logger
-from .constants import CACHE_DIR
+from .constants import CACHE_DIRECTORY
 from os import makedirs, remove
 from os.path import isdir, isfile, join
 from shutil import rmtree
@@ -25,7 +25,7 @@ from shutil import rmtree
 
 class FileSystem:
     _instance = None
-    _cache_dir = CACHE_DIR
+    _cache_dir = CACHE_DIRECTORY
 
     def __new__(cls):
         if cls._instance is None:


### PR DESCRIPTION
This renames the `CACHE_DIR` environment variable to `CACHE_DIRECTORY`, but provides fallback to `CACHE_DIR` if `CACHE_DIRECTORY` is unset. See #3343 for context.