### PR TITLE
Fix: Setting read status for archived books in the books list page

### DIFF
--- a/cps/helper.py
+++ b/cps/helper.py
@@ -329,7 +329,7 @@ def edit_book_read_status(book_id, read_status=None):
     else:
         try:
             calibre_db.create_functions(config)
-            book = calibre_db.get_filtered_book(book_id)
+            book = calibre_db.get_filtered_book(book_id, True)
             book_read_status = getattr(book, 'custom_column_' + str(config.config_read_column))
             if len(book_read_status):
                 if read_status is None:


### PR DESCRIPTION
Changing the read status in the booklist would fail for archived books with an error the the custom_column doesn't exist.
Unarchived books didn't have this issue.

The issue was that call to retrieve the book by default does not include archived books.
Setting the second parameter in the function call to True ensures that archived books are included.