### PR TITLE
Fix display issue on small width resolution and rename Google metadata provider

### DIFF
--- a/cps/metadata_provider/google.py
+++ b/cps/metadata_provider/google.py
@@ -31,7 +31,7 @@ log = logger.create()
 
 
 class Google(Metadata):
-    __name__ = "Google"
+    __name__ = "Google Books"
     __id__ = "google"
     DESCRIPTION = "Google Books"
     META_URL = "https://books.google.com/"

--- a/cps/static/css/caliBlur.css
+++ b/cps/static/css/caliBlur.css
@@ -2611,8 +2611,6 @@ textarea {
     line-height: 1.71428571;
     color: var(--color-primary);
     font-weight: 100;
-    text-align: right;
-    position: absolute;
     right: 0;
     padding: 12.5px
 }


### PR DESCRIPTION
**1. Caliblur theme display fix**
With the caliblur theme, there is a display issue when having a small resolution width (e.g. split screen, etc.)
<img width="600" height="771" alt="Screenshot 2025-11-27 121627" src="https://github.com/user-attachments/assets/661fb8b6-bc9c-4c09-87b3-f75e15aee458" />

This also happens if using extra providers
<img width="894" height="810" alt="Screenshot 2025-11-27 134341" src="https://github.com/user-attachments/assets/2d06ede8-d366-4de4-afb6-43082d17ba2c" />

The fix moves the yellow message to the top, like the standard theme. The other option would have been to replicate the mobile layout, e.g. hiding the message.
<img width="601" height="800" alt="Screenshot 2025-11-27 121711" src="https://github.com/user-attachments/assets/820c2143-95ae-459c-b6f2-3d8f815ab424" />


**2. Google Books metadata provider**
Renamed Google metadata provider to Google Books.

Currently, the Google Books metadata is named Google, which could be confused with the search engine being used as a metadata provider.  Replicating the naming of Google Scholar by renaming Google to Google Books, makes the list of metadata providers clearer.