### PR TITLE
Add hierarchical tree view for tag categories

### DIFF
--- a/cps/gdriveutils.py
+++ b/cps/gdriveutils.py
@@ -176,7 +176,7 @@ class PermissionAdded(Base):
         return str(self.gdrive_id)
 
 
-if not os.path.exists(cli_param.gd_path):
+if cli_param.gd_path and not os.path.exists(cli_param.gd_path):
     try:
         Base.metadata.create_all(engine)
     except Exception as ex:

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -1109,15 +1109,19 @@ def get_tag_display_name(tag_name, max_depth=2, separator='.'):
         separator: The hierarchy separator (default: '.')
 
     Returns:
-        Shortened display name (e.g., "Otherworld > Isekai" for max_depth=2)
+        Shortened display name (e.g., "Otherworld › Isekai" for max_depth=2)
     """
     parts = parse_tag_hierarchy(tag_name, separator)
-    if len(parts) <= max_depth:
+    if len(parts) <= 1:
         return tag_name
 
     # Take only the last max_depth levels
-    display_parts = parts[-max_depth:]
-    return ' > '.join(display_parts)
+    if len(parts) > max_depth:
+        display_parts = parts[-max_depth:]
+    else:
+        display_parts = parts
+
+    return ' › '.join(display_parts)
 
 
 def is_hierarchical_tag(tag_name, separator='.'):

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -1067,6 +1067,159 @@ def tags_filters():
     return and_(pos_content_tags_filter, ~neg_content_tags_filter)
 
 
+def parse_tag_hierarchy(tag_name, separator='.'):
+    """
+    Parse a hierarchical tag name into its components.
+
+    Args:
+        tag_name: The full tag name (e.g., "Fantasy.Magic.Dark")
+        separator: The hierarchy separator (default: '.')
+
+    Returns:
+        List of tag components (e.g., ["Fantasy", "Magic", "Dark"])
+    """
+    if not tag_name:
+        return []
+    return [part.strip() for part in tag_name.split(separator) if part.strip()]
+
+
+def get_tag_leaf_name(tag_name, separator='.'):
+    """
+    Get the leaf (last) component of a hierarchical tag.
+
+    Args:
+        tag_name: The full tag name (e.g., "Fantasy.Magic.Dark")
+        separator: The hierarchy separator (default: '.')
+
+    Returns:
+        The leaf name (e.g., "Dark")
+    """
+    parts = parse_tag_hierarchy(tag_name, separator)
+    return parts[-1] if parts else tag_name
+
+
+def get_tag_display_name(tag_name, max_depth=2, separator='.'):
+    """
+    Get a shortened display name for a hierarchical tag.
+    Shows only the deepest max_depth levels.
+
+    Args:
+        tag_name: The full tag name (e.g., "Fantasy.Otherworld.Isekai")
+        max_depth: Maximum number of levels to display (default: 2)
+        separator: The hierarchy separator (default: '.')
+
+    Returns:
+        Shortened display name (e.g., "Otherworld > Isekai" for max_depth=2)
+    """
+    parts = parse_tag_hierarchy(tag_name, separator)
+    if len(parts) <= max_depth:
+        return tag_name
+
+    # Take only the last max_depth levels
+    display_parts = parts[-max_depth:]
+    return ' > '.join(display_parts)
+
+
+def is_hierarchical_tag(tag_name, separator='.'):
+    """
+    Check if a tag name is hierarchical (contains the separator).
+
+    Args:
+        tag_name: The tag name to check
+        separator: The hierarchy separator (default: '.')
+
+    Returns:
+        True if the tag is hierarchical, False otherwise
+    """
+    return separator in tag_name if tag_name else False
+
+
+def build_tag_tree(tags_with_counts, separator='.'):
+    """
+    Build a hierarchical tree structure from flat tag list.
+
+    Args:
+        tags_with_counts: List of (tag_object, count) tuples
+        separator: The hierarchy separator (default: '.')
+
+    Returns:
+        Nested dictionary representing the tag tree with counts
+    """
+    tree = {}
+
+    for tag_entry in tags_with_counts:
+        tag_obj = tag_entry[0]
+        count = tag_entry[1]
+        tag_name = tag_obj.name
+
+        # Split the tag into parts
+        parts = parse_tag_hierarchy(tag_name, separator)
+
+        # Navigate/create the tree structure
+        current_level = tree
+        full_path = []
+
+        for i, part in enumerate(parts):
+            full_path.append(part)
+            is_leaf = (i == len(parts) - 1)
+
+            if part not in current_level:
+                current_level[part] = {
+                    '_count': 0,
+                    '_children': {},
+                    '_is_leaf': False,
+                    '_tag_id': None,
+                    '_full_path': separator.join(full_path)
+                }
+
+            # Add count to this level
+            current_level[part]['_count'] += count
+
+            if is_leaf:
+                current_level[part]['_is_leaf'] = True
+                current_level[part]['_tag_id'] = tag_obj.id
+
+            # Move to next level
+            current_level = current_level[part]['_children']
+
+    return tree
+
+
+def tree_to_list(tree, level=0, reverse=False):
+    """
+    Convert tree dictionary to a flat list for template rendering.
+
+    Args:
+        tree: Tree dictionary from build_tag_tree()
+        level: Current indentation level
+        reverse: If True, sort in reverse alphabetical order
+
+    Returns:
+        List of dictionaries with tree node information
+    """
+    result = []
+
+    for name in sorted(tree.keys(), reverse=reverse):
+        node = tree[name]
+        has_children = len(node['_children']) > 0
+
+        result.append({
+            'name': name,
+            'count': node['_count'],
+            'level': level,
+            'is_leaf': node['_is_leaf'],
+            'has_children': has_children,
+            'tag_id': node['_tag_id'],
+            'full_path': node['_full_path']
+        })
+
+        # Recursively add children
+        if has_children:
+            result.extend(tree_to_list(node['_children'], level + 1, reverse=reverse))
+
+    return result
+
+
 # checks if domain is in database (including wildcards)
 # example SELECT * FROM @TABLE WHERE 'abcdefg' LIKE Name;
 # from https://code.luasoftware.com/tutorials/flask/execute-raw-sql-in-flask-sqlalchemy/

--- a/cps/jinjia.py
+++ b/cps/jinjia.py
@@ -31,7 +31,7 @@ from flask import Blueprint, request, url_for, g
 from flask_babel import format_date
 from .cw_login import current_user
 
-from . import constants, logger
+from . import constants, logger, helper
 
 jinjia = Blueprint('jinjia', __name__)
 log = logger.create()
@@ -181,3 +181,18 @@ def contains_music(book_formats):
         if format.format.lower() in g.constants.EXTENSIONS_AUDIO:
             result = True
     return result
+
+
+@jinjia.app_template_filter('tag_display_name')
+def tag_display_name(tag_name, max_depth=2):
+    return helper.get_tag_display_name(tag_name, max_depth)
+
+
+@jinjia.app_template_filter('tag_leaf_name')
+def tag_leaf_name(tag_name):
+    return helper.get_tag_leaf_name(tag_name)
+
+
+@jinjia.app_template_filter('is_hierarchical_tag')
+def is_hierarchical_tag(tag_name):
+    return helper.is_hierarchical_tag(tag_name)

--- a/cps/static/css/style.css
+++ b/cps/static/css/style.css
@@ -438,3 +438,93 @@ div.log {
 .error-list {
     margin-top: 5px;
   }
+
+/* Hierarchical tag styles */
+.hierarchical-tag {
+  cursor: help;
+}
+
+.tags .hierarchical-tag:hover {
+  opacity: 0.8;
+}
+
+/* Tree view styles for category list */
+.tag-tree {
+  list-style: none;
+  padding-left: 0;
+  margin: 20px 0;
+}
+
+.tag-tree li {
+  margin: 0;
+  position: relative;
+}
+
+.tag-tree li[data-level="1"] {
+  padding-left: 25px;
+}
+
+.tag-tree li[data-level="2"] {
+  padding-left: 50px;
+}
+
+.tag-tree li[data-level="3"] {
+  padding-left: 75px;
+}
+
+.tag-tree li[data-level="4"] {
+  padding-left: 100px;
+}
+
+.tag-node {
+  display: flex;
+  align-items: center;
+  padding: 8px 5px;
+  cursor: pointer;
+  border-radius: 3px;
+  transition: background-color 0.2s;
+}
+
+.tag-node:hover {
+  background: #f5f5f5;
+}
+
+.tag-node.leaf {
+  cursor: default;
+}
+
+.tag-node .toggle {
+  width: 20px;
+  text-align: center;
+  margin-right: 5px;
+  font-size: 12px;
+  color: #666;
+  font-family: monospace;
+}
+
+.tag-node .icon {
+  margin-right: 8px;
+  color: #45b29d;
+  font-size: 14px;
+}
+
+.tag-node .name {
+  flex: 1;
+  color: #333;
+  text-decoration: none;
+}
+
+.tag-node a.name:hover {
+  text-decoration: underline;
+  color: #45b29d;
+}
+
+.tag-node .count {
+  margin-left: 10px;
+  background: #45b29d;
+  color: white;
+  padding: 2px 10px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: bold;
+}

--- a/cps/static/css/style.css
+++ b/cps/static/css/style.css
@@ -453,11 +453,14 @@ div.log {
   list-style: none;
   padding-left: 0;
   margin: 20px 0;
+  width: 100%;
+  max-width: 100%;
 }
 
 .tag-tree li {
   margin: 0;
   position: relative;
+  max-width: 100%;
 }
 
 .tag-tree li[data-level="1"] {
@@ -483,6 +486,7 @@ div.log {
   cursor: pointer;
   border-radius: 3px;
   transition: background-color 0.2s;
+  max-width: 100%;
 }
 
 .tag-node:hover {
@@ -504,27 +508,23 @@ div.log {
 
 .tag-node .icon {
   margin-right: 8px;
-  color: #45b29d;
   font-size: 14px;
 }
 
 .tag-node .name {
   flex: 1;
-  color: #333;
   text-decoration: none;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .tag-node a.name:hover {
   text-decoration: underline;
-  color: #45b29d;
 }
 
-.tag-node .count {
+/* Badge styling for tag tree */
+.tag-tree .tag-node .badge,
+.tag-node .badge {
   margin-left: 10px;
-  background: #45b29d;
-  color: white;
-  padding: 2px 10px;
-  border-radius: 12px;
-  font-size: 12px;
-  font-weight: bold;
+  flex-shrink: 0;
 }

--- a/cps/templates/category_tree.html
+++ b/cps/templates/category_tree.html
@@ -151,19 +151,31 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Add sort button handlers
     const currentDirection = parseInt(document.getElementById('asc').getAttribute('data-order'));
+    const csrfInput = document.querySelector('input[name="csrf_token"]');
+    const basePath = (typeof getPath === 'function' ? getPath() : '');
+
+    function postSortPreference(page, direction) {
+        const headers = { 'Content-Type': 'application/json' };
+        if (csrfInput && csrfInput.value) {
+            headers['X-CSRFToken'] = csrfInput.value;
+        }
+
+        fetch(basePath + '/ajax/view', {
+            method: 'POST',
+            headers: headers,
+            credentials: 'same-origin',
+            body: JSON.stringify({ [page]: { dir: direction } })
+        }).then(function() {
+            window.location.reload();
+        });
+    }
 
     document.getElementById('asc').addEventListener('click', function() {
         if (currentDirection === 1) return; // Already in ascending order
 
         // Send AJAX request to save preference, then reload
         const page = this.getAttribute('data-id');
-        fetch(window.location.origin + '/ajax/view', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ [page]: { dir: 'asc' } })
-        }).then(function() {
-            window.location.reload();
-        });
+        postSortPreference(page, 'asc');
     });
 
     document.getElementById('desc').addEventListener('click', function() {
@@ -171,13 +183,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
         // Send AJAX request to save preference, then reload
         const page = this.getAttribute('data-id');
-        fetch(window.location.origin + '/ajax/view', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ [page]: { dir: 'desc' } })
-        }).then(function() {
-            window.location.reload();
-        });
+        postSortPreference(page, 'desc');
     });
 });
 </script>

--- a/cps/templates/category_tree.html
+++ b/cps/templates/category_tree.html
@@ -148,6 +148,37 @@ document.addEventListener('DOMContentLoaded', function() {
             this.classList.add('active');
         });
     }
+
+    // Add sort button handlers
+    const currentDirection = parseInt(document.getElementById('asc').getAttribute('data-order'));
+
+    document.getElementById('asc').addEventListener('click', function() {
+        if (currentDirection === 1) return; // Already in ascending order
+
+        // Send AJAX request to save preference, then reload
+        const page = this.getAttribute('data-id');
+        fetch(window.location.origin + '/ajax/view', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ [page]: { dir: 'asc' } })
+        }).then(function() {
+            window.location.reload();
+        });
+    });
+
+    document.getElementById('desc').addEventListener('click', function() {
+        if (currentDirection === 0) return; // Already in descending order
+
+        // Send AJAX request to save preference, then reload
+        const page = this.getAttribute('data-id');
+        fetch(window.location.origin + '/ajax/view', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ [page]: { dir: 'desc' } })
+        }).then(function() {
+            window.location.reload();
+        });
+    });
 });
 </script>
 {% endblock %}

--- a/cps/templates/category_tree.html
+++ b/cps/templates/category_tree.html
@@ -1,0 +1,153 @@
+{% extends "layout.html" %}
+{% block body %}
+<h1 class="{{page}}">{{_(title)}}</h1>
+
+<div class="filterheader hidden-xs">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  <div id="asc" data-order="{{ order }}" data-id="{{ data }}" class="btn btn-primary {% if order == 1 %} active{% endif%}"><span class="glyphicon glyphicon-sort-by-alphabet"></span></div>
+  <div id="desc" data-id="{{ data }}" class="btn btn-primary{% if order == 0 %} active{% endif%}"><span class="glyphicon glyphicon-sort-by-alphabet-alt"></span></div>
+  {% if charlist|length %}
+  <div id="all" class="active btn btn-primary {% if charlist|length > 9 %}hidden-sm{% endif %}">{{_('All')}}</div>
+  {% endif %}
+  <div class="btn-group character {% if charlist|length > 9 %}hidden-sm{% endif %}" role="group">
+    {% for char in charlist %}
+    <div class="btn btn-primary char">{{char}}</div>
+    {% endfor %}
+  </div>
+</div>
+
+<div class="container">
+  <div class="col-xs-12">
+    <ul class="tag-tree" id="category-tree">
+      {% for entry in entries %}
+        <li data-level="{{ entry.level }}" data-tag-id="{{ entry.tag_id }}" data-full-path="{{ entry.full_path }}">
+          <div class="tag-node {% if not entry.has_children %}leaf{% endif %}"
+               {% if entry.has_children %}onclick="toggleCategoryNode(this)"{% endif %}>
+            <span class="toggle">
+              {% if entry.has_children %}
+                ►
+              {% else %}
+                <!-- Empty space for alignment -->
+              {% endif %}
+            </span>
+            <span class="glyphicon {% if entry.has_children %}glyphicon-folder-close{% else %}glyphicon-tag{% endif %} icon"></span>
+            {% if entry.is_leaf and entry.tag_id %}
+              <a href="{{ url_for('web.books_list', data='category', sort_param='stored', book_id=entry.tag_id) }}" class="name">{{ entry.name }}</a>
+            {% else %}
+              <span class="name">{{ entry.name }}</span>
+            {% endif %}
+            <span class="count">{{ entry.count }}</span>
+          </div>
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+</div>
+{% endblock %}
+
+{% block js %}
+<script>
+function toggleCategoryNode(element) {
+    const li = element.parentElement;
+    const currentLevel = parseInt(li.getAttribute('data-level'));
+    const toggle = element.querySelector('.toggle');
+    const icon = element.querySelector('.glyphicon');
+
+    // Find all siblings after this element with level > currentLevel
+    let nextSibling = li.nextElementSibling;
+    const childElements = [];
+
+    while (nextSibling && parseInt(nextSibling.getAttribute('data-level')) > currentLevel) {
+        childElements.push(nextSibling);
+        nextSibling = nextSibling.nextElementSibling;
+    }
+
+    // Check if currently expanded by looking at first child visibility
+    const isExpanded = childElements.length > 0 &&
+                      childElements[0].style.display !== 'none';
+
+    if (isExpanded) {
+        // Collapse: hide all children
+        toggle.textContent = '►';
+        icon.classList.remove('glyphicon-folder-open');
+        icon.classList.add('glyphicon-folder-close');
+
+        childElements.forEach(child => {
+            child.style.display = 'none';
+        });
+    } else {
+        // Expand: show direct children only
+        toggle.textContent = '▼';
+        icon.classList.remove('glyphicon-folder-close');
+        icon.classList.add('glyphicon-folder-open');
+
+        const directChildLevel = currentLevel + 1;
+        childElements.forEach(child => {
+            const childLevel = parseInt(child.getAttribute('data-level'));
+            if (childLevel === directChildLevel) {
+                child.style.display = '';
+            }
+        });
+    }
+}
+
+// Letter filter functionality
+function filterByLetter(letter) {
+    const allNodes = document.querySelectorAll('#category-tree li');
+
+    allNodes.forEach(node => {
+        const level = parseInt(node.getAttribute('data-level'));
+        const nodeName = node.querySelector('.name').textContent.trim();
+
+        if (level === 0) {
+            // Root level nodes
+            if (letter === 'all' || nodeName[0].toUpperCase() === letter.toUpperCase()) {
+                node.style.display = '';
+            } else {
+                node.style.display = 'none';
+            }
+        } else {
+            // Child nodes - hide all, will be shown by expand if parent is visible
+            node.style.display = 'none';
+        }
+    });
+}
+
+// Initialize tree - collapse all by default except root level
+document.addEventListener('DOMContentLoaded', function() {
+    const allNodes = document.querySelectorAll('#category-tree li');
+
+    // Hide all non-root level nodes
+    allNodes.forEach(node => {
+        const level = parseInt(node.getAttribute('data-level'));
+        if (level > 0) {
+            node.style.display = 'none';
+        }
+    });
+
+    // Add letter filter click handlers
+    document.querySelectorAll('.char').forEach(button => {
+        button.addEventListener('click', function() {
+            const letter = this.textContent.trim();
+            filterByLetter(letter);
+
+            // Update active state
+            document.querySelectorAll('.char, #all').forEach(b => b.classList.remove('active'));
+            this.classList.add('active');
+        });
+    });
+
+    // Add "All" button handler
+    const allButton = document.getElementById('all');
+    if (allButton) {
+        allButton.addEventListener('click', function() {
+            filterByLetter('all');
+
+            // Update active state
+            document.querySelectorAll('.char, #all').forEach(b => b.classList.remove('active'));
+            this.classList.add('active');
+        });
+    }
+});
+</script>
+{% endblock %}

--- a/cps/templates/category_tree.html
+++ b/cps/templates/category_tree.html
@@ -38,7 +38,7 @@
             {% else %}
               <span class="name">{{ entry.name }}</span>
             {% endif %}
-            <span class="count">{{ entry.count }}</span>
+            <span class="badge">{{ entry.count }}</span>
           </div>
         </li>
       {% endfor %}

--- a/cps/templates/category_tree.html
+++ b/cps/templates/category_tree.html
@@ -31,8 +31,10 @@
               {% endif %}
             </span>
             <span class="glyphicon {% if entry.has_children %}glyphicon-folder-close{% else %}glyphicon-tag{% endif %} icon"></span>
-            {% if entry.is_leaf and entry.tag_id %}
-              <a href="{{ url_for('web.books_list', data='category', sort_param='stored', book_id=entry.tag_id) }}" class="name">{{ entry.name }}</a>
+            {% if entry.has_children %}
+              <a href="{{ url_for('web.books_list', data='category', sort_param='stored', book_id='path:' ~ entry.full_path) }}" class="name" onclick="event.stopPropagation()">{{ entry.name }}</a>
+            {% elif entry.is_leaf and entry.tag_id %}
+              <a href="{{ url_for('web.books_list', data='category', sort_param='stored', book_id=entry.tag_id) }}" class="name" onclick="event.stopPropagation()">{{ entry.name }}</a>
             {% else %}
               <span class="name">{{ entry.name }}</span>
             {% endif %}

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -187,7 +187,10 @@
 
                         {% for tag in entry.tags %}
                             <a href="{{ url_for('web.books_list', data='category', sort_param='stored', book_id=tag.id) }}"
-                               class="btn btn-xs btn-info" role="button">{{ tag.name }}</a>
+                               class="btn btn-xs btn-info hierarchical-tag" role="button"
+                               {% if tag.name|is_hierarchical_tag %}title="{{ tag.name }}"{% endif %}>
+                                {{ tag.name|tag_display_name(2) }}
+                            </a>
                         {% endfor %}
                     </p>
 

--- a/cps/templates/list.html
+++ b/cps/templates/list.html
@@ -47,7 +47,9 @@
           {% if entry.format %}
             {{entry.format}}
           {% else %}
-            {{entry[0].name}}{% endif %}{% endif %}</a></div>
+            <span {% if data == 'category' and entry[0].name|is_hierarchical_tag %}title="{{entry[0].name}}"{% endif %}>
+              {% if data == 'category' %}{{entry[0].name|tag_display_name(2)}}{% else %}{{entry[0].name}}{% endif %}
+            </span>{% endif %}{% endif %}</a></div>
       </div>
     {% endfor %}
     </div>

--- a/cps/web.py
+++ b/cps/web.py
@@ -1150,6 +1150,7 @@ def category_list():
         # Build hierarchical tree structure
         tag_tree = helper.build_tag_tree(entries)
         # Pass reverse parameter based on sort order (order_no: 0=desc, 1=asc)
+        # reverse=True means descending (Z-A), which corresponds to order_no=0
         tree_list = helper.tree_to_list(tag_tree, reverse=(order_no == 0))
 
         # Generate character list for root-level tags (for letter filter buttons)
@@ -1159,6 +1160,9 @@ def category_list():
                 upper_char = node['name'][0].upper()
                 if upper_char not in char_list:
                     char_list.append(upper_char)
+
+        # Sort character list in same order as tags
+        char_list.sort(reverse=(order_no == 0))
 
         return render_title_template('category_tree.html', entries=tree_list, folder='web.books_list',
                                      charlist=char_list, title=_("Categories"), page="catlist",


### PR DESCRIPTION
<img width="1351" height="657" alt="SCR-20251106-jwzf" src="https://github.com/user-attachments/assets/a3b3733d-5268-45f1-8fba-a4cd355f982c" />

## Problem

Closes #1185

Currently, Calibre-Web displays all tags as a flat list on the Categories page. When users create hierarchical tags using dot notation (e.g., `Fantasy.Urban`, `SciFi.Space.Opera`) in Calibre, they appear as separate, individual entries rather than a nested hierarchy. This makes navigation difficult and creates visual clutter for users with large, organized tag collections.

## Solution

This PR implements hierarchical tag parsing and tree view display for the Categories page. Tags using period separators (`.`) are automatically parsed into a nested tree structure with expand/collapse functionality, matching how Calibre handles hierarchical tags.

## Features Implemented

### Core Functionality
- **Tree View Display**: Tags with period separators are parsed into hierarchical tree structure
- **Expand/Collapse**: Interactive navigation of parent/child categories with visual indicators (arrows, folder/tag icons)
- **Aggregated Counts**: Parent categories show total book count from all subcategories
- **Smart Display**: Tag names use chevron separator (`›`) instead of period for better readability within book view
- **Theme Compatible**: Book count badges adapt to active theme colors (default, caliBlur, etc.)

### Navigation Features
- **Sorting**: Alphabetical (A-Z) and reverse alphabetical (Z-A) sorting maintained across all tree levels
- **Letter Filtering**: Quick navigation by first letter for root-level categories
- **Responsive Layout**: Flexbox-based design prevents horizontal scrolling at any screen width
- **Backward Compatible**: Non-hierarchical tags (without periods) continue to work normally

## Technical Implementation

### Backend ([cps/helper.py](https://github.com/oliver-howard/calibre-web/blob/master/cps/helper.py))
Added tag hierarchy parsing and tree building functions:
- `parse_tag_hierarchy()` - Split hierarchical tag names into components
- `get_tag_leaf_name()` - Extract leaf node from hierarchical tag
- `get_tag_display_name()` - Format tags with chevron separator
- `is_hierarchical_tag()` - Check if tag contains hierarchy separator
- `build_tag_tree()` - Convert flat tag list to nested tree with aggregated counts
- `tree_to_list()` - Flatten tree for template rendering with level metadata

### Frontend
- **[cps/web.py](https://github.com/oliver-howard/calibre-web/blob/master/cps/web.py)**: Enhanced `category_list()` route to build and sort tree structure
- **[cps/templates/category_tree.html](https://github.com/oliver-howard/calibre-web/blob/master/cps/templates/category_tree.html)**: New template with tree view and JavaScript expand/collapse functionality
- **[cps/static/css/style.css](https://github.com/oliver-howard/calibre-web/blob/master/cps/static/css/style.css)**: Theme-aware tree styling with proper overflow handling
- **[cps/jinjia.py](https://github.com/oliver-howard/calibre-web/blob/master/cps/jinjia.py)**: Added Jinja2 template filters for tag formatting

### Display Updates
- **[cps/templates/detail.html](https://github.com/oliver-howard/calibre-web/blob/master/cps/templates/detail.html)** & **[cps/templates/list.html](https://github.com/oliver-howard/calibre-web/blob/master/cps/templates/list.html)**: Tags display with chevron separator (`›`) for consistency

### Additional Fix
- **[cps/gdriveutils.py](https://github.com/oliver-howard/calibre-web/blob/master/cps/gdriveutils.py)**: Added null check for `cli_param.gd_path` to prevent errors when Google Drive is not configured

## Usage Example

Users create hierarchical tags in Calibre using period separators:
Fantasy.Urban-Fantasy
Fantasy.Epic.High-Fantasy 
SciFi.Dystopian.Space-Opera

These automatically display as an expandable tree in Calibre-Web's Categories page, with parent categories showing aggregated book counts.

## Testing

- Python 3.8+ compatible
- Tested on macOS (Darwin 25.0.0)
- Tree navigation and expand/collapse works at all nesting levels
- Book counts aggregate correctly up the hierarchy
- Sorting (A-Z, Z-A) functions correctly across all levels
- Letter filtering works for root-level categories
- Theme compatibility verified (default & caliBlur themes)
- Tag links navigate to correct filtered book views
- Backward compatible with non-hierarchical tags

## Notes

- No database schema changes required
- Existing tag data is not modified
- Feature is opt-in (use periods in Calibre tag names to create hierarchy)
- Maintains existing Categories page functionality for flat tags