### PR TITLE
Replace trash‑can icon with folder‑open for “Archive” link

### DIFF
--- a/cps/render_template.py
+++ b/cps/render_template.py
@@ -92,7 +92,7 @@ def get_sidebar_config(kwargs=None):
                     "visibility": constants.SIDEBAR_FORMAT, 'public': True,
                     "page": "format", "show_text": _('Show File Formats Section'), "config_show": True})
     sidebar.append(
-        {"glyph": "glyphicon-trash", "text": _('Archived Books'), "link": 'web.books_list', "id": "archived",
+        {"glyph": "glyphicon-folder-open", "text": _('Archived Books'), "link": 'web.books_list', "id": "archived",
          "visibility": constants.SIDEBAR_ARCHIVED, 'public': (not current_user.is_anonymous), "page": "archived",
          "show_text": _('Show Archived Books'), "config_show": content})
     if not simple:


### PR DESCRIPTION
Issue addressed: https://github.com/janeczku/calibre-web/issues/3393

**Description**
The current “Archived Books” link in the left‑hand panel uses the _glyphicon‑trash_ icon, which suggests deletion rather than archiving. This PR swaps it for _glyphicon‑folder‑open_, a more accurate visual cue for the book archive.

**Screenshots**
Current view:
![Screenshot_2025-12-09_21-42-29](https://github.com/user-attachments/assets/cfda17af-c54f-40f6-90f1-9f3329783b10)

Proposed view:
![Screenshot_2025-12-09_21-42-00](https://github.com/user-attachments/assets/5e8c150a-68c1-4b6f-9d6c-e166682e2ea5)