### PR TITLE
Fix repeated Kobo "Sync to last page read" popup caused by float/int mismatch

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -898,9 +898,9 @@ def get_current_bookmark_response(current_bookmark):
     resp = {
         "LastModified": convert_to_kobo_timestamp_string(current_bookmark.last_modified),
     }
-    if current_bookmark.progress_percent:
+    if current_bookmark.progress_percent is not None:
         resp["ProgressPercent"] = _clean_progress(current_bookmark.progress_percent)
-    if current_bookmark.content_source_progress_percent:
+    if current_bookmark.content_source_progress_percent is not None:
         resp["ContentSourceProgressPercent"] = _clean_progress(current_bookmark.content_source_progress_percent)
     if current_bookmark.location_value:
         resp["Location"] = {


### PR DESCRIPTION
Fixes the repeated "Sync to last page read" popup on Kobo ereaders using calibre-web sync

Kobo devices send `ProgressPercent` as an integer (e.g. `33`) but calibre-web stores it in a SQLite Float column, so it gets returned as `33.0` in the JSON response. The device interprets this as a different reading position and shows the popup.

Fix is to convert whole-number floats to ints in the reading state response, as suggested by @piekay in #3449.  I believe stock kobo firmware only sends whole-number percent progress, so we could likely simplify this further (always cast to int or migrate the DB column to Integer), but this is the conservative fix that preserves any fractional values if they exist.

Also fixes a second related case: when `ProgressPercent` is `0`, a truthiness check (`if value:`) caused the field to be silently dropped from the response entirely. The Kobo then sees its local `0` vs a missing field and shows the popup. This may particularly affects comics/manga where `ProgressPercent` stays `0` while `ContentSourceProgressPercent` tracks page-by-page progress, but can also affect any book at position 0.

Fixes #3449, #2304