### PR TITLE
Lazy-load book covers

### DIFF
--- a/cps/templates/image.html
+++ b/cps/templates/image.html
@@ -6,6 +6,7 @@
         srcset="{{ srcset }}"
         src="{{ url_for('web.get_cover', book_id=book.id, resolution='og', c=book|last_modified) }}"
         alt="{{ image_alt }}"
+        loading="lazy"
     />
 {%- endmacro %}
 
@@ -16,5 +17,6 @@
         srcset="{{ srcset }}"
         src="{{ url_for('web.get_series_cover', series_id=series.id, resolution='og', c='day'|cache_timestamp) }}"
         alt="{{ title }}"
+        loading="lazy"
     />
 {%- endmacro %}


### PR DESCRIPTION
Title. This PR makes calibre-web feel a thousand times snappier.
In the future, we should probably look into serving the covers at another size and maybe even in different, optimized formats (webp, AV1).