### PR TITLE
Fix Kobo sync failure behind reverse proxy: rewrite library_sync URL

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -1101,6 +1101,8 @@ def HandleInitRequest():
                                                                width="{width}",
                                                                height="{height}",
                                                                isGreyscale='false'))
+        kobo_resources["library_sync"] = calibre_web_url + url_for("kobo.HandleSyncRequest",
+                                                                    auth_token=kobo_auth.get_auth_token())
     else:
         kobo_resources["image_host"] = url_for("web.index", _external=True).strip("/")
         kobo_resources["image_url_quality_template"] = unquote(url_for("kobo.HandleCoverImageRequest",
@@ -1118,6 +1120,9 @@ def HandleInitRequest():
                                                                height="{height}",
                                                                isGreyscale='false',
                                                                _external=True))
+        kobo_resources["library_sync"] = url_for("kobo.HandleSyncRequest",
+                                                  auth_token=kobo_auth.get_auth_token(),
+                                                  _external=True)
 
     response = make_response(jsonify({"Resources": kobo_resources}))
     response.headers["x-kobo-apitoken"] = "e30="


### PR DESCRIPTION
## Summary

The `HandleInitRequest()` function in `cps/kobo.py` rewrites `image_host`, `image_url_quality_template`, and `image_url_template` URLs to point to the local Calibre-Web instance, but does **not** rewrite `library_sync`. This causes Kobo e-readers to call `storeapi.kobo.com` for sync instead of the local server, resulting in no books being synced when running behind a reverse proxy.

This patch adds `library_sync` URL rewriting in both the proxied and non-proxied code paths, following the exact same pattern as the existing image URL rewrites:
- **Non-proxied**: `calibre_web_url + url_for(...)` (respects `config_external_port`)
- **Proxied**: `url_for(..., _external=True)` (uses reverse proxy headers)

## Root cause

1. Kobo calls `/v1/initialization`
2. Calibre-Web returns a `Resources` dict containing `library_sync: "https://storeapi.kobo.com/v1/library/sync"`
3. Only image URLs are rewritten to point to the local server
4. The Kobo reads `library_sync` and calls Kobo's servers for sync instead of the local instance
5. No books are synced

## Testing

I found this issue on my own setup and tested the fix end-to-end on:
- Debian 12, Python 3.11, calibreweb 0.6.26 (pip)
- nginx reverse proxy with HTTPS (Let's Encrypt)
- Kobo Clara, firmware 4.44.23552

Verified:
- `curl /v1/initialization` returns `library_sync` pointing to local server (both proxied and non-proxied paths tested)
- Kobo device successfully syncs books after the fix
- Server logs confirm both `Init` and `Kobo library sync request received` appear

## Potentially related issues

- #1758, #1891, #2339, #2991, #3271

Many reported Kobo sync failures behind reverse proxies may have been caused by this missing URL rewrite.

## Note on AI assistance

The analysis of the bug and the writing of this PR description were assisted by AI (Claude). The issue itself was discovered and diagnosed manually, and all testing was performed on real hardware. The code change follows the existing patterns in `HandleInitRequest()` exactly.