### PR TITLE
🐛 Calibre 9 compatibility

### DIFF
--- a/cps/db.py
+++ b/cps/db.py
@@ -416,8 +416,16 @@ class Books(Base):
     path = Column(String, default="", nullable=False)
     has_cover = Column(Integer, default=0)
     uuid = Column(String)
-    isbn = Column(String(collation='NOCASE'), default="")
-    flags = Column(Integer, nullable=False, default=1)
+    # These columns were removed from newer calibre version 9
+    # Accessing `book.isbn` / `book.flags` will return None when the column is not
+    # present in the underlying database.
+    @property
+    def isbn(self):
+        return getattr(self, "_isbn", None)
+
+    @property
+    def flags(self):
+        return getattr(self, "_flags", None)
 
     authors = relationship(Authors, secondary=books_authors_link, backref='books')
     tags = relationship(Tags, secondary=books_tags_link, backref='books', order_by="Tags.name")


### PR DESCRIPTION
> Do you think this PR help you? Consider a donation: https://github.com/sponsors/webysther
 
fix https://github.com/janeczku/calibre-web/issues/3537 
fix https://github.com/janeczku/calibre-web/issues/3538 
fix https://github.com/janeczku/calibre-web/issues/3539

Tested on Calibre 8.16.2 and Calibre 9.0.0

Removed unused columns while maintaining compatibility with older Calibre versions, as they were moved the isbn data to the table identifiers years ago.