### PR TITLE
Feature: keep c-w shelves in sync with calibre collections

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -947,10 +947,7 @@ def ajax_fullsync(userid):
 def ajax_self_synccollections():
     t = TaskSyncShelves()
     msg = t.sync()
-    return Response(
-        json.dumps([{"type": "success", "message": msg}]),
-        mimetype='application/json',
-    )
+    return make_response(jsonify(type="success", message=msg))
 
 
 
@@ -960,10 +957,7 @@ def ajax_self_synccollections():
 def ajax_synccollections(userid):
     t = TaskSyncShelves()
     msg = t.sync()
-    return Response(
-        json.dumps([{"type": "success", "message": msg}]),
-        mimetype='application/json',
-    )
+    return make_response(jsonify(type="success", message=msg))
 
 
 @admi.route("/ajax/pathchooser/")

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -110,6 +110,7 @@ class _Settings(_Base):
     config_restricted_column = Column(SmallInteger, default=0)
     config_denied_column_value = Column(String, default="")
     config_allowed_column_value = Column(String, default="")
+    config_sync_from_collections = Column(Boolean, default=False)
 
     config_use_google_drive = Column(Boolean, default=False)
     config_google_drive_folder = Column(String)
@@ -160,6 +161,7 @@ class _Settings(_Base):
     schedule_generate_series_covers = Column(Boolean, default=False)
     schedule_reconnect = Column(Boolean, default=False)
     schedule_metadata_backup = Column(Boolean, default=False)
+    schedule_sync_shelves = Column(Boolean, default=False)
 
     config_password_policy = Column(Boolean, default=True)
     config_password_min_length = Column(Integer, default=8)

--- a/cps/schedule.py
+++ b/cps/schedule.py
@@ -25,6 +25,7 @@ from .tasks.clean import TaskClean
 from .tasks.thumbnail import TaskGenerateCoverThumbnails, TaskGenerateSeriesThumbnails, TaskClearCoverThumbnailCache
 from .services.worker import WorkerThread
 from .tasks.metadata_backup import TaskBackupMetadata
+from .tasks.shelfsync import TaskSyncShelves
 
 def get_scheduled_tasks(reconnect=True):
     tasks = list()
@@ -47,6 +48,10 @@ def get_scheduled_tasks(reconnect=True):
     # Generate all missing series thumbnails
     if config.schedule_generate_series_covers:
         tasks.append([lambda: TaskGenerateSeriesThumbnails(), 'generate book covers', False])
+
+    # Sync shelves to collections (one-way)
+    if config.schedule_sync_shelves:
+        tasks.append([lambda: TaskSyncShelves(), 'sync shelves', False])
 
     return tasks
 

--- a/cps/static/js/main.js
+++ b/cps/static/js/main.js
@@ -692,6 +692,36 @@ $(function() {
         );
     });
 
+    $("#sync_collections_now").click(function() {
+        confirmDialog(
+            "btn_sync_collections",
+            "GeneralChangeModal",
+            0,
+            function (userid) {
+                if (userid) {
+                    path = getPath() + "/ajax/synccollections/" + userid
+                }
+                else {
+                    path = getPath() + "/ajax/synccollections"
+                }
+                $.ajax({
+                    method:"post",
+                    url: path,
+                    timeout: 900,
+                    success:function(data) {
+                        data.forEach(function(item) {
+                            if (!jQuery.isEmptyObject(item)) {
+                                $( ".navbar" ).after( '<div class="row-fluid text-center" >' +
+                                    '<div id="flash_'+item.type+'" class="alert alert-'+item.type+'">'+item.message+'</div>' +
+                                    '</div>');
+                            }
+                        });
+                    }
+                });
+            }
+        );
+    });
+
     $("#user_submit").click(function() {
         this.closest("form").submit();
     });

--- a/cps/tasks/shelfsync.py
+++ b/cps/tasks/shelfsync.py
@@ -22,14 +22,14 @@ from datetime import datetime, timezone
 from flask_babel import lazy_gettext as N_
 from sqlalchemy.exc import InvalidRequestError, OperationalError
 
-from cps import config, logger, db, ub
+from cps import config, logger, db, ub, app
 from cps.services.worker import CalibreTask
 
 class TaskSyncShelves(CalibreTask):
     def __init__(self, task_message=N_('Syncing shelves and collections')):
         super(TaskSyncShelves, self).__init__(task_message)
         self.log = logger.create()
-        self.cdb = db.CalibreDB(expire_on_commit=False, init=True)
+        self.cdb = db.CalibreDB(app)
 
     def run(self, worker_thread):
         self.log.info(f'Running {self.__class__.__name__}')

--- a/cps/tasks/shelfsync.py
+++ b/cps/tasks/shelfsync.py
@@ -1,0 +1,195 @@
+# -*- coding: utf-8 -*-
+# vim: ts=4 et
+
+#   This file is part of the Calibre-Web (https://github.com/janeczku/calibre-web)
+#     Copyright (C) 2020 mmonkey
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+from datetime import datetime, timezone
+
+from flask_babel import lazy_gettext as N_
+from sqlalchemy.exc import InvalidRequestError, OperationalError
+
+from cps import config, logger, db, ub
+from cps.services.worker import CalibreTask
+
+class TaskSyncShelves(CalibreTask):
+    def __init__(self, task_message=N_('Syncing shelves and collections')):
+        super(TaskSyncShelves, self).__init__(task_message)
+        self.log = logger.create()
+        self.cdb = db.CalibreDB(expire_on_commit=False, init=True)
+
+    def run(self, worker_thread):
+        self.log.info(f'Running {self.__class__.__name__}')
+        try:
+            self.sync()
+        except:
+            self.log.error_or_exception(ex)
+        return self._handleSuccess()
+
+    def info(self, *args, **kwargs):
+        args = ('SyncShelves: ' + args[0],) + args[1:]
+        self.log.info(*args, **kwargs)
+
+    def sync(self):
+        # Find which custom column holds collections
+        collcc = (
+                self.cdb.session.query(db.CustomColumns)
+                .filter(db.CustomColumns.label == 'collections')
+        ).first()
+
+        # Get the db table object and build the cc field name
+        colldb = db.cc_classes[collcc.id]
+        collfield = f'custom_column_{collcc.id}'
+
+        # debug
+        self.info(f'shelfsync {collcc.id}')
+        self.info(f'{colldb}, {collfield}')
+
+        # Find calibre books with collections assigned,
+        books = (
+                self.cdb.session.query(db.Books)
+                .order_by(db.Books.id.desc())
+        ).all()
+
+        # For each collection, build a list of bookids in that collection
+        cContents = {}
+        cAllBooks = [book.id for book in books]
+        for book in books:
+            bookcolls = getattr(book, collfield)
+            for coll in bookcolls:
+                if coll.value in cContents:
+                    cContents[coll.value].append(book.id)
+                else:
+                    cContents[coll.value] = [book.id]
+
+        # Loop over users, skipping users who have not enabled shelf sync.
+        # The rest of the sync activity occurs in this scope.
+        for user in ub.session.query(ub.User):
+            if user.sync_from_collections != 'on':
+                continue
+
+            # Get contents of this user's shelves
+            shelves = {}
+            sContents = {}
+
+            # There's probably a smarter way to do this with a join,
+            # but I don't really know sqlalchemy and right now I just
+            # want this to work.
+            for shelf in ub.session.query(ub.Shelf).filter(ub.Shelf.user_id == user.id):
+                books = (
+                        ub.session.query(ub.BookShelf)
+                        .filter(ub.BookShelf.shelf == shelf.id)
+                        .all()
+                )
+                # Create a list of bookids in each shelf
+                sContents[shelf.name] = [
+                    book.book_id
+                    for book in books
+                ]
+                # Update the mapping of shelf names to shelf objects
+                shelves[shelf.name] = shelf
+
+            # Loop over collection names.
+            # N.B. We intentionally do not loop over shelves that currently
+            # are not collections.
+            for name in cContents.keys():
+                name = str(name)
+
+                # If collection name not in shelves, create new shelf
+                if name not in sContents:
+                    self.info(f'Creating new shelf {name}')
+                    shelf = self.createShelf(name, user)
+                    # add to sContents{}
+                    sContents[name] = []
+                    shelves[name] = shelf
+
+                # Loop over books in collection/shelf, adding/removing as needed
+                self.info(f'collection {name}: {len(cContents[name])} {cContents[name]}')
+                self.info(f'shelf {name}: {len(sContents[name])} {sContents[name]}')
+                ctmp = set(cContents[name])
+                stmp = set(sContents[name])
+                toAdd = ctmp - stmp
+                toRemove = stmp - ctmp
+
+                # adds
+                for bookid in toAdd:
+                    self.info(f'adding {bookid} from collection to shelf {name}')
+                    self.addToShelf(shelves[name], bookid)
+
+                # removes
+                for bookid in toRemove:
+                    self.info(f'removing {bookid} from shelf {name}')
+                    self.removeFromShelf(shelves[name], bookid)
+
+        self.info(f'end shelfsync')
+
+    def createShelf(self, name, user):
+        shelf = ub.Shelf()
+        shelf.name = name
+
+        # flag it to sync
+        shelf.kobo_sync = config.config_kobo_sync
+
+        # make it private to this user
+        shelf.is_public = False
+        shelf.user_id = int(user.id)
+
+        ub.session.add(shelf)
+
+        try:
+            ub.session.commit()
+            self.info(f'shelf created: {name}')
+            return shelf
+        except (OperationalError, InvalidRequestError) as exc:
+            ub.session.rollback()
+            raise
+
+    def addToShelf(self, shelf, bookid):
+        shelf.books.append(ub.BookShelf(shelf=shelf.id, book_id=bookid))
+        shelf.last_modified = datetime.now(timezone.utc)
+        try:
+            ub.session.merge(shelf)
+            ub.session.commit()
+        except (OperationalError, InvalidRequestError) as e:
+            ub.session.rollback()
+            log.error_or_exception("Settings Database error: {}".format(e))
+
+    def removeFromShelf(self, shelf, bookid):
+        link = (
+            ub.session.query(ub.BookShelf)
+            .filter(ub.BookShelf.shelf == shelf.id,
+                    ub.BookShelf.book_id == bookid)
+        ).first()
+
+        if link is None:
+            log.error("Book %s already removed from %s", book_id, shelf)
+            return
+
+        try:
+            ub.session.delete(link)
+            shelf.last_modified = datetime.now(timezone.utc)
+            ub.session.commit()
+        except (OperationalError, InvalidRequestError) as e:
+            ub.session.rollback()
+            log.error_or_exception("Settings Database error: {}".format(e))
+
+    @property
+    def name(self):
+        return "Sync shelves and collections"
+
+    @property
+    def is_cancellable(self):
+        return False

--- a/cps/tasks/shelfsync.py
+++ b/cps/tasks/shelfsync.py
@@ -34,9 +34,10 @@ class TaskSyncShelves(CalibreTask):
     def run(self, worker_thread):
         self.log.info(f'Running {self.__class__.__name__}')
         try:
-            self.sync()
-        except:
-            self.log.error_or_exception(ex)
+            with app.app_context():
+                self.sync()
+        except Exception as exc:
+            self.log.error_or_exception(exc)
         return self._handleSuccess()
 
     def info(self, *args, **kwargs):
@@ -55,8 +56,8 @@ class TaskSyncShelves(CalibreTask):
         collfield = f'custom_column_{collcc.id}'
 
         # debug
-        self.info(f'shelfsync {collcc.id}')
-        self.info(f'{colldb}, {collfield}')
+        #self.info(f'shelfsync {collcc.id}')
+        #self.info(f'{colldb}, {collfield}')
 
         # Find calibre books with collections assigned,
         books = (

--- a/cps/templates/admin.html
+++ b/cps/templates/admin.html
@@ -190,6 +190,10 @@
             <div class="col-xs-6 col-sm-3">{{_('Generate Metadata Backup Files')}}</div>
             <div class="col-xs-6 col-sm-3">{{ display_bool_setting(config.schedule_metadata_backup) }}</div>
           </div>
+          <div class="row">
+            <div class="col-xs-6 col-sm-3">{{_('Sync Shelves and Collections')}}</div>
+            <div class="col-xs-6 col-sm-3">{{ display_bool_setting(config.schedule_sync_shelves) }}</div>
+          </div>
 
         </div>
       <a class="btn btn-default scheduledtasks" id="admin_edit_scheduled_tasks" href="{{url_for('admin.edit_scheduledtasks')}}">{{_('Edit Scheduled Tasks Settings')}}</a>

--- a/cps/templates/schedule_edit.html
+++ b/cps/templates/schedule_edit.html
@@ -40,6 +40,10 @@
       <input type="checkbox" id="schedule_metadata_backup" name="schedule_metadata_backup" {% if config.schedule_metadata_backup %}checked{% endif %}>
       <label for="schedule_metadata_backup">{{_('Generate Metadata Backup Files')}}</label>
     </div>
+    <div class="form-group">
+      <input type="checkbox" id="schedule_metadata_backup" name="schedule_sync_shelves" {% if config.schedule_sync_shelves %}checked{% endif %}>
+      <label for="schedule_sync_shelves">{{_('Sync Shelves and Collections')}}</label>
+    </div>
 
     <button type="submit" name="submit" value="submit" class="btn btn-default">{{_('Save')}}</button>
     <a href="{{ url_for('admin.admin') }}" id="email_back" class="btn btn-default">{{_('Cancel')}}</a>

--- a/cps/templates/user_edit.html
+++ b/cps/templates/user_edit.html
@@ -86,6 +86,7 @@
       {% if ( current_user and current_user.role_admin() and not new_user ) and not simple %}
       <a href="#" id="get_user_tags" class="btn btn-default" data-id="{{content.id}}" data-toggle="modal" data-target="#restrictModal">{{_('Add Allowed/Denied Tags')}}</a>
       <a href="#" id="get_user_column_values" data-id="{{content.id}}" class="btn btn-default" data-toggle="modal" data-target="#restrictModal">{{_('Add allowed/Denied Custom Column Values')}}</a>
+      <div class="btn btn-default" id="sync_collections_now" data-value="{{ content.id }}">{{_('Sync collections now')}}</div>
       {% endif %}
     </div>
       <div class="col-sm-6">
@@ -137,6 +138,10 @@
       <label for="kobo_only_shelves_sync">{{_('Sync only books in selected shelves with Kobo')}}</label>
     </div>
     {% endif %}
+    <div class="form-group">
+      <input type="checkbox" name="sync_from_collections" id="sync_from_collections" {% if content.sync_from_collections %}checked{% endif %}>
+      <label for="sync_from_collections">{{_('Sync shelves from Calibre collections (requires scheduled task)')}}</label>
+    </div>
     </div>
     <div class="col-sm-12">
       <div id="user_submit" class="btn btn-default">{{_('Save')}}</div>
@@ -170,6 +175,7 @@
 {% block modal %}
 {{ restrict_modal() }}
 {{ delete_confirm_modal() }}
+{{ change_confirm_modal() }}
 {% endblock %}
 {% block js %}
 <script src="{{ url_for('static', filename='js/libs/bootstrap-table/bootstrap-table.min.js') }}"></script>

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -257,6 +257,7 @@ class User(UserBase, Base):
     remote_auth_token = relationship('RemoteAuthToken', backref='user', lazy='dynamic')
     view_settings = Column(JSON, default={})
     kobo_only_shelves_sync = Column(Integer, default=0)
+    sync_from_collections = Column(Integer, default=0)
 
 
 if oauth_support:
@@ -281,6 +282,7 @@ class OAuthProvider(Base):
 class Anonymous(AnonymousUserMixin, UserBase):
     def __init__(self):
         self.kobo_only_shelves_sync = None
+        self.sync_from_collections = None
         self.view_settings = None
         self.allowed_column_value = None
         self.allowed_tags = None
@@ -310,6 +312,7 @@ class Anonymous(AnonymousUserMixin, UserBase):
         self.allowed_column_value = data.allowed_column_value
         self.view_settings = data.view_settings
         self.kobo_only_shelves_sync = data.kobo_only_shelves_sync
+        self.sync_from_collections = data.sync_from_collections
 
     def role_admin(self):
         return False

--- a/cps/web.py
+++ b/cps/web.py
@@ -1498,6 +1498,7 @@ def change_profile(kobo_support, local_oauth_check, oauth_status, translations, 
         current_user.kobo_only_shelves_sync = int(to_save.get("kobo_only_shelves_sync") == "on") or 0
         if old_state == 0 and current_user.kobo_only_shelves_sync == 1:
             kobo_sync_status.update_on_sync_shelfs(current_user.id)
+        current_user.sync_from_collections = to_save.get("sync_from_collections", False)
 
     except Exception as ex:
         flash(str(ex), category="error")


### PR DESCRIPTION
This adds a new feature to sync Calibre-Web shelves to Calibre Collections. This can run ad hoc from a user's personal settings page OR as a scheduled daily task. Each user who has this feature enabled will be synced — users who do not individually enable it will not see changes.

When sync runs by either method, C-W detects which custom column from Calibre is configured as "collections" and then gathers all books that have collections set. For each named collection, if that collection does not exist as a shelf on the user's account, the shelf is created. Shelves are never removed. Then the set of bookids in the Calibre collection is diffed against the set of bookids in the C-W shelf. Missing books are added, and surplus books are removed. To maintain a shelf in C-W separately from Calibre, just name it something that doesn't exist in Calibre.