### PR TITLE
fix(kobo): add catch-all route for proxying unknown product endpoints

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -1014,6 +1014,8 @@ def handle_getests():
 @kobo.route("/v1/products/dailydeal", methods=["GET", "POST"])
 @kobo.route("/v1/products/deals", methods=["GET", "POST"])
 @kobo.route("/v1/products", methods=["GET", "POST"])
+@kobo.route("/v1/products/<path:dummy>", methods=["GET", "POST"])
+@kobo.route("/v1/products/<path:dummy>/", methods=["GET", "POST"])
 @kobo.route("/v1/affiliate", methods=["GET", "POST"])
 @kobo.route("/v1/deals", methods=["GET", "POST"])
 def HandleProductsRequest(dummy=None):


### PR DESCRIPTION
On my Kobo Libra color, the Kobo store proxy feature was failing with 404 errors for certain store endpoints (e.g., /v1/products/featuredforkoboplus/) because Flask's routing couldn't match these paths. This prevented the Discover tab from working when "Proxy unknown requests to Kobo Store" was enabled. It seems like it's a newer endpoint they've added.

I added catch-all routes using Flask's path converter to match any /v1/products/* paths not handled by more specific routes, allowing the proxy logic to properly redirect these requests to the official Kobo store API.

I've built and made the image available at `ghcr.io/alasano/calibre-web:kobo-fix` and I've tested the fix, it's working perfectly.

https://github.com/users/alasano/packages/container/package/calibre-web

Thanks!