### PR TITLE
Update Google OAuth scope to include 'openid' 

### DIFF
--- a/cps/oauth_bb.py
+++ b/cps/oauth_bb.py
@@ -227,7 +227,10 @@ def generate_oauth_blueprints():
     ele2 = dict(provider_name='google',
                 id=oauth_ids[1].id,
                 active=oauth_ids[1].active,
-                scope=["https://www.googleapis.com/auth/userinfo.email"],
+                scope=[
+                    "openid",
+                    "https://www.googleapis.com/auth/userinfo.email",
+                ]
                 oauth_client_id=oauth_ids[1].oauth_client_id,
                 oauth_client_secret=oauth_ids[1].oauth_client_secret,
                 obtain_link='https://console.developers.google.com/apis/credentials')


### PR DESCRIPTION
Google includes `openid` by default, so configuring Google oAuth breaks unless you use the environment variable `OAUTHLIB_RELAX_TOKEN_SCOPE` as listed in the wiki. Seems like it would be better to just patch this, but I may be misunderstanding the root issue.

Tested on Python 3.11.2

Related Issue: #1998