### PR TITLE
Add timeout to Amazon metadata request and internal ThreadPoolExecutor

### DIFF
--- a/cps/metadata_provider/amazon.py
+++ b/cps/metadata_provider/amazon.py
@@ -56,17 +56,16 @@ class Amazon(Metadata):
         self, query: str, generic_cover: str = "", locale: str = "en"
     ) -> Optional[List[MetaRecord]]:
         def inner(link, index) -> [dict, int]:
-            with self.session as session:
-                try:
-                    r = session.get(f"https://www.amazon.com/{link}", timeout=10)
-                    r.raise_for_status()
-                except Exception as ex:
-                    log.warning(ex)
-                    return []
-                long_soup = BS(r.text, "lxml")  #~4sec :/
-                soup2 = long_soup.find("div", attrs={"cel_widget_id": "dpx-ppd_csm_instrumentation_wrapper"})
-                if soup2 is None:
-                    return []
+            try:
+                r = self.session.get(f"https://www.amazon.com/{link}", timeout=10)
+                r.raise_for_status()
+            except Exception as ex:
+                log.warning(ex)
+                return []
+            long_soup = BS(r.text, "lxml")  #~4sec :/
+            soup2 = long_soup.find("div", attrs={"cel_widget_id": "dpx-ppd_csm_instrumentation_wrapper"})
+            if soup2 is None:
+                return []
                 try:
                     match = MetaRecord(
                         title = "",
@@ -135,6 +134,10 @@ class Amazon(Metadata):
                           soup.findAll("div", attrs={"data-component-type": "s-search-result"})]
             with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
                 fut = {executor.submit(inner, link, index) for index, link in enumerate(links_list[:3])}
-                val = list(map(lambda x : x.result(), concurrent.futures.as_completed(fut, timeout=15)))
+                try:
+                    val = list(map(lambda x : x.result(), concurrent.futures.as_completed(fut, timeout=15)))
+                except concurrent.futures.TimeoutError:
+                    log.warning("Amazon search timeout after 15 seconds")
+                    val = []
         result = list(filter(lambda x: x, val))
         return [x[0] for x in sorted(result, key=itemgetter(1))] #sort by amazons listing order for best relevance


### PR DESCRIPTION
Fixes application freeze when fetching metadata from Amazon 