### PR TITLE
Set sync request to re-download books when the book file has changed

### DIFF
--- a/cps/helper.py
+++ b/cps/helper.py
@@ -734,6 +734,16 @@ def get_book_cover_with_uuid(book_uuid, resolution=None):
     return get_book_cover_internal(book, resolution=resolution)
 
 
+def get_book_cover_epoch_date_with_uuid(book_uuid):
+    book = calibre_db.get_book_by_uuid(book_uuid)
+    if book and book.has_cover:
+        file_path = os.path.join(config.get_book_path(), book.path, "cover.jpg")
+        if os.path.isfile(file_path):
+            ts = int(os.path.getmtime(file_path))
+            return str(ts)
+    return None
+
+
 def get_book_cover_internal(book, resolution=None):
     if book and book.has_cover:
 

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -986,6 +986,30 @@ def do_download_file(book, book_format, client, data, headers):
     return response
 
 
+#return the last modified time of the book file as epoch timestamp for use as a version number
+def get_file_modified_epoch(book, book_format, data):
+    book_name = data.name
+    download_name = filename = None
+    if config.config_use_google_drive:
+        #skip versioning for google drive (implementation )
+        return None
+    else:
+        filename = os.path.join(config.get_book_path(), book.path)
+        if not os.path.isfile(os.path.join(filename, book_name + "." + book_format)):
+            # ToDo: improve error handling
+            log.error('File not found: %s', os.path.join(filename, book_name + "." + book_format))
+        if book_format == "kepub" and config.config_kepubifypath and config.config_embed_metadata:
+            filename, download_name = do_kepubify_metadata_replace(book, os.path.join(filename,
+                                                                                      book_name + "." + book_format))
+        elif book_format != "kepub" and config.config_binariesdir and config.config_embed_metadata:
+            filename, download_name = do_calibre_export(book.id, book_format)
+        else:
+            download_name = book_name
+
+    full_path = os.path.join(filename, download_name + "." + book_format)
+    return int(os.path.getmtime(full_path))
+
+
 def do_kepubify_metadata_replace(book, file_path):
     custom_columns = (calibre_db.session.query(db.CustomColumns)
                       .filter(db.CustomColumns.mark_for_delete == 0)

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -253,8 +253,7 @@ def HandleSyncRequest():
 
         kobo_reading_state = get_or_create_reading_state(book.Books.id)
         entitlement = {
-            "BookEntitlement": create_book_entitlement(book.Books, archived = book.is_archived or (only_kobo_shelves and book.deleted)),
-            "BookMetadata": get_metadata(book.Books),
+            "BookEntitlement": create_book_entitlement(book.Books, archived = book.is_archived or (only_kobo_shelves and book.deleted))
         }
 
         if kobo_reading_state.last_modified > sync_token.reading_state_last_modified:
@@ -272,10 +271,12 @@ def HandleSyncRequest():
         log.debug("Syncing book %s, ts_created: %s", book.Books.id, ts_created)
         if ts_created > sync_token.books_last_created:
             log.debug("Marking as NewEntitlement")
+            entitlement["BookMetadata"] = get_metadata(book.Books)
             sync_results.append({"NewEntitlement": entitlement})
         else:
             log.debug("Marking as ChangedEntitlement")
             sync_results.append({"ChangedEntitlement": entitlement})
+            sync_results.append({"ChangedProductMetadata": get_metadata(book.Books)})
 
         new_books_last_modified = max(
             book.Books.last_modified.replace(tzinfo=None), new_books_last_modified

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -273,12 +273,13 @@ def HandleSyncRequest():
             log.debug("Marking as NewEntitlement")
             entitlement["BookMetadata"] = get_metadata(book.Books)
             sync_results.append({"NewEntitlement": entitlement})
-        else:
+        elif book.deleted:
             log.debug("Marking as ChangedEntitlement")
+            sync_results.append({"ChangedEntitlement": entitlement})
+        else:
+            log.debug("Marking as ChangedProductMetadata")
             entitlement["BookMetadata"] = get_metadata(book.Books)
             sync_results.append({"ChangedProductMetadata": entitlement})
-            # sync_results.append({"ChangedEntitlement": entitlement})
-            # sync_results.append({"ChangedProductMetadata": get_metadata(book.Books)})
 
         new_books_last_modified = max(
             book.Books.last_modified.replace(tzinfo=None), new_books_last_modified

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -245,6 +245,7 @@ def HandleSyncRequest():
     reading_states_in_new_entitlements = []
     books = changed_entries.limit(SYNC_ITEM_LIMIT)
     log.debug("Books to Sync: {}".format(len(books.all())))
+    log.debug("sync_token.books_last_created: %s", sync_token.books_last_created)
     for book in books:
         formats = [data.format for data in book.Books.data]
         if 'KEPUB' not in formats and config.config_kepubifypath and 'EPUB' in formats:
@@ -268,6 +269,7 @@ def HandleSyncRequest():
         except AttributeError:
             pass
 
+        log.debug("Syncing book %s, ts_created: %s", book.Books.id, ts_created)
         if ts_created > sync_token.books_last_created:
             sync_results.append({"NewEntitlement": entitlement})
         else:
@@ -297,8 +299,8 @@ def HandleSyncRequest():
 
     new_archived_last_modified = max(new_archived_last_modified, max_change)
 
-    # no. of books returned
-    book_count = changed_entries.count()
+    # books count not yet synced
+    book_count = changed_entries.count() - books.count()
     # last entry:
     cont_sync = bool(book_count)
     log.debug("Remaining books to Sync: {}".format(book_count))
@@ -319,10 +321,10 @@ def HandleSyncRequest():
         changed_reading_states = changed_reading_states.filter(
             ub.KoboReadingState.last_modified > sync_token.reading_state_last_modified)
 
-    changed_reading_states = changed_reading_states.filter(
+    changed_reading_states = (changed_reading_states.filter(
         and_(ub.KoboReadingState.user_id == current_user.id,
-             ub.KoboReadingState.book_id.notin_(reading_states_in_new_entitlements)))\
-        .order_by(ub.KoboReadingState.last_modified)
+             ub.KoboReadingState.book_id.notin_(reading_states_in_new_entitlements)))
+        .order_by(ub.KoboReadingState.last_modified))
     cont_sync |= bool(changed_reading_states.count() > SYNC_ITEM_LIMIT)
     for kobo_reading_state in changed_reading_states.limit(SYNC_ITEM_LIMIT).all():
         book = calibre_db.session.query(db.Books).filter(db.Books.id == kobo_reading_state.book_id).one_or_none()

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -39,7 +39,7 @@ from flask import (
 )
 from .cw_login import current_user
 from werkzeug.datastructures import Headers
-from sqlalchemy import func
+from sqlalchemy import func, null, literal
 from sqlalchemy.sql.expression import and_, or_
 from sqlalchemy.exc import StatementError
 
@@ -171,11 +171,15 @@ def HandleSyncRequest():
     only_kobo_shelves = current_user.kobo_only_shelves_sync
 
     if only_kobo_shelves:
-        changed_entries = calibre_db.session.query(db.Books,
+        extra_filters=[]
+        extra_filters.append(ub.Shelf.kobo_sync)
+
+        shelf_entries = calibre_db.session.query(db.Books,
                                                    ub.ArchivedBook.last_modified,
                                                    ub.BookShelf.date_added,
-                                                   ub.ArchivedBook.is_archived)
-        changed_entries = (changed_entries
+                                                   ub.ArchivedBook.is_archived,
+                                                   literal(False).label("deleted"))
+        shelf_entries = (shelf_entries
                            .join(db.Data).outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
                                                                           ub.ArchivedBook.user_id == current_user.id))
                            .filter(db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id)
@@ -183,13 +187,42 @@ def HandleSyncRequest():
                            .filter(ub.BookShelf.date_added > sync_token.books_last_modified)
                            .filter(db.Data.format.in_(KOBO_FORMATS))
                            .filter(calibre_db.common_filters(allow_show_archived=True))
-                           .order_by(db.Books.id)
-                           .order_by(ub.ArchivedBook.last_modified)
                            .join(ub.BookShelf, db.Books.id == ub.BookShelf.book_id)
                            .join(ub.Shelf)
                            .filter(ub.Shelf.user_id == current_user.id)
-                           .filter(ub.Shelf.kobo_sync)
+                           .filter(*extra_filters)
                            .distinct())
+
+        shelf_exists = (
+            calibre_db.session.query(ub.BookShelf)
+                .join(ub.Shelf)
+                .filter(
+                    ub.BookShelf.book_id == db.Books.id,
+                    *extra_filters
+                )
+                .exists()
+        )
+
+        deleted_entries = (
+            calibre_db.session.query(
+                db.Books,
+                ub.ArchivedBook.last_modified,
+                func.current_timestamp().label("date_added"),
+                ub.ArchivedBook.is_archived,
+                literal(True).label("deleted")
+            )
+            .join(ub.KoboSyncedBooks, and_(db.Books.id == ub.KoboSyncedBooks.book_id,
+                                                          ub.KoboSyncedBooks.user_id == current_user.id))
+            .outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
+                                             ub.ArchivedBook.user_id == current_user.id))
+            .filter(~shelf_exists)
+        )
+        changed_entries = (
+            shelf_entries
+            .union_all(deleted_entries)
+            .order_by(db.Books.id, ub.ArchivedBook.last_modified)
+        )
+
     else:
         changed_entries = calibre_db.session.query(db.Books,
                                                    ub.ArchivedBook.last_modified,
@@ -214,7 +247,7 @@ def HandleSyncRequest():
 
         kobo_reading_state = get_or_create_reading_state(book.Books.id)
         entitlement = {
-            "BookEntitlement": create_book_entitlement(book.Books, archived=(book.is_archived==True)),
+            "BookEntitlement": create_book_entitlement(book.Books, archived = book.is_archived or (only_kobo_shelves and book.deleted)),
             "BookMetadata": get_metadata(book.Books),
         }
 
@@ -246,7 +279,10 @@ def HandleSyncRequest():
             pass
 
         new_books_last_created = max(ts_created, new_books_last_created)
-        kobo_sync_status.add_synced_books(book.Books.id)
+        if only_kobo_shelves and book.deleted:
+            kobo_sync_status.remove_synced_book(book.Books.id)
+        else:
+            kobo_sync_status.add_synced_books(book.Books.id)
 
     max_change = changed_entries.filter(ub.ArchivedBook.is_archived)\
         .filter(ub.ArchivedBook.user_id == current_user.id) \

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -996,9 +996,9 @@ def HandleBookDeletionRequest(book_uuid):
         return redirect_or_proxy_request()
 
     book_id = book.id
-    is_archived = kobo_sync_status.change_archived_books(book_id, True)
-    if is_archived:
-        kobo_sync_status.remove_synced_book(book_id)
+    if not current_user.kobo_only_shelves_sync and current_user.check_visibility(32768):
+        kobo_sync_status.change_archived_books(book_id, True)
+    kobo_sync_status.remove_synced_book(book_id)
     return "", 204
 
 

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -168,6 +168,8 @@ def HandleSyncRequest():
     # We reload the book database so that the user gets a fresh view of the library
     # in case of external changes (e.g: adding a book through Calibre).
     calibre_db.reconnect_db(config, ub.app_DB_path)
+    # also refresh thumbnails if configured
+    helper.update_thumbnail_cache()
 
     only_kobo_shelves = current_user.kobo_only_shelves_sync
 
@@ -512,21 +514,17 @@ def get_metadata(book):
 
     book_uuid = book.uuid
 
-    thumbnail_generated_at = (
-        calibre_db.session
-        .query(ub.Thumbnail.generated_at)
-        .filter(ub.Thumbnail.entity_id == book.id)
-        .order_by(ub.Thumbnail.id)
-        .limit(1)
-    ).scalar()
-
-    #turn thumbnail generated_at timestamp into an epoch for use as the version
-    version_str = f"{thumbnail_generated_at.timestamp():.0f}"
+    #get cover version from book cover file
+    coverVersion = helper.get_book_cover_epoch_date_with_uuid(book_uuid)
+    if coverVersion:
+        coverImageId = book_uuid+"/"+coverVersion
+    else:
+        coverImageId = book_uuid
 
     metadata = {
         "Categories": ["00000000-0000-0000-0000-000000000001", ],
         # "Contributors": get_author(book),
-        "CoverImageId": book_uuid+"/"+version_str,
+        "CoverImageId": coverImageId,
         "CrossRevisionId": book_uuid,
         "CurrentDisplayPrice": {"CurrencyCode": "USD", "TotalAmount": 0},
         "CurrentLoveDisplayPrice": {"TotalAmount": 0},

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -18,7 +18,7 @@
 #  along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import base64
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 import os
 import uuid
 import zipfile
@@ -287,16 +287,23 @@ def HandleSyncRequest():
             log.debug("Marking as NewEntitlement")
             entitlement["BookMetadata"] = get_metadata(book.Books)
             sync_results.append({"NewEntitlement": entitlement})
+            kobo_sync_status.add_synced_books(book.Books.id)
         elif only_kobo_shelves and book.deleted:
             log.debug("Marking as ChangedEntitlement for deletion")
             sync_results.append({"ChangedEntitlement": entitlement})
-        elif file_modified > sync_token.books_last_modified:
+            log.debug("Removing book from synced books")
+            kobo_sync_status.remove_synced_book(book.Books.id)
+        #book modified (which is what sets the sync token) and file modified can differ by a few seconds, so allow for up to a minute of difference before considering the file to be changed
+        elif file_modified > sync_token.books_last_modified + timedelta(seconds=60):
             # setting Accessibility to "Preview" tricks the Kobo to automatically redownload a book on the next call to the sync URL
             # cont_sync will be set whenever this is hit, so the query is ran again, and since the book is also removed from the synced books list, it will show up again
             log.debug("Marking as ChangedEntitlement & Preview for file update")
             entitlement["BookEntitlement"]["Accessibility"]="Preview"
             sync_results.append({"ChangedEntitlement": entitlement})
             changed_books += 1
+            # delete sync record if book was changed to force redownload on next call to sync URL
+            log.debug("Removing changed book from synced books")
+            kobo_sync_status.remove_synced_book(book.Books.id)
         else:
             log.debug("Marking as ChangedProductMetadata")
             entitlement["BookMetadata"] = get_metadata(book.Books)
@@ -313,12 +320,6 @@ def HandleSyncRequest():
             pass
 
         new_books_last_created = max(ts_created, new_books_last_created)
-        # delete sync record if book was changed to force redownload on next call to sync URL
-        if (only_kobo_shelves and book.deleted) or file_modified > sync_token.books_last_modified:
-            log.debug("Removing book from synced books")
-            kobo_sync_status.remove_synced_book(book.Books.id)
-        else:
-            kobo_sync_status.add_synced_books(book.Books.id)
 
     max_change = changed_entries.filter(ub.ArchivedBook.is_archived)\
         .filter(ub.ArchivedBook.user_id == current_user.id) \

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -275,8 +275,10 @@ def HandleSyncRequest():
             sync_results.append({"NewEntitlement": entitlement})
         else:
             log.debug("Marking as ChangedEntitlement")
-            sync_results.append({"ChangedEntitlement": entitlement})
-            sync_results.append({"ChangedProductMetadata": get_metadata(book.Books)})
+            entitlement["BookMetadata"] = get_metadata(book.Books)
+            sync_results.append({"ChangedProductMetadata": entitlement})
+            # sync_results.append({"ChangedEntitlement": entitlement})
+            # sync_results.append({"ChangedProductMetadata": get_metadata(book.Books)})
 
         new_books_last_modified = max(
             book.Books.last_modified.replace(tzinfo=None), new_books_last_modified

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -271,8 +271,10 @@ def HandleSyncRequest():
 
         log.debug("Syncing book %s, ts_created: %s", book.Books.id, ts_created)
         if ts_created > sync_token.books_last_created:
+            log.debug("Marking as NewEntitlement")
             sync_results.append({"NewEntitlement": entitlement})
         else:
+            log.debug("Marking as ChangedEntitlement")
             sync_results.append({"ChangedEntitlement": entitlement})
 
         new_books_last_modified = max(

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -287,7 +287,7 @@ def HandleSyncRequest():
             log.debug("Marking as NewEntitlement")
             entitlement["BookMetadata"] = get_metadata(book.Books)
             sync_results.append({"NewEntitlement": entitlement})
-        elif book.deleted:
+        elif only_kobo_shelves and book.deleted:
             log.debug("Marking as ChangedEntitlement for deletion")
             sync_results.append({"ChangedEntitlement": entitlement})
         elif file_modified > sync_token.books_last_modified:

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -209,7 +209,7 @@ def HandleSyncRequest():
             calibre_db.session.query(
                 db.Books,
                 ub.ArchivedBook.last_modified,
-                func.current_timestamp().label("date_added"),
+                db.Books.timestamp.label("date_added"),
                 ub.ArchivedBook.is_archived,
                 literal(True).label("deleted")
             )

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -173,6 +173,13 @@ def HandleSyncRequest():
 
     only_kobo_shelves = current_user.kobo_only_shelves_sync
 
+    synced_ids = (
+        calibre_db.session
+        .query(ub.KoboSyncedBooks.book_id)
+        .filter(ub.KoboSyncedBooks.user_id == current_user.id)
+        .scalar_subquery()
+    )
+
     if only_kobo_shelves:
         extra_filters=[]
         extra_filters.append(ub.Shelf.kobo_sync)
@@ -181,12 +188,13 @@ def HandleSyncRequest():
                                                    ub.ArchivedBook.last_modified,
                                                    ub.BookShelf.date_added,
                                                    ub.ArchivedBook.is_archived,
+                                                   db.Books.id.in_(synced_ids).label("kobo_synced"),
                                                    literal(False).label("deleted"))
         shelf_entries = (shelf_entries
                            .join(db.Data).outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
                                                                           ub.ArchivedBook.user_id == current_user.id))
                            .filter(or_(
-                                db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id).filter(ub.KoboSyncedBooks.user_id == current_user.id)),
+                                db.Books.id.notin_(synced_ids),
                                 func.datetime(db.Books.last_modified) > sync_token.books_last_modified,
                                 func.datetime(ub.BookShelf.date_added) > sync_token.books_last_modified,
                             ))
@@ -214,6 +222,7 @@ def HandleSyncRequest():
                 ub.ArchivedBook.last_modified,
                 db.Books.timestamp.label("date_added"),
                 ub.ArchivedBook.is_archived,
+                db.Books.id.in_(synced_ids).label("kobo_synced"),
                 literal(True).label("deleted")
             )
             .join(ub.KoboSyncedBooks, and_(db.Books.id == ub.KoboSyncedBooks.book_id,
@@ -232,12 +241,13 @@ def HandleSyncRequest():
     else:
         changed_entries = calibre_db.session.query(db.Books,
                                                    ub.ArchivedBook.last_modified,
-                                                   ub.ArchivedBook.is_archived)
+                                                   ub.ArchivedBook.is_archived,
+                                                   db.Books.id.in_(synced_ids).label("kobo_synced"))
         changed_entries = (changed_entries
                            .join(db.Data).outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
                                                                           ub.ArchivedBook.user_id == current_user.id))
                            .filter(or_(
-                                db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id).filter(ub.KoboSyncedBooks.user_id == current_user.id)),
+                                db.Books.id.notin_(synced_ids),
                                 func.datetime(db.Books.last_modified) > sync_token.books_last_modified
                             ))
                            .filter(calibre_db.common_filters(allow_show_archived=True))
@@ -249,6 +259,7 @@ def HandleSyncRequest():
     books = changed_entries.limit(SYNC_ITEM_LIMIT)
     log.debug("Books to Sync: {}".format(len(books.all())))
     log.debug("sync_token.books_last_created: %s", sync_token.books_last_created)
+    changed_books=0
     for book in books:
         formats = [data.format for data in book.Books.data]
         if 'KEPUB' not in formats and config.config_kepubifypath and 'EPUB' in formats:
@@ -270,15 +281,22 @@ def HandleSyncRequest():
             ts_created = max(ts_created, book.date_added.replace(tzinfo=None))
         except AttributeError:
             pass
-
-        log.debug("Syncing book %s, ts_created: %s", book.Books.id, ts_created)
-        if ts_created > sync_token.books_last_created:
+        file_modified = get_book_file_modified(book.Books)
+        log.debug("Syncing book %s, ts_created: %s, book file modified: %s", book.Books.id, ts_created, file_modified)
+        if ts_created > sync_token.books_last_created or not book.kobo_synced:
             log.debug("Marking as NewEntitlement")
             entitlement["BookMetadata"] = get_metadata(book.Books)
             sync_results.append({"NewEntitlement": entitlement})
         elif book.deleted:
-            log.debug("Marking as ChangedEntitlement")
+            log.debug("Marking as ChangedEntitlement for deletion")
             sync_results.append({"ChangedEntitlement": entitlement})
+        elif file_modified > sync_token.books_last_modified:
+            # setting Accessibility to "Preview" tricks the Kobo to automatically redownload a book on the next call to the sync URL
+            # cont_sync will be set whenever this is hit, so the query is ran again, and since the book is also removed from the synced books list, it will show up again
+            log.debug("Marking as ChangedEntitlement & Preview for file update")
+            entitlement["BookEntitlement"]["Accessibility"]="Preview"
+            sync_results.append({"ChangedEntitlement": entitlement})
+            changed_books += 1
         else:
             log.debug("Marking as ChangedProductMetadata")
             entitlement["BookMetadata"] = get_metadata(book.Books)
@@ -295,7 +313,9 @@ def HandleSyncRequest():
             pass
 
         new_books_last_created = max(ts_created, new_books_last_created)
-        if only_kobo_shelves and book.deleted:
+        # delete sync record if book was changed to force redownload on next call to sync URL
+        if (only_kobo_shelves and book.deleted) or file_modified > sync_token.books_last_modified:
+            log.debug("Removing book from synced books")
             kobo_sync_status.remove_synced_book(book.Books.id)
         else:
             kobo_sync_status.add_synced_books(book.Books.id)
@@ -308,8 +328,9 @@ def HandleSyncRequest():
 
     new_archived_last_modified = max(new_archived_last_modified, max_change)
 
-    # books count not yet synced
-    book_count = changed_entries.count() - books.count()
+    # Determine books count not yet synced.
+    # changed_books indicates the count of books that need to be redownloaded due to file change
+    book_count = changed_entries.count() - books.count() + changed_books
     # last entry:
     cont_sync = bool(book_count)
     log.debug("Remaining books to Sync: {}".format(book_count))
@@ -485,6 +506,27 @@ def get_language(book):
     if not book.languages:
         return 'en'
     return isoLanguages.get(part3=book.languages[0].lang_code).part1
+
+
+def get_book_file_modified(book):
+    kepub = [data for data in book.data if data.format == 'KEPUB']
+    revision = 0
+    for book_data in kepub if len(kepub) > 0 else book.data:
+        if book_data.format not in KOBO_FORMATS:
+            continue
+        for kobo_format in KOBO_FORMATS[book_data.format]:
+            # log.debug('Id: %s, Format: %s' % (book.id, kobo_format))
+            try:
+                if get_epub_layout(book, book_data) == 'pre-paginated':
+                    kobo_format = 'EPUB3FL'
+                version = helper.get_file_modified_epoch(book, kobo_format, book_data)
+                if version > revision:
+                    revision = version
+            except (zipfile.BadZipfile, FileNotFoundError) as e:
+                log.error(e)
+
+    modified_dt = datetime.fromtimestamp(revision, tz=timezone.utc).replace(tzinfo=None)
+    return modified_dt
 
 
 def get_metadata(book):

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -182,9 +182,11 @@ def HandleSyncRequest():
         shelf_entries = (shelf_entries
                            .join(db.Data).outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
                                                                           ub.ArchivedBook.user_id == current_user.id))
-                           .filter(db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id)
-                                                      .filter(ub.KoboSyncedBooks.user_id == current_user.id)))
-                           .filter(ub.BookShelf.date_added > sync_token.books_last_modified)
+                           .filter(and_(
+                                db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id).filter(ub.KoboSyncedBooks.user_id == current_user.id)),
+                                db.Books.last_modified < sync_token.books_last_modified
+                            ))
+                           .filter(or_(ub.Shelf.is_public == 1, ub.BookShelf.date_added > sync_token.books_last_modified))
                            .filter(db.Data.format.in_(KOBO_FORMATS))
                            .filter(calibre_db.common_filters(allow_show_archived=True))
                            .join(ub.BookShelf, db.Books.id == ub.BookShelf.book_id)
@@ -230,8 +232,10 @@ def HandleSyncRequest():
         changed_entries = (changed_entries
                            .join(db.Data).outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
                                                                           ub.ArchivedBook.user_id == current_user.id))
-                           .filter(db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id)
-                                                      .filter(ub.KoboSyncedBooks.user_id == current_user.id)))
+                           .filter(and_(
+                                db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id).filter(ub.KoboSyncedBooks.user_id == current_user.id)),
+                                db.Books.last_modified < sync_token.books_last_modified
+                            ))
                            .filter(calibre_db.common_filters(allow_show_archived=True))
                            .filter(db.Data.format.in_(KOBO_FORMATS))
                            .order_by(db.Books.last_modified)

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -26,6 +26,7 @@ from time import gmtime, strftime
 import json
 from urllib.parse import unquote
 import requests
+import uuid
 
 from flask import (
     Blueprint,
@@ -510,10 +511,22 @@ def get_metadata(book):
                 log.error(e)
 
     book_uuid = book.uuid
+
+    thumbnail_generated_at = (
+        calibre_db.session
+        .query(ub.Thumbnail.generated_at)
+        .filter(ub.Thumbnail.entity_id == book.id)
+        .order_by(ub.Thumbnail.id)
+        .limit(1)
+    ).scalar()
+
+    #turn thumbnail generated_at timestamp into an epoch for use as the version
+    version_str = f"{thumbnail_generated_at.timestamp():.0f}"
+
     metadata = {
         "Categories": ["00000000-0000-0000-0000-000000000001", ],
         # "Contributors": get_author(book),
-        "CoverImageId": book_uuid,
+        "CoverImageId": book_uuid+"/"+version_str,
         "CrossRevisionId": book_uuid,
         "CurrentDisplayPrice": {"CurrencyCode": "USD", "TotalAmount": 0},
         "CurrentLoveDisplayPrice": {"TotalAmount": 0},
@@ -962,10 +975,12 @@ def get_current_bookmark_response(current_bookmark):
     return resp
 
 
-@kobo.route("/<book_uuid>/<width>/<height>/<isGreyscale>/image.jpg", defaults={'Quality': ""})
-@kobo.route("/<book_uuid>/<width>/<height>/<Quality>/<isGreyscale>/image.jpg")
+@kobo.route("/<book_uuid>/<width>/<height>/<isGreyscale>/image.jpg", defaults={'Quality': "", 'version': ""})
+@kobo.route("/<book_uuid>/<width>/<height>/<Quality>/<isGreyscale>/image.jpg", defaults={'version': ""})
+@kobo.route("/<book_uuid>/<version>/<width>/<height>/<isGreyscale>/image.jpg", defaults={'Quality': ""})
+@kobo.route("/<book_uuid>/<version>/<width>/<height>/<Quality>/<isGreyscale>/image.jpg")
 @requires_kobo_auth
-def HandleCoverImageRequest(book_uuid, width, height, Quality, isGreyscale):
+def HandleCoverImageRequest(book_uuid, version, width, height, Quality, isGreyscale):
     try:
         if int(height) > 1000:
             resolution = COVER_THUMBNAIL_LARGE

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -182,11 +182,11 @@ def HandleSyncRequest():
         shelf_entries = (shelf_entries
                            .join(db.Data).outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
                                                                           ub.ArchivedBook.user_id == current_user.id))
-                           .filter(and_(
+                           .filter(or_(
                                 db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id).filter(ub.KoboSyncedBooks.user_id == current_user.id)),
-                                db.Books.last_modified < sync_token.books_last_modified
+                                db.Books.last_modified > sync_token.books_last_modified
                             ))
-                           .filter(or_(ub.Shelf.is_public == 1, ub.BookShelf.date_added > sync_token.books_last_modified))
+                           .filter(ub.BookShelf.date_added > sync_token.books_last_modified)
                            .filter(db.Data.format.in_(KOBO_FORMATS))
                            .filter(calibre_db.common_filters(allow_show_archived=True))
                            .join(ub.BookShelf, db.Books.id == ub.BookShelf.book_id)
@@ -232,9 +232,9 @@ def HandleSyncRequest():
         changed_entries = (changed_entries
                            .join(db.Data).outerjoin(ub.ArchivedBook, and_(db.Books.id == ub.ArchivedBook.book_id,
                                                                           ub.ArchivedBook.user_id == current_user.id))
-                           .filter(and_(
+                           .filter(or_(
                                 db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id).filter(ub.KoboSyncedBooks.user_id == current_user.id)),
-                                db.Books.last_modified < sync_token.books_last_modified
+                                db.Books.last_modified > sync_token.books_last_modified
                             ))
                            .filter(calibre_db.common_filters(allow_show_archived=True))
                            .filter(db.Data.format.in_(KOBO_FORMATS))

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -184,9 +184,9 @@ def HandleSyncRequest():
                                                                           ub.ArchivedBook.user_id == current_user.id))
                            .filter(or_(
                                 db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id).filter(ub.KoboSyncedBooks.user_id == current_user.id)),
-                                func.datetime(db.Books.last_modified) > sync_token.books_last_modified
+                                func.datetime(db.Books.last_modified) > sync_token.books_last_modified,
+                                func.datetime(ub.BookShelf.date_added) > sync_token.books_last_modified,
                             ))
-                           .filter(func.datetime(ub.BookShelf.date_added) > sync_token.books_last_modified)
                            .filter(db.Data.format.in_(KOBO_FORMATS))
                            .filter(calibre_db.common_filters(allow_show_archived=True))
                            .join(ub.BookShelf, db.Books.id == ub.BookShelf.book_id)
@@ -264,7 +264,7 @@ def HandleSyncRequest():
         ts_created = book.Books.timestamp.replace(tzinfo=None)
 
         try:
-            ts_created = max(ts_created, book.date_added)
+            ts_created = max(ts_created, book.date_added.replace(tzinfo=None))
         except AttributeError:
             pass
 

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -184,9 +184,9 @@ def HandleSyncRequest():
                                                                           ub.ArchivedBook.user_id == current_user.id))
                            .filter(or_(
                                 db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id).filter(ub.KoboSyncedBooks.user_id == current_user.id)),
-                                db.Books.last_modified > sync_token.books_last_modified
+                                func.datetime(db.Books.last_modified) > sync_token.books_last_modified
                             ))
-                           .filter(ub.BookShelf.date_added > sync_token.books_last_modified)
+                           .filter(func.datetime(ub.BookShelf.date_added) > sync_token.books_last_modified)
                            .filter(db.Data.format.in_(KOBO_FORMATS))
                            .filter(calibre_db.common_filters(allow_show_archived=True))
                            .join(ub.BookShelf, db.Books.id == ub.BookShelf.book_id)
@@ -223,6 +223,7 @@ def HandleSyncRequest():
             shelf_entries
             .union_all(deleted_entries)
             .order_by(db.Books.id, ub.ArchivedBook.last_modified)
+            .group_by(db.Books.id)
         )
 
     else:
@@ -234,7 +235,7 @@ def HandleSyncRequest():
                                                                           ub.ArchivedBook.user_id == current_user.id))
                            .filter(or_(
                                 db.Books.id.notin_(calibre_db.session.query(ub.KoboSyncedBooks.book_id).filter(ub.KoboSyncedBooks.user_id == current_user.id)),
-                                db.Books.last_modified > sync_token.books_last_modified
+                                func.datetime(db.Books.last_modified) > sync_token.books_last_modified
                             ))
                            .filter(calibre_db.common_filters(allow_show_archived=True))
                            .filter(db.Data.format.in_(KOBO_FORMATS))
@@ -277,7 +278,7 @@ def HandleSyncRequest():
         )
         try:
             new_books_last_modified = max(
-                new_books_last_modified, book.date_added
+                new_books_last_modified, book.date_added.replace(tzinfo=None)
             )
         except AttributeError:
             pass


### PR DESCRIPTION
This is a continuation of PR #3381, and is dependent on changes from it, but I branched it off from my branch for that PR, separating it out since the functionality is for a pretty narrow use case, and the maintainers may not want to include this part.

This is for issue #3133.

When a sync is run, for any books that have any of the `KOBO_FORMAT` books with a `file last modified` date greater than the last sync, the sync request first sends a `ChangedEntitlemet` with `Accessibility` set to `Preview`. This causes the book download to be removed, but that isn't the purpose of it. The purpose is to make it so that with the next sync, when `Accessibility` is set to `Full` like normal, the Kobo sees it as a change, which causes a re-download.

So, after the `ChangedEntitlement` is sent, the book is removed from the `kobo_synced_books` table, and `cont_sync` is set to true, so that when Kobo process the request, it does another request to the sync page.

On that second call, since the book file is no longer modified after the last sync date, and the book is not in the `kobo_synced_books` table, it is sent as a `NewEntitlement`, which will trigger an automatic download of it - for the first 5 new books from a sync request as usual.
