### PR TITLE
Bugfix: fix the missing progress bar when readning CBZ files

### DIFF
--- a/cps/static/css/main.css
+++ b/cps/static/css/main.css
@@ -918,10 +918,3 @@ input:-moz-placeholder {
 .icon-resize-small::before {
   content: "\e808";
 } /* '' */
-
-#progress {
-  right: 4rem;
-  bottom: 2px;
-  width: fit-content;
-  position: absolute;
-}

--- a/cps/static/css/reader.css
+++ b/cps/static/css/reader.css
@@ -72,3 +72,10 @@
   right: 50px;
   // position: absolute;
 }
+
+#progress {
+  right: 4rem;
+  bottom: 2px;
+  width: fit-content;
+  position: absolute;
+}


### PR DESCRIPTION
## Problem

There was a progress bar when reading CBZ files, it was missing maybe since 0.6.22

## Reproduce steps

To Create any cbz file with images

```bash
$ mkdir /tmp/test
$ cp *.jpg /tmp/test
$ zip -jr test.cbz /tmp/test
```

The add the cbz file to Calibre, then use Calibre-web to read it.

## Reason

In kthoom implementation, there is also a [DOM](https://github.com/janeczku/calibre-web/blob/eb8b0096a132b1219c38376df49d90598f53d231/cps/templates/readcbr.html#L49) with same id `#progress`, and kthoom implementation is also [applying css](https://github.com/janeczku/calibre-web/blob/eb8b0096a132b1219c38376df49d90598f53d231/cps/static/css/kthoom.css#L70) to it.

If this part of css style stays in **main.css**, it also effects the kthoom implementation, therefore the progress bar will disappear when reading comic files (such as cbz).

## Fix

The `#progress {..}` in **main.css** is only for progress DOM of **read.html**, and the page is for epub file. Since the **read.html** also includes **reader.css**, I thought this would be a proper place for the css.
