### PR TITLE
change initial mobile book layout to reduce UI updates

### DIFF
--- a/cps/static/css/caliBlur_override.css
+++ b/cps/static/css/caliBlur_override.css
@@ -26,3 +26,8 @@ body.serieslist.grid-view div.container-fluid > div > div.col-sm-10::before {
 input.datepicker {color: transparent}
 input.datepicker:focus {color: transparent}
 input.datepicker:focus + input {color: #555}
+
+.col-sm-3.col-lg-2.col-xs-6.book.session {
+    margin-left: 0;
+    margin-right: 0;
+}


### PR DESCRIPTION
this css change prevents the book table to shift the book icons once isotope is done ordering them which leads to less visible UI updates.
the last row now starts like this:
![image](https://github.com/user-attachments/assets/9239192d-d927-4bb6-b19c-8cbc291ca5f4)
and not like this:
![image](https://github.com/user-attachments/assets/d02730e4-7847-47b0-a1b9-84ea17bc7c86)
