### PR TITLE
Updated metadata, covers, and deleted books added to Kobo Sync

### DIFF
--- a/cps/helper.py
+++ b/cps/helper.py
@@ -734,6 +734,16 @@ def get_book_cover_with_uuid(book_uuid, resolution=None):
     return get_book_cover_internal(book, resolution=resolution)
 
 
+def get_book_cover_epoch_date_with_uuid(book_uuid):
+    book = calibre_db.get_book_by_uuid(book_uuid)
+    if book and book.has_cover:
+        file_path = os.path.join(config.get_book_path(), book.path, "cover.jpg")
+        if os.path.isfile(file_path):
+            ts = int(os.path.getmtime(file_path))
+            return str(ts)
+    return None
+
+
 def get_book_cover_internal(book, resolution=None):
     if book and book.has_cover:
 

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -184,9 +184,11 @@ def HandleSyncRequest():
         shelf_entries = (shelf_entries
                            .join(db.Data).outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
                                                                           ub.ArchivedBook.user_id == current_user.id))
-                           .filter(db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id)
-                                                      .filter(ub.KoboSyncedBooks.user_id == current_user.id)))
-                           .filter(ub.BookShelf.date_added > sync_token.books_last_modified)
+                           .filter(and_(
+                                db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id).filter(ub.KoboSyncedBooks.user_id == current_user.id)),
+                                db.Books.last_modified < sync_token.books_last_modified
+                            ))
+                           .filter(or_(ub.Shelf.is_public == 1, ub.BookShelf.date_added > sync_token.books_last_modified))
                            .filter(db.Data.format.in_(KOBO_FORMATS))
                            .filter(calibre_db.common_filters(allow_show_archived=True))
                            .join(ub.BookShelf, db.Books.id == ub.BookShelf.book_id)
@@ -232,8 +234,10 @@ def HandleSyncRequest():
         changed_entries = (changed_entries
                            .join(db.Data).outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
                                                                           ub.ArchivedBook.user_id == current_user.id))
-                           .filter(db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id)
-                                                      .filter(ub.KoboSyncedBooks.user_id == current_user.id)))
+                           .filter(and_(
+                                db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id).filter(ub.KoboSyncedBooks.user_id == current_user.id)),
+                                db.Books.last_modified < sync_token.books_last_modified
+                            ))
                            .filter(calibre_db.common_filters(allow_show_archived=True))
                            .filter(db.Data.format.in_(KOBO_FORMATS))
                            .order_by(db.Books.last_modified)

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -277,8 +277,10 @@ def HandleSyncRequest():
             sync_results.append({"NewEntitlement": entitlement})
         else:
             log.debug("Marking as ChangedEntitlement")
-            sync_results.append({"ChangedEntitlement": entitlement})
-            sync_results.append({"ChangedProductMetadata": get_metadata(book.Books)})
+            entitlement["BookMetadata"] = get_metadata(book.Books)
+            sync_results.append({"ChangedProductMetadata": entitlement})
+            # sync_results.append({"ChangedEntitlement": entitlement})
+            # sync_results.append({"ChangedProductMetadata": get_metadata(book.Books)})
 
         new_books_last_modified = max(
             book.Books.last_modified.replace(tzinfo=None), new_books_last_modified

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -186,9 +186,9 @@ def HandleSyncRequest():
                                                                           ub.ArchivedBook.user_id == current_user.id))
                            .filter(or_(
                                 db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id).filter(ub.KoboSyncedBooks.user_id == current_user.id)),
-                                func.datetime(db.Books.last_modified) > sync_token.books_last_modified
+                                func.datetime(db.Books.last_modified) > sync_token.books_last_modified,
+                                func.datetime(ub.BookShelf.date_added) > sync_token.books_last_modified,
                             ))
-                           .filter(func.datetime(ub.BookShelf.date_added) > sync_token.books_last_modified)
                            .filter(db.Data.format.in_(KOBO_FORMATS))
                            .filter(calibre_db.common_filters(allow_show_archived=True))
                            .join(ub.BookShelf, db.Books.id == ub.BookShelf.book_id)
@@ -266,7 +266,7 @@ def HandleSyncRequest():
         ts_created = book.Books.timestamp.replace(tzinfo=None)
 
         try:
-            ts_created = max(ts_created, book.date_added)
+            ts_created = max(ts_created, book.date_added.replace(tzinfo=None))
         except AttributeError:
             pass
 

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -184,11 +184,11 @@ def HandleSyncRequest():
         shelf_entries = (shelf_entries
                            .join(db.Data).outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
                                                                           ub.ArchivedBook.user_id == current_user.id))
-                           .filter(and_(
+                           .filter(or_(
                                 db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id).filter(ub.KoboSyncedBooks.user_id == current_user.id)),
-                                db.Books.last_modified < sync_token.books_last_modified
+                                db.Books.last_modified > sync_token.books_last_modified
                             ))
-                           .filter(or_(ub.Shelf.is_public == 1, ub.BookShelf.date_added > sync_token.books_last_modified))
+                           .filter(ub.BookShelf.date_added > sync_token.books_last_modified)
                            .filter(db.Data.format.in_(KOBO_FORMATS))
                            .filter(calibre_db.common_filters(allow_show_archived=True))
                            .join(ub.BookShelf, db.Books.id == ub.BookShelf.book_id)
@@ -234,9 +234,9 @@ def HandleSyncRequest():
         changed_entries = (changed_entries
                            .join(db.Data).outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
                                                                           ub.ArchivedBook.user_id == current_user.id))
-                           .filter(and_(
+                           .filter(or_(
                                 db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id).filter(ub.KoboSyncedBooks.user_id == current_user.id)),
-                                db.Books.last_modified < sync_token.books_last_modified
+                                db.Books.last_modified > sync_token.books_last_modified
                             ))
                            .filter(calibre_db.common_filters(allow_show_archived=True))
                            .filter(db.Data.format.in_(KOBO_FORMATS))

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -278,7 +278,7 @@ def HandleSyncRequest():
             log.debug("Marking as NewEntitlement")
             entitlement["BookMetadata"] = get_metadata(book.Books)
             sync_results.append({"NewEntitlement": entitlement})
-        elif book.deleted:
+        elif only_kobo_shelves and book.deleted:
             log.debug("Marking as ChangedEntitlement")
             sync_results.append({"ChangedEntitlement": entitlement})
         else:

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -255,8 +255,7 @@ def HandleSyncRequest():
 
         kobo_reading_state = get_or_create_reading_state(book.Books.id)
         entitlement = {
-            "BookEntitlement": create_book_entitlement(book.Books, archived = book.is_archived or (only_kobo_shelves and book.deleted)),
-            "BookMetadata": get_metadata(book.Books),
+            "BookEntitlement": create_book_entitlement(book.Books, archived = book.is_archived or (only_kobo_shelves and book.deleted))
         }
 
         if kobo_reading_state.last_modified > sync_token.reading_state_last_modified:
@@ -274,10 +273,12 @@ def HandleSyncRequest():
         log.debug("Syncing book %s, ts_created: %s", book.Books.id, ts_created)
         if ts_created > sync_token.books_last_created:
             log.debug("Marking as NewEntitlement")
+            entitlement["BookMetadata"] = get_metadata(book.Books)
             sync_results.append({"NewEntitlement": entitlement})
         else:
             log.debug("Marking as ChangedEntitlement")
             sync_results.append({"ChangedEntitlement": entitlement})
+            sync_results.append({"ChangedProductMetadata": get_metadata(book.Books)})
 
         new_books_last_modified = max(
             book.Books.last_modified.replace(tzinfo=None), new_books_last_modified

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -273,8 +273,10 @@ def HandleSyncRequest():
 
         log.debug("Syncing book %s, ts_created: %s", book.Books.id, ts_created)
         if ts_created > sync_token.books_last_created:
+            log.debug("Marking as NewEntitlement")
             sync_results.append({"NewEntitlement": entitlement})
         else:
+            log.debug("Marking as ChangedEntitlement")
             sync_results.append({"ChangedEntitlement": entitlement})
 
         new_books_last_modified = max(

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -38,7 +38,7 @@ from flask import (
 )
 from .cw_login import current_user
 from werkzeug.datastructures import Headers
-from sqlalchemy import func
+from sqlalchemy import func, null, literal
 from sqlalchemy.sql.expression import and_, or_
 from sqlalchemy.exc import StatementError
 from sqlalchemy.sql import select
@@ -173,11 +173,15 @@ def HandleSyncRequest():
     only_kobo_shelves = current_user.kobo_only_shelves_sync
 
     if only_kobo_shelves:
-        changed_entries = calibre_db.session.query(db.Books,
+        extra_filters=[]
+        extra_filters.append(ub.Shelf.kobo_sync)
+
+        shelf_entries = calibre_db.session.query(db.Books,
                                                    ub.ArchivedBook.last_modified,
                                                    ub.BookShelf.date_added,
-                                                   ub.ArchivedBook.is_archived)
-        changed_entries = (changed_entries
+                                                   ub.ArchivedBook.is_archived,
+                                                   literal(False).label("deleted"))
+        shelf_entries = (shelf_entries
                            .join(db.Data).outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
                                                                           ub.ArchivedBook.user_id == current_user.id))
                            .filter(db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id)
@@ -185,13 +189,42 @@ def HandleSyncRequest():
                            .filter(ub.BookShelf.date_added > sync_token.books_last_modified)
                            .filter(db.Data.format.in_(KOBO_FORMATS))
                            .filter(calibre_db.common_filters(allow_show_archived=True))
-                           .order_by(db.Books.id)
-                           .order_by(ub.ArchivedBook.last_modified)
                            .join(ub.BookShelf, db.Books.id == ub.BookShelf.book_id)
                            .join(ub.Shelf)
                            .filter(ub.Shelf.user_id == current_user.id)
-                           .filter(ub.Shelf.kobo_sync)
+                           .filter(*extra_filters)
                            .distinct())
+
+        shelf_exists = (
+            calibre_db.session.query(ub.BookShelf)
+                .join(ub.Shelf)
+                .filter(
+                    ub.BookShelf.book_id == db.Books.id,
+                    *extra_filters
+                )
+                .exists()
+        )
+
+        deleted_entries = (
+            calibre_db.session.query(
+                db.Books,
+                ub.ArchivedBook.last_modified,
+                func.current_timestamp().label("date_added"),
+                ub.ArchivedBook.is_archived,
+                literal(True).label("deleted")
+            )
+            .join(ub.KoboSyncedBooks, and_(db.Books.id == ub.KoboSyncedBooks.book_id,
+                                                          ub.KoboSyncedBooks.user_id == current_user.id))
+            .outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
+                                             ub.ArchivedBook.user_id == current_user.id))
+            .filter(~shelf_exists)
+        )
+        changed_entries = (
+            shelf_entries
+            .union_all(deleted_entries)
+            .order_by(db.Books.id, ub.ArchivedBook.last_modified)
+        )
+
     else:
         changed_entries = calibre_db.session.query(db.Books,
                                                    ub.ArchivedBook.last_modified,
@@ -216,7 +249,7 @@ def HandleSyncRequest():
 
         kobo_reading_state = get_or_create_reading_state(book.Books.id)
         entitlement = {
-            "BookEntitlement": create_book_entitlement(book.Books, archived=(book.is_archived==True)),
+            "BookEntitlement": create_book_entitlement(book.Books, archived = book.is_archived or (only_kobo_shelves and book.deleted)),
             "BookMetadata": get_metadata(book.Books),
         }
 
@@ -248,7 +281,10 @@ def HandleSyncRequest():
             pass
 
         new_books_last_created = max(ts_created, new_books_last_created)
-        kobo_sync_status.add_synced_books(book.Books.id)
+        if only_kobo_shelves and book.deleted:
+            kobo_sync_status.remove_synced_book(book.Books.id)
+        else:
+            kobo_sync_status.add_synced_books(book.Books.id)
 
     max_change = changed_entries.filter(ub.ArchivedBook.is_archived)\
         .filter(ub.ArchivedBook.user_id == current_user.id) \

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -170,6 +170,8 @@ def HandleSyncRequest():
     # We reload the book database so that the user gets a fresh view of the library
     # in case of external changes (e.g: adding a book through Calibre).
     calibre_db.reconnect_db(config, ub.app_DB_path)
+    # also refresh thumbnails if configured
+    helper.update_thumbnail_cache()
 
     only_kobo_shelves = current_user.kobo_only_shelves_sync
 
@@ -514,21 +516,17 @@ def get_metadata(book):
 
     book_uuid = book.uuid
 
-    thumbnail_generated_at = (
-        calibre_db.session
-        .query(ub.Thumbnail.generated_at)
-        .filter(ub.Thumbnail.entity_id == book.id)
-        .order_by(ub.Thumbnail.id)
-        .limit(1)
-    ).scalar()
-
-    #turn thumbnail generated_at timestamp into an epoch for use as the version
-    version_str = f"{thumbnail_generated_at.timestamp():.0f}"
+    #get cover version from book cover file
+    coverVersion = helper.get_book_cover_epoch_date_with_uuid(book_uuid)
+    if coverVersion:
+        coverImageId = book_uuid+"/"+coverVersion
+    else:
+        coverImageId = book_uuid
 
     metadata = {
         "Categories": ["00000000-0000-0000-0000-000000000001", ],
         # "Contributors": get_author(book),
-        "CoverImageId": book_uuid+"/"+version_str,
+        "CoverImageId": coverImageId,
         "CrossRevisionId": book_uuid,
         "CurrentDisplayPrice": {"CurrencyCode": "USD", "TotalAmount": 0},
         "CurrentLoveDisplayPrice": {"TotalAmount": 0},

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -988,9 +988,9 @@ def HandleBookDeletionRequest(book_uuid):
         return redirect_or_proxy_request()
 
     book_id = book.id
-    is_archived = kobo_sync_status.change_archived_books(book_id, True)
-    if is_archived:
-        kobo_sync_status.remove_synced_book(book_id)
+    if not current_user.kobo_only_shelves_sync and current_user.check_visibility(32768):
+        kobo_sync_status.change_archived_books(book_id, True)
+    kobo_sync_status.remove_synced_book(book_id)
     return "", 204
 
 

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -211,7 +211,7 @@ def HandleSyncRequest():
             calibre_db.session.query(
                 db.Books,
                 ub.ArchivedBook.last_modified,
-                func.current_timestamp().label("date_added"),
+                db.Books.timestamp.label("date_added"),
                 ub.ArchivedBook.is_archived,
                 literal(True).label("deleted")
             )

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -275,12 +275,13 @@ def HandleSyncRequest():
             log.debug("Marking as NewEntitlement")
             entitlement["BookMetadata"] = get_metadata(book.Books)
             sync_results.append({"NewEntitlement": entitlement})
-        else:
+        elif book.deleted:
             log.debug("Marking as ChangedEntitlement")
+            sync_results.append({"ChangedEntitlement": entitlement})
+        else:
+            log.debug("Marking as ChangedProductMetadata")
             entitlement["BookMetadata"] = get_metadata(book.Books)
             sync_results.append({"ChangedProductMetadata": entitlement})
-            # sync_results.append({"ChangedEntitlement": entitlement})
-            # sync_results.append({"ChangedProductMetadata": get_metadata(book.Books)})
 
         new_books_last_modified = max(
             book.Books.last_modified.replace(tzinfo=None), new_books_last_modified

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -186,9 +186,9 @@ def HandleSyncRequest():
                                                                           ub.ArchivedBook.user_id == current_user.id))
                            .filter(or_(
                                 db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id).filter(ub.KoboSyncedBooks.user_id == current_user.id)),
-                                db.Books.last_modified > sync_token.books_last_modified
+                                func.datetime(db.Books.last_modified) > sync_token.books_last_modified
                             ))
-                           .filter(ub.BookShelf.date_added > sync_token.books_last_modified)
+                           .filter(func.datetime(ub.BookShelf.date_added) > sync_token.books_last_modified)
                            .filter(db.Data.format.in_(KOBO_FORMATS))
                            .filter(calibre_db.common_filters(allow_show_archived=True))
                            .join(ub.BookShelf, db.Books.id == ub.BookShelf.book_id)
@@ -225,6 +225,7 @@ def HandleSyncRequest():
             shelf_entries
             .union_all(deleted_entries)
             .order_by(db.Books.id, ub.ArchivedBook.last_modified)
+            .group_by(db.Books.id)
         )
 
     else:
@@ -236,7 +237,7 @@ def HandleSyncRequest():
                                                                           ub.ArchivedBook.user_id == current_user.id))
                            .filter(or_(
                                 db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id).filter(ub.KoboSyncedBooks.user_id == current_user.id)),
-                                db.Books.last_modified > sync_token.books_last_modified
+                                func.datetime(db.Books.last_modified) > sync_token.books_last_modified
                             ))
                            .filter(calibre_db.common_filters(allow_show_archived=True))
                            .filter(db.Data.format.in_(KOBO_FORMATS))
@@ -279,7 +280,7 @@ def HandleSyncRequest():
         )
         try:
             new_books_last_modified = max(
-                new_books_last_modified, book.date_added
+                new_books_last_modified, book.date_added.replace(tzinfo=None)
             )
         except AttributeError:
             pass

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -253,8 +253,7 @@ def HandleSyncRequest():
 
         kobo_reading_state = get_or_create_reading_state(book.Books.id)
         entitlement = {
-            "BookEntitlement": create_book_entitlement(book.Books, archived = book.is_archived or (only_kobo_shelves and book.deleted)),
-            "BookMetadata": get_metadata(book.Books),
+            "BookEntitlement": create_book_entitlement(book.Books, archived = book.is_archived or (only_kobo_shelves and book.deleted))
         }
 
         if kobo_reading_state.last_modified > sync_token.reading_state_last_modified:
@@ -272,10 +271,12 @@ def HandleSyncRequest():
         log.debug("Syncing book %s, ts_created: %s", book.Books.id, ts_created)
         if ts_created > sync_token.books_last_created:
             log.debug("Marking as NewEntitlement")
+            entitlement["BookMetadata"] = get_metadata(book.Books)
             sync_results.append({"NewEntitlement": entitlement})
         else:
             log.debug("Marking as ChangedEntitlement")
             sync_results.append({"ChangedEntitlement": entitlement})
+            sync_results.append({"ChangedProductMetadata": get_metadata(book.Books)})
 
         new_books_last_modified = max(
             book.Books.last_modified.replace(tzinfo=None), new_books_last_modified

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -273,12 +273,13 @@ def HandleSyncRequest():
             log.debug("Marking as NewEntitlement")
             entitlement["BookMetadata"] = get_metadata(book.Books)
             sync_results.append({"NewEntitlement": entitlement})
-        else:
+        elif book.deleted:
             log.debug("Marking as ChangedEntitlement")
+            sync_results.append({"ChangedEntitlement": entitlement})
+        else:
+            log.debug("Marking as ChangedProductMetadata")
             entitlement["BookMetadata"] = get_metadata(book.Books)
             sync_results.append({"ChangedProductMetadata": entitlement})
-            # sync_results.append({"ChangedEntitlement": entitlement})
-            # sync_results.append({"ChangedProductMetadata": get_metadata(book.Books)})
 
         new_books_last_modified = max(
             book.Books.last_modified.replace(tzinfo=None), new_books_last_modified

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -245,6 +245,7 @@ def HandleSyncRequest():
     reading_states_in_new_entitlements = []
     books = changed_entries.limit(SYNC_ITEM_LIMIT)
     log.debug("Books to Sync: {}".format(len(books.all())))
+    log.debug("sync_token.books_last_created: %s", sync_token.books_last_created)
     for book in books:
         formats = [data.format for data in book.Books.data]
         if 'KEPUB' not in formats and config.config_kepubifypath and 'EPUB' in formats:
@@ -268,6 +269,7 @@ def HandleSyncRequest():
         except AttributeError:
             pass
 
+        log.debug("Syncing book %s, ts_created: %s", book.Books.id, ts_created)
         if ts_created > sync_token.books_last_created:
             sync_results.append({"NewEntitlement": entitlement})
         else:
@@ -297,8 +299,8 @@ def HandleSyncRequest():
 
     new_archived_last_modified = max(new_archived_last_modified, max_change)
 
-    # no. of books returned
-    book_count = changed_entries.count()
+    # books count not yet synced
+    book_count = changed_entries.count() - books.count()
     # last entry:
     cont_sync = bool(book_count)
     log.debug("Remaining books to Sync: {}".format(book_count))
@@ -319,10 +321,10 @@ def HandleSyncRequest():
         changed_reading_states = changed_reading_states.filter(
             ub.KoboReadingState.last_modified > sync_token.reading_state_last_modified)
 
-    changed_reading_states = changed_reading_states.filter(
+    changed_reading_states = (changed_reading_states.filter(
         and_(ub.KoboReadingState.user_id == current_user.id,
-             ub.KoboReadingState.book_id.notin_(reading_states_in_new_entitlements)))\
-        .order_by(ub.KoboReadingState.last_modified)
+             ub.KoboReadingState.book_id.notin_(reading_states_in_new_entitlements)))
+        .order_by(ub.KoboReadingState.last_modified))
     cont_sync |= bool(changed_reading_states.count() > SYNC_ITEM_LIMIT)
     for kobo_reading_state in changed_reading_states.limit(SYNC_ITEM_LIMIT).all():
         book = calibre_db.session.query(db.Books).filter(db.Books.id == kobo_reading_state.book_id).one_or_none()

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -39,7 +39,7 @@ from flask import (
 )
 from .cw_login import current_user
 from werkzeug.datastructures import Headers
-from sqlalchemy import func
+from sqlalchemy import func, null, literal
 from sqlalchemy.sql.expression import and_, or_
 from sqlalchemy.exc import StatementError
 
@@ -171,11 +171,15 @@ def HandleSyncRequest():
     only_kobo_shelves = current_user.kobo_only_shelves_sync
 
     if only_kobo_shelves:
-        changed_entries = calibre_db.session.query(db.Books,
+        extra_filters=[]
+        extra_filters.append(ub.Shelf.kobo_sync)
+
+        shelf_entries = calibre_db.session.query(db.Books,
                                                    ub.ArchivedBook.last_modified,
                                                    ub.BookShelf.date_added,
-                                                   ub.ArchivedBook.is_archived)
-        changed_entries = (changed_entries
+                                                   ub.ArchivedBook.is_archived,
+                                                   literal(False).label("deleted"))
+        shelf_entries = (shelf_entries
                            .join(db.Data).outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
                                                                           ub.ArchivedBook.user_id == current_user.id))
                            .filter(db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id)
@@ -183,13 +187,42 @@ def HandleSyncRequest():
                            .filter(ub.BookShelf.date_added > sync_token.books_last_modified)
                            .filter(db.Data.format.in_(KOBO_FORMATS))
                            .filter(calibre_db.common_filters(allow_show_archived=True))
-                           .order_by(db.Books.id)
-                           .order_by(ub.ArchivedBook.last_modified)
                            .join(ub.BookShelf, db.Books.id == ub.BookShelf.book_id)
                            .join(ub.Shelf)
                            .filter(ub.Shelf.user_id == current_user.id)
-                           .filter(ub.Shelf.kobo_sync)
+                           .filter(*extra_filters)
                            .distinct())
+
+        shelf_exists = (
+            calibre_db.session.query(ub.BookShelf)
+                .join(ub.Shelf)
+                .filter(
+                    ub.BookShelf.book_id == db.Books.id,
+                    *extra_filters
+                )
+                .exists()
+        )
+
+        deleted_entries = (
+            calibre_db.session.query(
+                db.Books,
+                ub.ArchivedBook.last_modified,
+                func.current_timestamp().label("date_added"),
+                ub.ArchivedBook.is_archived,
+                literal(True).label("deleted")
+            )
+            .join(ub.KoboSyncedBooks, and_(db.Books.id == ub.KoboSyncedBooks.book_id,
+                                                          ub.KoboSyncedBooks.user_id == current_user.id))
+            .outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
+                                             ub.ArchivedBook.user_id == current_user.id))
+            .filter(~shelf_exists)
+        )
+        changed_entries = (
+            shelf_entries
+            .union_all(deleted_entries)
+            .order_by(db.Books.id, ub.ArchivedBook.last_modified)
+        )
+
     else:
         changed_entries = calibre_db.session.query(db.Books,
                                                    ub.ArchivedBook.last_modified,
@@ -214,7 +247,7 @@ def HandleSyncRequest():
 
         kobo_reading_state = get_or_create_reading_state(book.Books.id)
         entitlement = {
-            "BookEntitlement": create_book_entitlement(book.Books, archived=(book.is_archived==True)),
+            "BookEntitlement": create_book_entitlement(book.Books, archived = book.is_archived or (only_kobo_shelves and book.deleted)),
             "BookMetadata": get_metadata(book.Books),
         }
 
@@ -246,7 +279,10 @@ def HandleSyncRequest():
             pass
 
         new_books_last_created = max(ts_created, new_books_last_created)
-        kobo_sync_status.add_synced_books(book.Books.id)
+        if only_kobo_shelves and book.deleted:
+            kobo_sync_status.remove_synced_book(book.Books.id)
+        else:
+            kobo_sync_status.add_synced_books(book.Books.id)
 
     max_change = changed_entries.filter(ub.ArchivedBook.is_archived)\
         .filter(ub.ArchivedBook.user_id == current_user.id) \

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -996,9 +996,9 @@ def HandleBookDeletionRequest(book_uuid):
         return redirect_or_proxy_request()
 
     book_id = book.id
-    is_archived = kobo_sync_status.change_archived_books(book_id, True)
-    if is_archived:
-        kobo_sync_status.remove_synced_book(book_id)
+    if not current_user.kobo_only_shelves_sync and current_user.check_visibility(32768):
+        kobo_sync_status.change_archived_books(book_id, True)
+    kobo_sync_status.remove_synced_book(book_id)
     return "", 204
 
 

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -168,6 +168,8 @@ def HandleSyncRequest():
     # We reload the book database so that the user gets a fresh view of the library
     # in case of external changes (e.g: adding a book through Calibre).
     calibre_db.reconnect_db(config, ub.app_DB_path)
+    # also refresh thumbnails if configured
+    helper.update_thumbnail_cache()
 
     only_kobo_shelves = current_user.kobo_only_shelves_sync
 
@@ -512,21 +514,17 @@ def get_metadata(book):
 
     book_uuid = book.uuid
 
-    thumbnail_generated_at = (
-        calibre_db.session
-        .query(ub.Thumbnail.generated_at)
-        .filter(ub.Thumbnail.entity_id == book.id)
-        .order_by(ub.Thumbnail.id)
-        .limit(1)
-    ).scalar()
-
-    #turn thumbnail generated_at timestamp into an epoch for use as the version
-    version_str = f"{thumbnail_generated_at.timestamp():.0f}"
+    #get cover version from book cover file
+    coverVersion = helper.get_book_cover_epoch_date_with_uuid(book_uuid)
+    if coverVersion:
+        coverImageId = book_uuid+"/"+coverVersion
+    else:
+        coverImageId = book_uuid
 
     metadata = {
         "Categories": ["00000000-0000-0000-0000-000000000001", ],
         # "Contributors": get_author(book),
-        "CoverImageId": book_uuid+"/"+version_str,
+        "CoverImageId": coverImageId,
         "CrossRevisionId": book_uuid,
         "CurrentDisplayPrice": {"CurrencyCode": "USD", "TotalAmount": 0},
         "CurrentLoveDisplayPrice": {"TotalAmount": 0},

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -275,8 +275,10 @@ def HandleSyncRequest():
             sync_results.append({"NewEntitlement": entitlement})
         else:
             log.debug("Marking as ChangedEntitlement")
-            sync_results.append({"ChangedEntitlement": entitlement})
-            sync_results.append({"ChangedProductMetadata": get_metadata(book.Books)})
+            entitlement["BookMetadata"] = get_metadata(book.Books)
+            sync_results.append({"ChangedProductMetadata": entitlement})
+            # sync_results.append({"ChangedEntitlement": entitlement})
+            # sync_results.append({"ChangedProductMetadata": get_metadata(book.Books)})
 
         new_books_last_modified = max(
             book.Books.last_modified.replace(tzinfo=None), new_books_last_modified

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -271,8 +271,10 @@ def HandleSyncRequest():
 
         log.debug("Syncing book %s, ts_created: %s", book.Books.id, ts_created)
         if ts_created > sync_token.books_last_created:
+            log.debug("Marking as NewEntitlement")
             sync_results.append({"NewEntitlement": entitlement})
         else:
+            log.debug("Marking as ChangedEntitlement")
             sync_results.append({"ChangedEntitlement": entitlement})
 
         new_books_last_modified = max(

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -209,7 +209,7 @@ def HandleSyncRequest():
             calibre_db.session.query(
                 db.Books,
                 ub.ArchivedBook.last_modified,
-                func.current_timestamp().label("date_added"),
+                db.Books.timestamp.label("date_added"),
                 ub.ArchivedBook.is_archived,
                 literal(True).label("deleted")
             )

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -182,9 +182,11 @@ def HandleSyncRequest():
         shelf_entries = (shelf_entries
                            .join(db.Data).outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
                                                                           ub.ArchivedBook.user_id == current_user.id))
-                           .filter(db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id)
-                                                      .filter(ub.KoboSyncedBooks.user_id == current_user.id)))
-                           .filter(ub.BookShelf.date_added > sync_token.books_last_modified)
+                           .filter(and_(
+                                db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id).filter(ub.KoboSyncedBooks.user_id == current_user.id)),
+                                db.Books.last_modified < sync_token.books_last_modified
+                            ))
+                           .filter(or_(ub.Shelf.is_public == 1, ub.BookShelf.date_added > sync_token.books_last_modified))
                            .filter(db.Data.format.in_(KOBO_FORMATS))
                            .filter(calibre_db.common_filters(allow_show_archived=True))
                            .join(ub.BookShelf, db.Books.id == ub.BookShelf.book_id)
@@ -230,8 +232,10 @@ def HandleSyncRequest():
         changed_entries = (changed_entries
                            .join(db.Data).outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
                                                                           ub.ArchivedBook.user_id == current_user.id))
-                           .filter(db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id)
-                                                      .filter(ub.KoboSyncedBooks.user_id == current_user.id)))
+                           .filter(and_(
+                                db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id).filter(ub.KoboSyncedBooks.user_id == current_user.id)),
+                                db.Books.last_modified < sync_token.books_last_modified
+                            ))
                            .filter(calibre_db.common_filters(allow_show_archived=True))
                            .filter(db.Data.format.in_(KOBO_FORMATS))
                            .order_by(db.Books.last_modified)

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -182,11 +182,11 @@ def HandleSyncRequest():
         shelf_entries = (shelf_entries
                            .join(db.Data).outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
                                                                           ub.ArchivedBook.user_id == current_user.id))
-                           .filter(and_(
+                           .filter(or_(
                                 db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id).filter(ub.KoboSyncedBooks.user_id == current_user.id)),
-                                db.Books.last_modified < sync_token.books_last_modified
+                                db.Books.last_modified > sync_token.books_last_modified
                             ))
-                           .filter(or_(ub.Shelf.is_public == 1, ub.BookShelf.date_added > sync_token.books_last_modified))
+                           .filter(ub.BookShelf.date_added > sync_token.books_last_modified)
                            .filter(db.Data.format.in_(KOBO_FORMATS))
                            .filter(calibre_db.common_filters(allow_show_archived=True))
                            .join(ub.BookShelf, db.Books.id == ub.BookShelf.book_id)
@@ -232,9 +232,9 @@ def HandleSyncRequest():
         changed_entries = (changed_entries
                            .join(db.Data).outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
                                                                           ub.ArchivedBook.user_id == current_user.id))
-                           .filter(and_(
+                           .filter(or_(
                                 db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id).filter(ub.KoboSyncedBooks.user_id == current_user.id)),
-                                db.Books.last_modified < sync_token.books_last_modified
+                                db.Books.last_modified > sync_token.books_last_modified
                             ))
                            .filter(calibre_db.common_filters(allow_show_archived=True))
                            .filter(db.Data.format.in_(KOBO_FORMATS))

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -184,9 +184,9 @@ def HandleSyncRequest():
                                                                           ub.ArchivedBook.user_id == current_user.id))
                            .filter(or_(
                                 db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id).filter(ub.KoboSyncedBooks.user_id == current_user.id)),
-                                func.datetime(db.Books.last_modified) > sync_token.books_last_modified
+                                func.datetime(db.Books.last_modified) > sync_token.books_last_modified,
+                                func.datetime(ub.BookShelf.date_added) > sync_token.books_last_modified,
                             ))
-                           .filter(func.datetime(ub.BookShelf.date_added) > sync_token.books_last_modified)
                            .filter(db.Data.format.in_(KOBO_FORMATS))
                            .filter(calibre_db.common_filters(allow_show_archived=True))
                            .join(ub.BookShelf, db.Books.id == ub.BookShelf.book_id)
@@ -264,7 +264,7 @@ def HandleSyncRequest():
         ts_created = book.Books.timestamp.replace(tzinfo=None)
 
         try:
-            ts_created = max(ts_created, book.date_added)
+            ts_created = max(ts_created, book.date_added.replace(tzinfo=None))
         except AttributeError:
             pass
 

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -184,9 +184,9 @@ def HandleSyncRequest():
                                                                           ub.ArchivedBook.user_id == current_user.id))
                            .filter(or_(
                                 db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id).filter(ub.KoboSyncedBooks.user_id == current_user.id)),
-                                db.Books.last_modified > sync_token.books_last_modified
+                                func.datetime(db.Books.last_modified) > sync_token.books_last_modified
                             ))
-                           .filter(ub.BookShelf.date_added > sync_token.books_last_modified)
+                           .filter(func.datetime(ub.BookShelf.date_added) > sync_token.books_last_modified)
                            .filter(db.Data.format.in_(KOBO_FORMATS))
                            .filter(calibre_db.common_filters(allow_show_archived=True))
                            .join(ub.BookShelf, db.Books.id == ub.BookShelf.book_id)
@@ -223,6 +223,7 @@ def HandleSyncRequest():
             shelf_entries
             .union_all(deleted_entries)
             .order_by(db.Books.id, ub.ArchivedBook.last_modified)
+            .group_by(db.Books.id)
         )
 
     else:
@@ -234,7 +235,7 @@ def HandleSyncRequest():
                                                                           ub.ArchivedBook.user_id == current_user.id))
                            .filter(or_(
                                 db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id).filter(ub.KoboSyncedBooks.user_id == current_user.id)),
-                                db.Books.last_modified > sync_token.books_last_modified
+                                func.datetime(db.Books.last_modified) > sync_token.books_last_modified
                             ))
                            .filter(calibre_db.common_filters(allow_show_archived=True))
                            .filter(db.Data.format.in_(KOBO_FORMATS))
@@ -277,7 +278,7 @@ def HandleSyncRequest():
         )
         try:
             new_books_last_modified = max(
-                new_books_last_modified, book.date_added
+                new_books_last_modified, book.date_added.replace(tzinfo=None)
             )
         except AttributeError:
             pass

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -25,6 +25,7 @@ import zipfile
 from time import gmtime, strftime
 import json
 from urllib.parse import unquote
+import uuid
 import requests
 
 from flask import (
@@ -510,10 +511,22 @@ def get_metadata(book):
                 log.error(e)
 
     book_uuid = book.uuid
+
+    thumbnail_generated_at = (
+        calibre_db.session
+        .query(ub.Thumbnail.generated_at)
+        .filter(ub.Thumbnail.entity_id == book.id)
+        .order_by(ub.Thumbnail.id)
+        .limit(1)
+    ).scalar()
+
+    #turn thumbnail generated_at timestamp into an epoch for use as the version
+    version_str = f"{thumbnail_generated_at.timestamp():.0f}"
+
     metadata = {
         "Categories": ["00000000-0000-0000-0000-000000000001", ],
         # "Contributors": get_author(book),
-        "CoverImageId": book_uuid,
+        "CoverImageId": book_uuid+"/"+version_str,
         "CrossRevisionId": book_uuid,
         "CurrentDisplayPrice": {"CurrencyCode": "USD", "TotalAmount": 0},
         "CurrentLoveDisplayPrice": {"TotalAmount": 0},
@@ -962,10 +975,12 @@ def get_current_bookmark_response(current_bookmark):
     return resp
 
 
-@kobo.route("/<book_uuid>/<width>/<height>/<isGreyscale>/image.jpg", defaults={'Quality': ""})
-@kobo.route("/<book_uuid>/<width>/<height>/<Quality>/<isGreyscale>/image.jpg")
+@kobo.route("/<book_uuid>/<width>/<height>/<isGreyscale>/image.jpg", defaults={'Quality': "", 'version': ""})
+@kobo.route("/<book_uuid>/<width>/<height>/<Quality>/<isGreyscale>/image.jpg", defaults={'version': ""})
+@kobo.route("/<book_uuid>/<version>/<width>/<height>/<isGreyscale>/image.jpg", defaults={'Quality': ""})
+@kobo.route("/<book_uuid>/<version>/<width>/<height>/<Quality>/<isGreyscale>/image.jpg")
 @requires_kobo_auth
-def HandleCoverImageRequest(book_uuid, width, height, Quality, isGreyscale):
+def HandleCoverImageRequest(book_uuid, version, width, height, Quality, isGreyscale):
     try:
         if int(height) > 1000:
             resolution = COVER_THUMBNAIL_LARGE

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -276,7 +276,7 @@ def HandleSyncRequest():
             log.debug("Marking as NewEntitlement")
             entitlement["BookMetadata"] = get_metadata(book.Books)
             sync_results.append({"NewEntitlement": entitlement})
-        elif book.deleted:
+        elif only_kobo_shelves and book.deleted:
             log.debug("Marking as ChangedEntitlement")
             sync_results.append({"ChangedEntitlement": entitlement})
         else:


### PR DESCRIPTION
For #3298, #2685, #2816, #2509, #3133
Adds functionality to Kobo Sync for removing books from a shelf, updating metadata, and updating covers.

Sends a `BookEntitlement` deletion for any books that have already been synced to the kobo but are now no longer on a sync shelf (when sync only kobo marked shelves is turned on)

Also sends a `ChangedProductMetadata` for any books that has a modification date after the last sync, so the Kobo will get the new metadata

Added a version to the CoverImageId based on the cover file modified date. Also added an automatic thumbnail refresh to Kobo sync initialization.