### PR TITLE
Add an option to add series info in download file name

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -1792,6 +1792,7 @@ def _configuration_update_helper():
 
         _config_checkbox_int(to_save, "config_uploading")
         _config_checkbox_int(to_save, "config_unicode_filename")
+        _config_checkbox_int(to_save, "config_series_in_filename")
         _config_checkbox_int(to_save, "config_embed_metadata")
         # Reboot on config_anonbrowse with enabled ldap, as decoraters are changed in this case
         reboot_required |= (_config_checkbox_int(to_save, "config_anonbrowse")

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -148,6 +148,7 @@ class _Settings(_Base):
     config_rarfile_location = Column(String, default=None)
     config_upload_formats = Column(String, default=','.join(constants.EXTENSIONS_UPLOAD))
     config_unicode_filename = Column(Boolean, default=False)
+    config_series_in_filename = Column(Boolean, default=False)
     config_embed_metadata = Column(Boolean, default=True)
 
     config_updatechannel = Column(Integer, default=constants.UPDATE_STABLE)

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -1089,6 +1089,14 @@ def get_download_link(book_id, book_format, client):
             if current_user.is_authenticated:
                 ub.update_download(book_id, int(current_user.id))
             file_name = book.title
+            if config.config_series_in_filename and len(book.series) > 0:
+                series_name = book.series[0].name
+                series_num = float(book.series_index)
+                if series_num == int(series_num):
+                    series_num = int(series_num)
+                series_id = f'{series_name} {series_num}'
+                file_name = file_name + " (" + series_id + ")"
+
             if len(book.authors) > 0:
                 file_name = file_name + ' - ' + book.authors[0].name
             if client == "kindle":

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -104,6 +104,10 @@
       <label for="config_unicode_filename">{{_('Convert non-English characters in title and author while saving to disk')}}</label>
     </div>
     <div class="form-group">
+      <input type="checkbox" id="config_series_in_filename" name="config_series_in_filename" {% if config.config_series_in_filename %}checked{% endif %}>
+      <label for="config_series_in_filename">{{_('When downloading a file, add series information')}}</label>
+    </div>
+    <div class="form-group">
       <input type="checkbox" id="config_embed_metadata" name="config_embed_metadata" {% if config.config_embed_metadata %}checked{% endif %}>
       <label for="config_embed_metadata">{{_('Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/Kepubify binaries)')}}</label>
     </div>


### PR DESCRIPTION
Add a config option (`config_series_in_filename`) to include series information in the downloaded file name.

If the config option is set to false (default), or the book doesn't have series information, the current behavior remains.

If the config option is set to true, and the book has series information, the series is added to the downloaded file name right after the book title. Example: "Pyramids (Discworld 7) - Terry Pratchett.epub".

The new config option can be edited from the site admin panel, in the basic config page, inside the features section.

No translation is added as part of this PR.