### PR TITLE
TYPO on settings of epub reader

### DIFF
--- a/cps/templates/read.html
+++ b/cps/templates/read.html
@@ -82,7 +82,7 @@
         <div class="md-content">
             <h3>{{_('Settings')}}</h3>
             <div class="form-group themes" id="themes">
-                {{_('Choose a theme below:')}}}<br />
+                {{_('Choose a theme below:')}}<br />
 
           <!-- Hardcoded a tick in the light theme button because it is the "default" theme. Need to find a way to do this dynamically on startup-->
                 <button type="button" id="lightTheme" class="lightTheme" onclick="selectTheme(this.id)"><span


### PR DESCRIPTION
Fix theme selection prompt in read.html

<img width="505" height="370" alt="image" src="https://github.com/user-attachments/assets/73752206-7865-4c95-b90b-c642aa10f6df" />

Added by this commit of translation: https://github.com/janeczku/calibre-web/commit/5d8908db4972d3fc4cec5a5b0d516ae1059c76da#diff-90a24daf06e6f24fff4feae75ad2747fceec10a5fd5f662761f00b8c804ba287R80