### PR TITLE
Enhanced error message (decode ele in calibre_traceback bytes into string)

### DIFF
--- a/cps/tasks/convert.py
+++ b/cps/tasks/convert.py
@@ -285,6 +285,9 @@ class TaskConvert(CalibreTask):
                 else:
                     error_message = ""
                     for ele in calibre_traceback:
+                        # Decode bytes to string if needed
+                        if isinstance(ele, bytes):
+                            ele = ele.decode('utf-8', errors="ignore").strip('\n')                       
                         if not ele.startswith('Traceback') and not ele.startswith('  File'):
                             error_message = N_("Calibre failed with error: %(error)s", error=ele)
                     return check, error_message


### PR DESCRIPTION
When Calibre-Web used to convert file type to another (_ex. RTF -> TXT_) while calibre itself is running, the task will fail and it shows the following vegue error message:

`startswith first arg must be bytes or a tuple of bytes, not str`	
  
By decoding `ele` in `calibre_traceback` before the `startswith` check (only if ele is bytes), it shows clearer error message:

`Calibre failed with error: Another calibre program such as calibre-server or the main calibre program is running. Having multiple programs that can make changes to a calibre library running at the same time is a bad idea. calibredb can connect directly to a running calibre Content server, to make changes through it, instead. See the documentation of the --with-library option for details.	`

_By the way, line 46 `current_milli_time = lambda: int(round(time() * 1000))` seems dead code._ 