### PR TITLE
Update kobo.py to include subtitle if field exists in custom columns

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -426,7 +426,21 @@ def get_series(book):
         return None
     return book.series[0].name
 
-
+def get_subtitle(book):
+    #ID the Column id associated with Subtitle
+    col = (calibre_db.session.query(db.CustomColumns)
+                      .filter(db.CustomColumns.mark_for_delete == 0)
+                      .filter(db.CustomColumns.datatype.notin_(db.cc_exceptions))
+                      .filter(db.CustomColumns.label == 'subtitle') 
+                      .order_by(db.CustomColumns.label).all())[0]
+    
+    if (col):
+        subtitleColumn = getattr(book, 'custom_column_' + str(col.id))
+        if len(subtitleColumn):
+            return subtitleColumn[0].value
+    else:
+            return ""
+        
 def get_seriesindex(book):
     return book.series_index if isinstance(book.series_index, float) else 1
 
@@ -485,6 +499,7 @@ def get_metadata(book):
         "Publisher": {"Imprint": "", "Name": get_publisher(book), },
         "RevisionId": book_uuid,
         "Title": book.title,
+        "Subtitle": get_subtitle(book),
         "WorkId": book_uuid,
     }
     metadata.update(get_author(book))


### PR DESCRIPTION
Since Subtitle is becoming more common in Calibre DB setups with Kobo users, I added subtitle to the sync data when there's a custom column labeled 'subtitle'. When no matching column exists it returns an empty string.