### PR TITLE
Fix AttributeError on unauthenticated OPDS requests

### DIFF
--- a/cps/main.py
+++ b/cps/main.py
@@ -24,7 +24,7 @@ from flask import request
 
 
 def request_username():
-    return request.authorization.username
+    return request.authorization.username if request.authorization else ""
 
 
 def main():


### PR DESCRIPTION
## Problem

`/opds` returns `500 Internal Server Error` instead of `401 Unauthorized` when accessed without an `Authorization` header.

`request_username()` is registered as flask-limiter's `key_func` for the OPDS blueprint. Flask-limiter evaluates `key_func` inside a `before_request` handler, which runs before the route's `@requires_basic_auth_if_no_ano` decorator. When no credentials are supplied, `request.authorization` is `None`:

```python
def request_username():
    return request.authorization.username  # AttributeError when no auth header
```

`swallow_errors=True` on the `Limiter` instance does not help — it only suppresses storage backend errors, not exceptions raised inside `key_func`.

## Fix

Guard against `None` so unauthenticated requests use an empty string as the rate-limit key, and the auth decorator handles the `401` correctly:

```python
def request_username():
    return request.authorization.username if request.authorization else ""
```

## Impact

Narrow scope. Standard OPDS clients always send Basic Auth headers and are unaffected. The 500 surfaces only when the OPDS endpoint is hit without credentials (e.g. browser access, local setup without anonymous access enabled, misconfigured client).

Closes #3592