### PR TITLE
Chore: Remove Exclamation Marks from HTML Strings

### DIFF
--- a/cps/static/js/get_meta.js
+++ b/cps/static/js/get_meta.js
@@ -103,11 +103,11 @@ $(function () {
                         });
                     }
                     else {
-                        $("#meta-info").html("<p class=\"text-danger\">" + msg.no_result + "!</p>" + $("#meta-info")[0].innerHTML)
+                        $("#meta-info").html("<p class=\"text-danger\">" + msg.no_result + "</p>" + $("#meta-info")[0].innerHTML)
                     }
                 },
                 error: function error() {
-                    $("#meta-info").html("<p class=\"text-danger\">" + msg.search_error + "!</p>" + $("#meta-info")[0].innerHTML);
+                    $("#meta-info").html("<p class=\"text-danger\">" + msg.search_error + "</p>" + $("#meta-info")[0].innerHTML);
                 },
             });
         }


### PR DESCRIPTION
Remove the exclamation marks from the two HTML strings in `cps/static/js/get_meta.js`, since the messages already include punctuation.

![Screenshot_2026-02-05_21-51-05](https://github.com/user-attachments/assets/f6e4ecbf-11f3-4fac-bac5-25dd879102a8)
