### PR TITLE
Fix traceback encoding

### DIFF
--- a/cps/tasks/convert.py
+++ b/cps/tasks/convert.py
@@ -285,6 +285,8 @@ class TaskConvert(CalibreTask):
                 else:
                     error_message = ""
                     for ele in calibre_traceback:
+                        ele = ele.decode('utf-8', errors="ignore").strip('\n')
+                        log.debug(ele)
                         if not ele.startswith('Traceback') and not ele.startswith('  File'):
                             error_message = N_("Calibre failed with error: %(error)s", error=ele)
                     return check, error_message


### PR DESCRIPTION
stderr output is returned as a byte stream and requires decoding to convert it to a valid string for textual processing.