### PR TITLE
Reading progress sync feature

### DIFF
--- a/cps/static/css/style.css
+++ b/cps/static/css/style.css
@@ -193,7 +193,7 @@ table .bg-dark-danger a { color: #fff; }
 
 .container-fluid .book .meta .title {
   font-weight: bold;
-  font-size: 16px;
+  font-size: 15px;
   color: #444;
 }
 

--- a/cps/static/css/style.css
+++ b/cps/static/css/style.css
@@ -193,7 +193,7 @@ table .bg-dark-danger a { color: #fff; }
 
 .container-fluid .book .meta .title {
   font-weight: bold;
-  font-size: 15px;
+  font-size: 16px;
   color: #444;
 }
 

--- a/cps/static/js/reading/epub.js
+++ b/cps/static/js/reading/epub.js
@@ -70,75 +70,253 @@ var reader;
         let locations_key = reader.book.key() + "-locations";
         // Key to persist last-read position for this book in localStorage
         let position_key = "calibre.reader.position." + reader.book.key();
-        let stored_locations = localStorage.getItem(locations_key);
-        let make_locations, save_locations;
-        if (stored_locations) {
-            make_locations = Promise.resolve(
-                reader.book.locations.load(stored_locations)
-            );
-            // No-op because locations are already saved
-            save_locations = () => {};
-        } else {
-            make_locations = reader.book.locations.generate();
-            save_locations = () => {
-                localStorage.setItem(
-                    locations_key,
-                    reader.book.locations.save()
-                );
-            };
+        
+        let progressSyncTimeout = null;
+        let lastSyncedCfi = null;
+        // Flag to suppress sync immediately after restore (prevents overwriting server with reflow-adjusted position)
+        let justRestored = false;
+        let justRestoredTimeout = null;
+        // Track if locations are ready for page count display
+        let locationsReady = false;
+
+        function isProgressEnabled() {
+            return calibre.useProgress === true || calibre.useProgress === "true";
         }
-        make_locations
-            .then(() => {
-                // Try to restore last position (CFI) from localStorage if present
+
+        function showSyncToast(message, type) {
+            var toast = document.createElement("div");
+            toast.className = "sync-toast sync-toast-" + (type || "info");
+            toast.textContent = message;
+            toast.style.cssText = "position:fixed;top:10px;left:50%;transform:translateX(-50%);padding:8px 16px;border-radius:4px;z-index:9999;font-size:14px;opacity:0.95;transition:opacity 0.3s;";
+            if (type === "success") {
+                toast.style.background = "#4CAF50";
+                toast.style.color = "white";
+            } else if (type === "info") {
+                toast.style.background = "#2196F3";
+                toast.style.color = "white";
+            } else {
+                toast.style.background = "#333";
+                toast.style.color = "white";
+            }
+            document.body.appendChild(toast);
+            setTimeout(function() {
+                toast.style.opacity = "0";
+                setTimeout(function() { toast.remove(); }, 300);
+            }, 3000);
+        }
+
+        function debugLog(label, data) {
+            console.log("[EPUB Sync] " + label, data);
+        }
+
+        // Start loading/generating locations in the background (for page count display)
+        let stored_locations = localStorage.getItem(locations_key);
+        let locationsPromise;
+        if (stored_locations) {
+            locationsPromise = Promise.resolve(reader.book.locations.load(stored_locations));
+        } else {
+            locationsPromise = reader.book.locations.generate().then(() => {
+                localStorage.setItem(locations_key, reader.book.locations.save());
+            });
+        }
+        locationsPromise.then(() => {
+            locationsReady = true;
+            debugLog("Locations ready");
+        });
+
+        // Restore position IMMEDIATELY - don't wait for locations
+        function restorePosition() {
+            return new Promise((resolve) => {
+                let localPos = null;
                 try {
                     var _savedPos = localStorage.getItem(position_key);
                     if (_savedPos) {
-                        try {
-                            var _posObj = JSON.parse(_savedPos);
-                            if (_posObj && _posObj.cfi) {
-                                // Display the saved CFI location
-                                try {
-                                    reader.rendition.display(_posObj.cfi);
-                                } catch (e) {}
-                            }
-                        } catch (e) {}
+                        localPos = JSON.parse(_savedPos);
                     }
                 } catch (e) {}
 
-                reader.rendition.on("relocated", (location) => {
-                    let percentage = Math.round(location.end.percentage * 100);
-                    progressDiv.textContent = percentage + "%";
+                debugLog("Local position", localPos);
 
-                    // Pages based on generated EPUB locations (CFI positions)
-                    const cfi = location.start.cfi;
-                    const current =
-                        reader.book.locations.locationFromCfi(cfi) || 0; // 1-based index typically
+                function displayCfi(cfi) {
+                    if (!cfi) return false;
+                    try {
+                        debugLog("Displaying CFI", cfi);
+                        let p = reader.rendition.display(cfi);
+                        if (p && typeof p.catch === "function") {
+                            p.catch(function () {});
+                        }
+                        return true;
+                    } catch (e) {
+                        debugLog("CFI display failed", e);
+                        return false;
+                    }
+                }
+
+                function displayLocal() {
+                    if (localPos && localPos.cfi) {
+                        displayCfi(localPos.cfi);
+                    }
+                }
+
+                if (!isProgressEnabled() || !calibre.progressUrl) {
+                    debugLog("Progress sync disabled or no URL", { useProgress: calibre.useProgress, progressUrl: calibre.progressUrl });
+                    displayLocal();
+                    resolve();
+                    return;
+                }
+
+                debugLog("Fetching remote progress from", calibre.progressUrl);
+                $.ajax(calibre.progressUrl, { method: "get" })
+                    .done(function (remote) {
+                        debugLog("Remote progress response", remote);
+                        let usedRemote = false;
+                        if (
+                            remote &&
+                            remote.location_type === "epub-cfi" &&
+                            remote.location
+                        ) {
+                            let remoteTs = 0;
+                            try {
+                                remoteTs = Date.parse(remote.last_modified || "") || 0;
+                            } catch (e) {
+                                remoteTs = 0;
+                            }
+                            let localTs = localPos && localPos.ts ? localPos.ts : 0;
+
+                            debugLog("Timestamp comparison", {
+                                remoteTs: remoteTs,
+                                remoteTsDate: new Date(remoteTs).toISOString(),
+                                localTs: localTs,
+                                localTsDate: localTs ? new Date(localTs).toISOString() : null,
+                                remoteNewer: remoteTs > localTs
+                            });
+
+                            if (!localPos || !localPos.cfi || remoteTs > localTs) {
+                                let remotePercentage =
+                                    remote.data && remote.data.percentage != null
+                                        ? remote.data.percentage
+                                        : localPos && localPos.percentage != null
+                                        ? localPos.percentage
+                                        : null;
+                                debugLog("Using REMOTE position", {
+                                    cfi: remote.location,
+                                    percentage: remotePercentage,
+                                    progressPercent: remote.progress_percent
+                                });
+                                showSyncToast("Restored from server: " + (remote.progress_percent || Math.round((remotePercentage || 0) * 100)) + "%", "success");
+                                
+                                // Set flag to prevent immediate re-sync after restore
+                                justRestored = true;
+                                if (justRestoredTimeout) clearTimeout(justRestoredTimeout);
+                                justRestoredTimeout = setTimeout(function() {
+                                    justRestored = false;
+                                    debugLog("Restore cooldown ended, sync enabled");
+                                }, 5000);
+                                
+                                displayCfi(remote.location);
+                                usedRemote = true;
+                                try {
+                                    localStorage.setItem(
+                                        position_key,
+                                        JSON.stringify({
+                                            cfi: remote.location,
+                                            percentage: remotePercentage,
+                                            ts: remoteTs || Date.now(),
+                                        })
+                                    );
+                                } catch (e) {}
+                            } else {
+                                debugLog("Using LOCAL position (local is newer)", {
+                                    localCfi: localPos.cfi,
+                                    localPercentage: localPos.percentage
+                                });
+                                showSyncToast("Using local position: " + Math.round((localPos.percentage || 0) * 100) + "%", "info");
+                            }
+                        } else {
+                            debugLog("No valid remote position, using local", remote);
+                        }
+
+                        if (!usedRemote) {
+                            displayLocal();
+                        }
+                        resolve();
+                    })
+                    .fail(function (xhr, status, error) {
+                        debugLog("Failed to fetch remote progress", { status: status, error: error, xhr: xhr.status });
+                        displayLocal();
+                        resolve();
+                    });
+            });
+        }
+
+        // Restore position immediately (don't wait for locations)
+        restorePosition().then(() => {
+            reader.rendition.on("relocated", (location) => {
+                let percentage = Math.round(location.end.percentage * 100);
+                progressDiv.textContent = percentage + "%";
+
+                // Pages based on generated EPUB locations (only show if locations are ready)
+                const cfi = location.start.cfi;
+                if (locationsReady) {
+                    const current = reader.book.locations.locationFromCfi(cfi) || 0;
                     const total = reader.book.locations.length() || 0;
-
                     if (total > 0) {
                         pagesDiv.textContent = current + "/" + total;
                         pagesDiv.style.visibility = "visible";
-                    } else {
-                        pagesDiv.textContent = "";
-                        pagesDiv.style.visibility = "hidden";
                     }
+                }
 
-                    // Persist last position (CFI + percentage) to localStorage so reader can restore on next open
-                    try {
-                        var posObj = {
-                            cfi: location.start.cfi,
-                            percentage: location.start.percentage,
-                        };
-                        localStorage.setItem(
-                            position_key,
-                            JSON.stringify(posObj)
-                        );
-                    } catch (e) {}
-                });
-                reader.rendition.reportLocation();
-                progressDiv.style.visibility = "visible";
-            })
-            .then(save_locations);
+                // Skip saving if we just restored from server
+                if (justRestored) {
+                    debugLog("Skipping save (just restored from server)", { cfi: cfi, percentage: percentage });
+                    return;
+                }
+
+                // Persist last position to localStorage
+                try {
+                    var posObj = {
+                        cfi: location.start.cfi,
+                        percentage: location.start.percentage,
+                        ts: Date.now(),
+                    };
+                    localStorage.setItem(position_key, JSON.stringify(posObj));
+                } catch (e) {}
+
+                if (isProgressEnabled() && calibre.progressUrl && cfi) {
+                    if (progressSyncTimeout) {
+                        clearTimeout(progressSyncTimeout);
+                    }
+                    progressSyncTimeout = setTimeout(() => {
+                        if (cfi === lastSyncedCfi) {
+                            return;
+                        }
+                        lastSyncedCfi = cfi;
+
+                        debugLog("Syncing position to server", { cfi: cfi, percentage: percentage });
+
+                        var csrftoken = $("input[name='csrf_token']").val();
+                        $.ajax(calibre.progressUrl, {
+                            method: "post",
+                            data: {
+                                location_type: "epub-cfi",
+                                location: cfi,
+                                progress_percent: percentage,
+                                data: JSON.stringify({
+                                    percentage: location.start.percentage,
+                                }),
+                            },
+                            headers: { "X-CSRFToken": csrftoken },
+                        }).done(function() {
+                            debugLog("Position synced successfully", { cfi: cfi });
+                        }).fail(function (xhr, status, error) {
+                            console.error("[EPUB Sync] Failed to sync:", error);
+                        });
+                    }, 2000);
+                }
+            });
+            reader.rendition.reportLocation();
+            progressDiv.style.visibility = "visible";
+        });
     });
 
     /**

--- a/cps/static/js/reading/pdf_progress.js
+++ b/cps/static/js/reading/pdf_progress.js
@@ -1,0 +1,324 @@
+(function () {
+    "use strict";
+
+    function debugLog(label, data) {
+        console.log("[PDF Sync] " + label, data);
+    }
+
+    function showSyncToast(message, type) {
+        var toast = document.createElement("div");
+        toast.className = "sync-toast sync-toast-" + (type || "info");
+        toast.textContent = message;
+        toast.style.cssText = "position:fixed;top:10px;left:50%;transform:translateX(-50%);padding:8px 16px;border-radius:4px;z-index:9999;font-size:14px;opacity:0.95;transition:opacity 0.3s;";
+        if (type === "success") {
+            toast.style.background = "#4CAF50";
+            toast.style.color = "white";
+        } else if (type === "info") {
+            toast.style.background = "#2196F3";
+            toast.style.color = "white";
+        } else {
+            toast.style.background = "#333";
+            toast.style.color = "white";
+        }
+        document.body.appendChild(toast);
+        setTimeout(function() {
+            toast.style.opacity = "0";
+            setTimeout(function() { toast.remove(); }, 300);
+        }, 3000);
+    }
+
+    function isProgressEnabled() {
+        return (
+            window.calibre &&
+            (window.calibre.useProgress === true ||
+                window.calibre.useProgress === "true")
+        );
+    }
+
+    debugLog("Initializing", { calibre: window.calibre, enabled: isProgressEnabled() });
+
+    if (!isProgressEnabled() || !window.calibre || !window.calibre.progressUrl) {
+        debugLog("Progress sync disabled or no URL, exiting");
+        return;
+    }
+
+    var progressUrl = window.calibre.progressUrl;
+    debugLog("Progress URL", progressUrl);
+
+    function getCsrfToken() {
+        var el = document.querySelector("input[name='csrf_token']");
+        return el ? el.value : null;
+    }
+
+    function parseRemoteTimestamp(remote) {
+        try {
+            return Date.parse(remote && remote.last_modified ? remote.last_modified : "") || 0;
+        } catch (e) {
+            return 0;
+        }
+    }
+
+    function getLocalStorageKey() {
+        try {
+            var match = String(progressUrl).match(/\/ajax\/reading-progress\/(\d+)\//i);
+            var bookId = match ? match[1] : "unknown";
+            return "calibre.reader.position.pdf." + bookId;
+        } catch (e) {
+            return "calibre.reader.position.pdf";
+        }
+    }
+
+    var localStorageKey = getLocalStorageKey();
+
+    function loadLocalPosition() {
+        try {
+            var raw = localStorage.getItem(localStorageKey);
+            if (!raw) {
+                return null;
+            }
+            return JSON.parse(raw);
+        } catch (e) {
+            return null;
+        }
+    }
+
+    function saveLocalPosition(pageNumber) {
+        try {
+            localStorage.setItem(
+                localStorageKey,
+                JSON.stringify({ page: pageNumber, ts: Date.now() })
+            );
+        } catch (e) {}
+    }
+
+    async function fetchRemoteProgress() {
+        try {
+            var resp = await fetch(progressUrl, {
+                method: "GET",
+                credentials: "same-origin",
+            });
+            if (resp.status === 204) {
+                return null;
+            }
+            if (!resp.ok) {
+                return null;
+            }
+            return await resp.json();
+        } catch (e) {
+            return null;
+        }
+    }
+
+    async function postProgress(pageNumber, pagesCount) {
+        var csrf = getCsrfToken();
+        if (!csrf) {
+            return;
+        }
+
+        var percent = null;
+        if (pagesCount && pagesCount > 0) {
+            percent = Math.round((pageNumber / pagesCount) * 100);
+        }
+
+        var payload = {
+            location_type: "pdf-page",
+            location: String(pageNumber),
+            progress_percent: percent,
+            data: {
+                page: pageNumber,
+                pages: pagesCount || null,
+            },
+        };
+
+        try {
+            await fetch(progressUrl, {
+                method: "POST",
+                credentials: "same-origin",
+                headers: {
+                    "Content-Type": "application/json",
+                    "X-CSRFToken": csrf,
+                },
+                body: JSON.stringify(payload),
+            });
+        } catch (e) {}
+    }
+
+    var lastSyncedPage = null;
+    var progressSyncTimeout = null;
+    var restoring = false;
+    var documentLoaded = false;
+    var desiredPage = null;
+
+    async function setup() {
+        debugLog("Setup starting");
+        
+        if (
+            !window.PDFViewerApplication ||
+            !window.PDFViewerApplication.initializedPromise
+        ) {
+            debugLog("PDFViewerApplication not available yet, waiting...");
+            // Wait for webviewerloaded event if PDFViewerApplication isn't ready
+            await new Promise(function(resolve) {
+                if (window.PDFViewerApplication && window.PDFViewerApplication.initializedPromise) {
+                    resolve();
+                } else {
+                    window.addEventListener("webviewerloaded", resolve, { once: true });
+                }
+            });
+        }
+
+        debugLog("Waiting for PDFViewerApplication.initializedPromise");
+        await window.PDFViewerApplication.initializedPromise;
+        debugLog("PDFViewerApplication initialized");
+
+        var app = window.PDFViewerApplication;
+        if (!app.eventBus) {
+            debugLog("No eventBus available, exiting");
+            return;
+        }
+
+        function doRestore() {
+            var pagesCount = app.pagesCount || 0;
+            if (desiredPage == null || pagesCount <= 0 || desiredPage < 1 || desiredPage > pagesCount) {
+                debugLog("doRestore: invalid page", { desiredPage: desiredPage, pagesCount: pagesCount });
+                return;
+            }
+
+            var currentPage = app.pdfViewer ? app.pdfViewer.currentPageNumber : null;
+            if (currentPage === desiredPage) {
+                debugLog("Already on desired page", desiredPage);
+                return;
+            }
+
+            debugLog("Navigating to page", desiredPage);
+            restoring = true;
+            try {
+                // Use page setter which is more reliable
+                app.page = desiredPage;
+            } catch (e) {
+                debugLog("Error during restore", e);
+            }
+        }
+
+        // Wait for documentinit event which fires after PDF.js sets initial view
+        // This ensures we navigate AFTER PDF.js does its own initialization
+        var restored = false;
+        
+        app.eventBus.on("documentinit", function () {
+            debugLog("documentinit event fired");
+            if (!restored && desiredPage != null) {
+                restored = true;
+                // Small delay to let PDF.js finish its initial page set
+                setTimeout(function() {
+                    doRestore();
+                }, 100);
+            }
+        });
+
+        // Fallback: also listen for pagesloaded in case documentinit doesn't fire
+        app.eventBus.on("pagesloaded", function () {
+            debugLog("pagesloaded event fired");
+            documentLoaded = true;
+            if (!restored && desiredPage != null) {
+                restored = true;
+                setTimeout(function() {
+                    doRestore();
+                }, 100);
+            }
+        });
+        
+        documentLoaded = !!app.pdfDocument;
+        debugLog("Initial documentLoaded state", documentLoaded);
+
+        var localPos = loadLocalPosition();
+        var localTs =
+            localPos && typeof localPos.ts === "number" ? localPos.ts : 0;
+        debugLog("Local position", { localPos: localPos, localTs: localTs });
+
+        var remote = await fetchRemoteProgress();
+        debugLog("Remote progress response", remote);
+        
+        var remotePage = null;
+        var remoteTs = 0;
+
+        if (remote && remote.location) {
+            remoteTs = parseRemoteTimestamp(remote);
+            var lt = String(remote.location_type || "").toLowerCase();
+            debugLog("Remote location type", lt);
+            if (lt === "pdf-page" || lt === "pdf") {
+                var p = parseInt(remote.location, 10);
+                if (Number.isInteger(p) && p > 0) {
+                    remotePage = p;
+                }
+            }
+        }
+
+        debugLog("Timestamp comparison", {
+            remotePage: remotePage,
+            remoteTs: remoteTs,
+            localTs: localTs,
+            remoteNewer: remoteTs > localTs
+        });
+
+        var syncSource = null;
+        if (remotePage != null && (localTs === 0 || remoteTs > localTs)) {
+            desiredPage = remotePage;
+            syncSource = "server";
+            debugLog("Using remote page", desiredPage);
+        } else if (localPos && localPos.page) {
+            desiredPage = localPos.page;
+            syncSource = "local";
+            debugLog("Using local page", desiredPage);
+        }
+
+        if (desiredPage != null && syncSource) {
+            showSyncToast("Restored from " + syncSource + ": page " + desiredPage, syncSource === "server" ? "success" : "info");
+        }
+
+        // If document is already loaded, trigger restore now (with delay)
+        if (documentLoaded && desiredPage != null && !restored) {
+            restored = true;
+            setTimeout(function() {
+                doRestore();
+            }, 100);
+        }
+
+        app.eventBus.on("pagechanging", function (evt) {
+            var pageNumber = evt && evt.pageNumber ? evt.pageNumber : null;
+            if (!Number.isInteger(pageNumber) || pageNumber <= 0) {
+                return;
+            }
+
+            saveLocalPosition(pageNumber);
+
+            if (restoring) {
+                restoring = false;
+                lastSyncedPage = pageNumber;
+                return;
+            }
+
+            if (!isProgressEnabled() || !progressUrl) {
+                return;
+            }
+
+            var pagesCount = app.pagesCount || 0;
+            if (pagesCount > 0 && (pageNumber < 1 || pageNumber > pagesCount)) {
+                return;
+            }
+
+            if (progressSyncTimeout) {
+                clearTimeout(progressSyncTimeout);
+            }
+
+            progressSyncTimeout = setTimeout(function () {
+                if (pageNumber === lastSyncedPage) {
+                    return;
+                }
+                lastSyncedPage = pageNumber;
+                postProgress(pageNumber, pagesCount);
+            }, 1500);
+        });
+    }
+
+    setup();
+})();

--- a/cps/templates/index.html
+++ b/cps/templates/index.html
@@ -1,6 +1,51 @@
 {% import 'image.html' as image %}
 {% extends "layout.html" %}
 {% block body %}
+{% if continue_reading and continue_reading|length > 0 %}
+<div class="discover continue-reading">
+  <h2 class="continue-reading">{{_('Continue Reading')}}</h2>
+  <div class="row display-flex">
+   {% for item in continue_reading %}
+    <div class="col-sm-3 col-lg-2 col-xs-6 book session" id="books_continue">
+      <div class="cover">
+          <a href="{{ url_for('web.read_book', book_id=item.book.id, book_format=item.format) }}">
+              <span class="img" title="{{ item.book.title }}">
+                {{ image.book_cover(item.book) }}
+                <span class="badge progress-badge" style="background:#4CAF50;bottom:5px;top:auto;">{{ item.progress_percent }}%</span>
+              </span>
+          </a>
+      </div>
+      <div class="meta">
+        <a href="{{ url_for('web.read_book', book_id=item.book.id, book_format=item.format) }}">
+          <p title="{{item.book.title}}" class="title">{{item.book.title|shortentitle}}</p>
+        </a>
+        <p class="author">
+          {% for author in item.book.authors %}
+            {% if loop.index > g.config_authors_max and g.config_authors_max != 0 %}
+              {% if not loop.first %}
+                <span class="author-hidden-divider">&amp;</span>
+			  {% endif %}
+              <a class="author-name author-hidden" href="{{url_for('web.books_list', data='author', sort_param='stored', book_id=author.id) }}">{{author.name.replace('|',',')|shortentitle(30)}}</a>
+              {% if loop.last %}
+                <a href="#" class="author-expand" data-authors-max="{{g.config_authors_max}}" data-collapse-caption="({{_('reduce')}})">(...)</a>
+              {% endif %}
+            {% else %}
+              {% if not loop.first %}
+                <span>&amp;</span>
+              {% endif %}
+              <a class="author-name" href="{{url_for('web.books_list',  data='author', sort_param='stored', book_id=author.id) }}">{{author.name.replace('|',',')|shortentitle(30)}}</a>
+            {% endif %}
+          {% endfor %}
+        </p>
+        <p class="reading-progress" style="color:#4CAF50;font-size:12px;">
+          <span class="glyphicon glyphicon-book"></span> {{ item.progress_percent }}% · {{ item.format|upper }}
+        </p>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+</div>
+{% endif %}
 {% if current_user.show_detail_random() and page != "discover" %}
 <div class="discover random-books">
   <h2 class="random-books">{{_('Discover (Random Books)')}}</h2>

--- a/cps/templates/read.html
+++ b/cps/templates/read.html
@@ -147,9 +147,11 @@
             filePath: "{{ url_for('static', filename='js/libs/') }}",
             cssPath: "{{ url_for('static', filename='css/') }}",
             bookmarkUrl: "{{ url_for('web.set_bookmark', book_id=bookid, book_format=book_format) }}",
+            progressUrl: "{{ url_for('web.set_reading_progress', book_id=bookid, book_format=book_format) }}",
             bookUrl: "{{ url_for('web.serve_book', book_id=bookid, book_format=book_format, anyname='file.epub') }}",
             bookmark: "{{ bookmark.bookmark_key if bookmark != None }}",
-            useBookmarks: "{{ current_user.is_authenticated | tojson }}"
+            useBookmarks: "{{ current_user.is_authenticated | tojson }}",
+            useProgress: "{{ current_user.is_authenticated | tojson }}"
         };
 
       // load custom theme color from localStorage (if any)

--- a/cps/templates/readpdf.html
+++ b/cps/templates/readpdf.html
@@ -51,11 +51,20 @@ See https://github.com/adobe-type-tools/cmap-resources
     });
     </script>
 
-    <script src="{{ url_for('static', filename='js/libs/viewer.js') }}" type="module">></script>
+    <script src="{{ url_for('static', filename='js/libs/viewer.js') }}" type="module"></script>
+
+    <script type="text/javascript">
+    window.calibre = {
+        progressUrl: "{{ url_for('web.set_reading_progress', book_id=pdffile, book_format='pdf') }}",
+        useProgress: {{ current_user.is_authenticated | tojson }}
+    };
+    </script>
+    <script src="{{ url_for('static', filename='js/reading/pdf_progress.js') }}" type="module"></script>
 
   </head>
 
   <body tabindex="1">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <div id="outerContainer">
 
       <div id="sidebarContainer">

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -432,6 +432,21 @@ class Bookmark(Base):
     bookmark_key = Column(String)
 
 
+class ReadingProgress(Base):
+    __tablename__ = 'reading_progress'
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey('user.id'))
+    book_id = Column(Integer)
+    format = Column(String(collation='NOCASE'))
+    location_type = Column(String)
+    location = Column(String)
+    progress_percent = Column(Float)
+    data = Column(JSON)
+    last_modified = Column(DateTime, default=lambda: datetime.now(timezone.utc),
+                           onupdate=lambda: datetime.now(timezone.utc))
+
+
 # Baseclass representing books that are archived on the user's Kobo device.
 class ArchivedBook(Base):
     __tablename__ = 'archived_book'
@@ -572,6 +587,8 @@ def add_missing_tables(engine, _session):
         ArchivedBook.__table__.create(bind=engine)
     if not engine.dialect.has_table(engine.connect(), "thumbnail"):
         Thumbnail.__table__.create(bind=engine)
+    if not engine.dialect.has_table(engine.connect(), "reading_progress"):
+        ReadingProgress.__table__.create(bind=engine)
 
 
 # migrate all settings missing in registration table

--- a/cps/web.py
+++ b/cps/web.py
@@ -174,6 +174,80 @@ def set_bookmark(book_id, book_format):
     return "", 201
 
 
+@web.route("/ajax/reading-progress/<int:book_id>/<book_format>", methods=['GET'])
+@user_login_required
+def get_reading_progress(book_id, book_format):
+    progress = ub.session.query(ub.ReadingProgress).filter(and_(ub.ReadingProgress.user_id == int(current_user.id),
+                                                                ub.ReadingProgress.book_id == book_id,
+                                                                ub.ReadingProgress.format == book_format)).one_or_none()
+    if not progress:
+        return "", 204
+    return jsonify({
+        "location_type": progress.location_type,
+        "location": progress.location,
+        "progress_percent": progress.progress_percent,
+        "data": progress.data,
+        "last_modified": progress.last_modified.isoformat() if progress.last_modified else None,
+    }), 200
+
+
+@web.route("/ajax/reading-progress/<int:book_id>/<book_format>", methods=['POST'])
+@user_login_required
+def set_reading_progress(book_id, book_format):
+    data = request.get_json(silent=True)
+    if data is None:
+        data = request.form.to_dict()
+
+    location = data.get("location")
+    if location is None or location == "":
+        ub.session.query(ub.ReadingProgress).filter(and_(ub.ReadingProgress.user_id == int(current_user.id),
+                                                         ub.ReadingProgress.book_id == book_id,
+                                                         ub.ReadingProgress.format == book_format)).delete()
+        ub.session_commit()
+        return "", 204
+
+    location_type = data.get("location_type")
+    if not location_type:
+        log.error("Could not save reading progress (missing location_type) for user %s book %s format %s",
+                  current_user.id, book_id, book_format)
+        return "Invalid request", 400
+
+    progress_percent = data.get("progress_percent")
+    if progress_percent in (None, ""):
+        progress_percent = None
+    else:
+        try:
+            progress_percent = float(progress_percent)
+        except (TypeError, ValueError):
+            log.error("Could not save reading progress (invalid progress_percent) for user %s book %s format %s: %r",
+                      current_user.id, book_id, book_format, progress_percent)
+            return "Invalid request", 400
+
+    extra_data = data.get("data")
+    if isinstance(extra_data, str):
+        try:
+            extra_data = json.loads(extra_data)
+        except ValueError:
+            log.error("Could not parse reading progress data JSON for user %s book %s format %s",
+                      current_user.id, book_id, book_format)
+            extra_data = None
+
+    ub.session.query(ub.ReadingProgress).filter(and_(ub.ReadingProgress.user_id == int(current_user.id),
+                                                     ub.ReadingProgress.book_id == book_id,
+                                                     ub.ReadingProgress.format == book_format)).delete()
+
+    l_progress = ub.ReadingProgress(user_id=current_user.id,
+                                    book_id=book_id,
+                                    format=book_format,
+                                    location_type=location_type,
+                                    location=location,
+                                    progress_percent=progress_percent,
+                                    data=extra_data)
+    ub.session.merge(l_progress)
+    ub.session_commit("Reading progress for user {} in book {} created".format(current_user.id, book_id))
+    return "", 201
+
+
 @web.route("/ajax/toggleread/<int:book_id>", methods=['POST'])
 @user_login_required
 def toggle_read(book_id):
@@ -182,6 +256,38 @@ def toggle_read(book_id):
         return message, 400
     else:
         return message
+
+
+def get_continue_reading_books(limit=6):
+    """Get books with recent reading progress for the current user."""
+    if not current_user.is_authenticated:
+        return []
+    
+    try:
+        # Get reading progress entries for current user, ordered by last_modified desc
+        progress_entries = ub.session.query(ub.ReadingProgress).filter(
+            ub.ReadingProgress.user_id == int(current_user.id)
+        ).order_by(ub.ReadingProgress.last_modified.desc()).limit(limit).all()
+        
+        if not progress_entries:
+            return []
+        
+        # Get the corresponding books from calibre database
+        result = []
+        for progress in progress_entries:
+            book_query = calibre_db.session.query(db.Books).filter(db.Books.id == progress.book_id).first()
+            if book_query:
+                result.append({
+                    'book': book_query,
+                    'progress': progress,
+                    'progress_percent': int(progress.progress_percent) if progress.progress_percent else 0,
+                    'format': progress.format
+                })
+        
+        return result
+    except Exception as ex:
+        log.error_or_exception(ex)
+        return []
 
 
 @web.route("/ajax/togglearchived/<int:book_id>", methods=['POST'])
@@ -420,8 +526,10 @@ def render_books_list(data, sort_param, book_id, page):
                                                                 db.books_series_link,
                                                                 db.Books.id == db.books_series_link.c.book,
                                                                 db.Series)
+        continue_reading = get_continue_reading_books(limit=6) if page == 1 else []
         return render_title_template('index.html', random=random, entries=entries, pagination=pagination,
-                                     title=_("Books"), page=website, order=order[1])
+                                     title=_("Books"), page=website, order=order[1],
+                                     continue_reading=continue_reading)
 
 
 def render_rated_books(page, book_id, order):


### PR DESCRIPTION
# Reading Progress Sync & Continue Reading Dashboard

## Summary


Hey! Long time user of the app and a software engineer, so i figured i'd contribute something back, hope you like it! Have been using it in my personal setup for a week or two ironing it out and i think with it i can finally move away from bookfusion (i was only paying for it because it had reading progress sync).

This PR adds cross-device reading progress synchronization for EPUB and PDF (it's not coded to work with other file formats yet), along with a "Continue Reading" section on the main library dashboard.

I've tested it cross-device (reading on phone, then laptop, then other computer, in various combinations and orders) and it works great so far. I also added a brief section to the dashboard to show the progress of books that you've been reading on other devices because i noticed while testing that i couldn't find a quick way to jump back into the books i was just reading from the library view.

All testing was done with the calibre-web reader client directly through the web browser (firefox/chrome on desktop/mobile) because that's what i use, so I haven't tested this with any mobile apps or downstream apps that consume from calibre-web and use their own reader clients (honestly not sure there are any but i just wanted to put this out there).

Lastly I just wanted to say that if this gets merged and needs iterative improvement i'll be happy to own this feature and continue to improve it and possibly make other contributions to the project!

## What's included

### Backend
- New `ReadingProgress` model in `ub.py` with fields for location (CFI for EPUB, page number for PDF), progress percentage, and timestamp
- GET/POST endpoints at `/ajax/reading-progress/<book_id>/<format>` for fetching and saving progress
- Helper function `get_continue_reading_books()` that queries recent reading progress for the dashboard

### EPUB Reader (`epub.js`)
- Fetches server progress on load, compares timestamps with localStorage, uses whichever is newer
- Debounced POST to server when position changes (2 second delay to avoid spamming)
- Race condition fix: added a cooldown period after restoring from server to prevent the `relocated` event from immediately overwriting the restored position

### PDF Reader (`pdf_progress.js`)
- New module that hooks into PDF.js viewer events
- Same timestamp-based sync logic as EPUB
- Waits for `pagesloaded` event before restoring to avoid PDF.js's own initialization from overwriting our navigation

### Dashboard
- "Continue Reading" section above "Discover (Random Books)" on the index page
- Shows up to the 6 most recently read books with progress badges
- Links go directly to the reader (not the book detail page)

## Design decisions

**Simple Summary of Sync Logic cross device**

No server progress (uses local), no local progress (uses server), both exist (uses newer)


**Why timestamp-based "last write wins"?**
Simpler than trying to do proper conflict resolution. If you read further on device A, then open device B, you want to jump to where you were on A. The timestamp handles this naturally. Edge cases exist (reading the same book on two devices simultaneously) but they're rare enough that I didn't want to over-engineer this.

**Why store CFI for EPUB instead of percentage?**
CFI (Canonical Fragment Identifier) in EPUBs points to a specific location in the document regardless of screen size or font settings. Percentage-based positions shift when the book reflows on different devices or different screen sizes, single pane/double pane etc. CFIs are more accurate for cross-device sync, but sometimes they're not entirely obvious to users "what part of the page" you were focused on reading was actually synced. So in general, there's no black magic to it where you if you last read  sentence 5 with your eyes on page 75 it's going to somehow know that and jump you to the same exact spot with that sentence at the top of the page. It'll get you close enough to where you were reading, maybe a few sentences or a paragraph off, but it's overall very close and reliable.

In general epub CFI structure can vary by publisher or edition or copy so i tried not to be too granular with it, but i tested it with dozens of books from various sources and publishers, and it always landed me within a paragraph or few sentences of where i was, although i'm sure there will be edge cases.

**Why not use the existing bookmark system?**
Bookmarks are user-initiated and intentional. this is an automatic reading progress syncing that doesn't interfere with bookmarks so that users can still bookmark specific locations if they want to but automatically sync their reading progress between devices if they abruptly stop reading on one device and start on another. 

A lot of users want to track their reading progress but dont want to litter their books with tons of bookmarks that they have to go back and clean out or muddy the water on important pages they bookmarked to go back and re-read or annotate later.

**Why the 2-second debounce on saves?**
Rapid page turns would hammer the server otherwise. Two seconds felt like a good balance - long enough to batch rapid navigation, short enough that you won't lose much if you close the tab.

## Trade-offs

- **More database writes**: Every reading session now writes to the server periodically. For most deployments i can't think of any feasible scenario where this wouldn't be fine (it's not a lot of data), but if there are any, the debounce interval could be changed.
- **No offline queue**: If you're offline, progress just stays in localStorage until you're back online and open the book again. Didn't add a service worker or background sync - felt like overkill for v1.
- **EPUB location generation still happens**: I moved position restore to happen immediately (before locations are generated), but the location generation still runs in the background for the page count display. First open of a large EPUB will still take a few seconds before you see page numbers.

## Testing done many times on different devices with many different books

- EPUB: Opened on desktop, navigated to ~50%, closed, opened on phone browser, verified it jumped to correct position with toast notification
- PDF: Same flow, verified page number restore works
- Continue Reading: Verified books appear after reading, ordered by most recent

## Not in scope / future work

- **Kobo sync integration**: Would be nice to sync with Kobo devices but that's a much bigger lift
- **CBR/CBZ support**: Comic readers could use the same pattern but I didn't touch those
- **Reading statistics/history**: The progress data could feed into reading stats but that's a separate feature
- **Configurable sync interval**: Currently hardcoded, could be a user preference
- **Progress bar in book list**: Could show progress on book covers throughout the UI, not just Continue Reading section

## What i changed where

- `cps/ub.py` - ReadingProgress model
- `cps/web.py` - API endpoints and dashboard helper
- `cps/templates/index.html` - Continue Reading section
- `cps/templates/read.html` - Wire up progress URL for EPUB
- `cps/templates/readpdf.html` - Wire up progress URL for PDF
- `cps/static/js/reading/epub.js` - EPUB sync logic
- `cps/static/js/reading/pdf_progress.js` - New file, PDF sync logic


<img width="1176" height="893" alt="image" src="https://github.com/user-attachments/assets/2c3c64ca-9319-4747-8e46-43696f3991fb" />

<img width="1320" height="662" alt="image" src="https://github.com/user-attachments/assets/6eb8a931-2ed2-477a-a7de-93edf169cd07" />

