### PR TITLE
Add on-demand conversion to ePub to support in browser reading of other formats

### DIFF
--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 #   This file is part of the Calibre-Web (https://github.com/janeczku/calibre-web)
-#     Copyright (C) 2019 OzzieIsaacs, pwr
+#     Copyright (C) 2019-2025 OzzieIsaacs, pwr, akharlamov
 #
 #   This program is free software: you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
@@ -19,7 +19,9 @@
 import os
 import sys
 import json
+from typing import Sequence
 
+from packaging.tags import android_platforms
 from sqlalchemy import Column, String, Integer, SmallInteger, Boolean, BLOB, JSON
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.sql.expression import text
@@ -39,6 +41,7 @@ from .string_helper import strip_whitespaces
 
 log = logger.create()
 _Base = declarative_base()
+CONVERSION_SOURCE_FMT_PRIORITY = ('FB2', 'FBZ', 'MOBI', 'PRC', 'TXT', 'TXTZ')
 
 
 class _Flask_Settings(_Base):
@@ -419,6 +422,14 @@ class ConfigSQL(object):
         super().__setattr__(attr_name, attr_value)
         self.__dict__["dirty"].append(attr_name)
 
+    def convertable_to(self, fmt: str) -> Sequence[str]:
+        if not self.config_converterpath:
+            return list()
+
+        convertable_formats = {
+            'EPUB': CONVERSION_SOURCE_FMT_PRIORITY
+        }
+        return convertable_formats.get(fmt.upper(), [])
 
 def _encrypt_fields(session, secret_key):
     try:

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 
 #  This file is part of the Calibre-Web (https://github.com/janeczku/calibre-web)
-#    Copyright (C) 2012-2019 cervinko, idalin, SiphonSquirrel, ouzklcn, akushsky,
-#                            OzzieIsaacs, bodybybuddha, jkrehm, matthazinski, janeczku
+#    Copyright (C) 2012-2025 cervinko, idalin, SiphonSquirrel, ouzklcn, akushsky,
+#                            OzzieIsaacs, bodybybuddha, jkrehm, matthazinski, janeczku,
+#                            akharlamov
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -200,11 +201,13 @@ def check_send_to_ereader(entry):
 # list with supported formats
 def check_read_formats(entry):
     extensions_reader = {'TXT', 'PDF', 'EPUB', 'KEPUB', 'CBZ', 'CBT', 'CBR', 'DJVU', 'DJV'}
+    if config.config_converterpath:
+        extensions_reader = {'FB2', 'FBZ', 'MOBI', 'PRC', *extensions_reader}
+
     book_formats = list()
-    if len(entry.data):
-        for ele in iter(entry.data):
-            if ele.format.upper() in extensions_reader:
-                book_formats.append(ele.format.lower())
+    for ele in iter(entry.data):
+        if ele.format.upper() in extensions_reader:
+            book_formats.append(ele.format.lower())
     return book_formats
 
 

--- a/cps/static/js/refresh.js
+++ b/cps/static/js/refresh.js
@@ -1,0 +1,33 @@
+/* This file is part of the Calibre-Web (https://github.com/janeczku/calibre-web)
+ *    Copyright (C) 2025 akharlamov
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+function incrementProgress() {
+    let pb = document.getElementById('progressbar');
+    let val = parseInt(pb.getAttribute('aria-valuenow') || '0') + 1;
+    let w = Math.round(100 * val / parseInt(pb.getAttribute('aria-valuemax') || '10'));
+
+    pb.setAttribute('style', `width:${w}%`);
+    pb.setAttribute('aria-valuenow', `${val}`);
+}
+
+$(document).ready(function () {
+        setTimeout(function () {
+            location.reload();
+        }, 5000);
+        setInterval(incrementProgress, 1000);
+    }
+);

--- a/cps/templates/converting.html
+++ b/cps/templates/converting.html
@@ -1,0 +1,22 @@
+{% extends "layout.html" %}
+{% block header %}
+<link href="{{ url_for('static', filename='css/libs/bootstrap-table.min.css') }}" rel="stylesheet">
+{% endblock %}
+{% block body %}
+<div class="discover">
+    <h2>{{_('Converting e-book')}}</h2>
+    <div>{{ entry.authors[0].name }}, {{ entry.title }}</div>
+    <div class="progress">
+        <div id="progressbar" class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="5"></div>
+    </div>
+    <a href="{{ url_for('web.read_book', book_id=book_id, book_format='epub') }}">
+        Press here if the book does not open
+    </a>
+</div>
+{% endblock %}
+{% block js %}
+<script src="{{ url_for('static', filename='js/libs/bootstrap-table/bootstrap-table.min.js') }}"></script>
+<script src="{{ url_for('static', filename='js/libs/bootstrap-table/bootstrap-table-locale-all.min.js') }}"></script>
+<script src="{{ url_for('static', filename='js/table.js') }}"></script>
+<script src="{{ url_for('static', filename='js/refresh.js') }}"></script>
+{% endblock %}

--- a/cps/web.py
+++ b/cps/web.py
@@ -1,9 +1,9 @@
 #  This file is part of the Calibre-Web (https://github.com/janeczku/calibre-web)
-#    Copyright (C) 2018-2019 OzzieIsaacs, cervinko, jkrehm, bodybybuddha, ok11,
+#    Copyright (C) 2018-2025 OzzieIsaacs, cervinko, jkrehm, bodybybuddha, ok11,
 #                            andy29485, idalin, Kyosfonica, wuqi, Kennyl, lemmsh,
 #                            falgh1, grunjol, csitko, ytils, xybydy, trasba, vrabe,
 #                            ruben-herold, marblepebble, JackED42, SiphonSquirrel,
-#                            apetresc, nanu-c, mutschler
+#                            apetresc, nanu-c, mutschler, akharlamov
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -21,6 +21,9 @@
 import os
 import json
 import mimetypes
+import uuid
+from pathlib import Path
+
 import chardet  # dependency of requests
 import copy
 from importlib.metadata import metadata
@@ -29,6 +32,8 @@ from flask import Blueprint, jsonify, request, redirect, send_from_directory, ma
 from flask import session as flask_session
 from flask_babel import gettext as _
 from flask_babel import get_locale
+
+from .config_sql import CONVERSION_SOURCE_FMT_PRIORITY
 from .cw_login import login_user, logout_user, current_user
 from flask_limiter import RateLimitExceeded
 from flask_limiter.util import get_remote_address
@@ -47,10 +52,11 @@ from .gdriveutils import getFileFromEbooksFolder, do_gdrive_download
 from .helper import check_valid_domain, check_email, check_username, \
     get_book_cover, get_series_cover_thumbnail, get_download_link, send_mail, generate_random_password, \
     send_registration_mail, check_send_to_ereader, check_read_formats, tags_filters, reset_password, valid_email, \
-    edit_book_read_status, valid_password
+    edit_book_read_status, valid_password, convert_book_format
 from .pagination import Pagination
 from .redirect import get_redirect_location
 from .cw_babel import get_available_locale
+from .tasks.convert import TaskConvert
 from .usermanagement import login_required_if_no_ano
 from .kobo_sync_status import remove_synced_book
 from .render_template import render_title_template
@@ -1566,6 +1572,39 @@ def profile():
 # ###################################Show single book ##################################################################
 
 
+def _start_epub_convert_task(book_id, filepath, source_format):
+    lib_dir = config.config_calibre_split_dir if config.config_calibre_split else config.config_calibre_dir
+    task = TaskConvert(
+        str(Path(lib_dir) / filepath),
+        book_id,
+        f'Converting {book_id} to EPUB',
+        {
+            'old_book_format': source_format,
+            'new_book_format': 'EPUB',
+        },
+        None,
+        user=current_user.name,
+    )
+    queued_task = WorkerThread.add(current_user, task)
+    return queued_task.task.id
+
+
+def _select_conversion_source(book):
+    cur_candidate = None
+    cur_name = None
+    cur_priority = -1
+    for data in book.data:
+        if data.format in CONVERSION_SOURCE_FMT_PRIORITY:
+            priority = CONVERSION_SOURCE_FMT_PRIORITY.index(data.format)
+        else:
+            priority = -1
+        if priority > cur_priority:
+            cur_candidate = data.format
+            cur_name = data.name
+            cur_priority = priority
+    return cur_candidate, cur_name
+
+
 @web.route("/read/<int:book_id>/<book_format>")
 @login_required_if_no_ano
 @viewer_required
@@ -1586,20 +1625,28 @@ def read_book(book_id, book_format):
         bookmark = ub.session.query(ub.Bookmark).filter(and_(ub.Bookmark.user_id == int(current_user.id),
                                                              ub.Bookmark.book_id == book_id,
                                                              ub.Bookmark.format == book_format.upper())).first()
-    if book_format.lower() == "epub" or book_format.lower() == "kepub":
+    format_id = book_format.lower()
+    if format_id in ["epub", "kepub"]:
         log.debug("Start [k]epub reader for %d", book_id)
         return render_title_template('read.html', bookid=book_id, title=book.title, bookmark=bookmark,
                                      book_format=book_format)
-    elif book_format.lower() == "pdf":
+    elif format_id == "pdf":
         log.debug("Start pdf reader for %d", book_id)
         return render_title_template('readpdf.html', pdffile=book_id, title=book.title)
-    elif book_format.lower() == "txt":
+    elif format_id == "txt":
         log.debug("Start txt reader for %d", book_id)
         return render_title_template('readtxt.html', txtfile=book_id, title=book.title)
-    elif book_format.lower() in ["djvu", "djv"]:
+    elif format_id in ["djvu", "djv"]:
         log.debug("Start djvu reader for %d", book_id)
         return render_title_template('readdjvu.html', djvufile=book_id, title=book.title,
-                                     extension=book_format.lower())
+                                     extension=format_id)
+    elif book_format.upper() in config.convertable_to('EPUB'):
+        log.debug("Start conversion to epub for %d", book_id)
+        src_format, name = _select_conversion_source(book)
+        task_id = _start_epub_convert_task(book_id, Path(book.path) / name, src_format)
+
+        url = url_for('web.show_book_converting', book_id=book_id, task_id=task_id)
+        return redirect(url)
     else:
         for fileExt in constants.EXTENSIONS_AUDIO:
             if book_format.lower() == fileExt:
@@ -1623,10 +1670,7 @@ def read_book(book_id, book_format):
               category="error")
         return redirect(url_for("web.index"))
 
-
-@web.route("/book/<int:book_id>")
-@login_required_if_no_ano
-def show_book(book_id):
+def _get_book_entry(book_id):
     entries = calibre_db.get_book_read_archived(book_id, config.config_read_column, allow_show_archived=True)
     if entries:
         read_book = entries[1]
@@ -1660,15 +1704,52 @@ def show_book(book_id):
             if media_format.format.lower() in constants.EXTENSIONS_AUDIO:
                 entry.audio_entries.append(media_format.format.lower())
 
+        return entry, book_in_shelves, cc
+    else:
+        return None, None, None
+
+
+@web.route("/book/<int:book_id>")
+@login_required_if_no_ano
+def show_book(book_id):
+    entry, shelves, cc = _get_book_entry(book_id)
+    if entry:
         return render_title_template('detail.html',
                                      entry=entry,
                                      cc=cc,
                                      is_xhr=request.headers.get('X-Requested-With') == 'XMLHttpRequest',
                                      title=entry.title,
-                                     books_shelfs=book_in_shelves,
+                                     books_shelfs=shelves,
                                      page="book")
     else:
-        log.debug("Selected book is unavailable. File does not exist or is not accessible")
-        flash(_("Oops! Selected book is unavailable. File does not exist or is not accessible"),
-              category="error")
-        return redirect(url_for("web.index"))
+        return _no_book_entry()
+
+
+def _no_book_entry():
+    log.debug("Selected book is unavailable. File does not exist or is not accessible")
+    flash(_("Oops! Selected book is unavailable. File does not exist or is not accessible"),
+          category="error")
+    return redirect(url_for("web.index"))
+
+
+@web.route("/book/<int:book_id>/converting/<task_id>")
+@login_required_if_no_ano
+def show_book_converting(book_id, task_id):
+    task_uuid = uuid.UUID(task_id)
+    task = WorkerThread.get_instance().get_task(task_uuid)
+    complete = not task or task.dead
+    if complete:
+        return redirect(url_for("web.read_book", book_id=book_id, book_format='epub'))
+    else:
+        entry = _get_book_entry(book_id)
+        if entry:
+            return render_title_template(
+                "converting.html",
+                entry=entry[0],
+                book_id=book_id,
+                task_id=task_id,
+            )
+        else:
+            return _no_book_entry()
+
+


### PR DESCRIPTION
Some libraries (including mine) have a large body of non-EPUB books. While it is possible to batch convert them to ePub, it is not efficient for multi-gigabyte libraries. 

The PR adds a simple on-demand conversion functionality, so in-browser reading is available for FB2 and MOBI if Calibre binaries are available. 

Implementation details:
A background task is started through WorkerThread. User is redirected to conversion page that reloads with 5 second interval and polls state of the task. On completion, the user is redirected to read_book page.