### PR TITLE
hide desktop navbar when in mobile resolution

### DIFF
--- a/cps/static/css/caliBlur_override.css
+++ b/cps/static/css/caliBlur_override.css
@@ -26,3 +26,9 @@ body.serieslist.grid-view div.container-fluid > div > div.col-sm-10::before {
 input.datepicker {color: transparent}
 input.datepicker:focus {color: transparent}
 input.datepicker:focus + input {color: #555}
+
+@media only screen and (max-width: 767px) {
+        .row-fluid > .col-sm-2 {
+        visibility: hidden;
+    }
+}


### PR DESCRIPTION
this hides the navbar in mobile resolution before it is moved to the collapsed sidebar to prevent this effect:
![image](https://github.com/user-attachments/assets/891e2710-4658-44c7-a3f2-c7a851712b08)
