### PR TITLE
fix(reverseproxy): set is_proxied=True when X-Forwarded-Proto is present

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -33,7 +33,7 @@ from functools import wraps
 from urllib.parse import urlparse
 
 from flask import Blueprint, flash, redirect, url_for, abort, request, make_response, \
-    send_from_directory, g, jsonify
+    send_from_directory, g, jsonify, current_app
 from markupsafe import Markup
 from .cw_login import current_user
 from flask_babel import gettext as _
@@ -230,6 +230,7 @@ def admin():
     return render_title_template("admin.html", allUser=all_user, config=config, commit=commit,
                                  feature_support=feature_support, schedule_time=schedule_time,
                                  schedule_duration=schedule_duration,
+                                 is_proxied=current_app.wsgi_app.is_proxied,
                                  title=_("Admin page"), page="admin")
 
 
@@ -250,6 +251,7 @@ def configuration():
                                  config=config,
                                  provider=oauthblueprints,
                                  feature_support=feature_support,
+                                 is_proxied=current_app.wsgi_app.is_proxied,
                                  title=_("Basic Configuration"), page="config")
 
 
@@ -1799,7 +1801,10 @@ def _configuration_update_helper():
         _config_checkbox_int(to_save, "config_public_reg")
         _config_checkbox_int(to_save, "config_register_email")
         reboot_required |= _config_checkbox_int(to_save, "config_kobo_sync")
-        _config_int(to_save, "config_external_port")
+        if not to_save.get("config_external_port", "").strip():
+            config.config_external_port = None
+        else:
+            _config_int(to_save, "config_external_port")
         _config_checkbox_int(to_save, "config_kobo_proxy")
 
         if "config_upload_formats" in to_save:

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -74,7 +74,7 @@ class _Settings(_Base):
     config_calibre_split = Column(Boolean, default=False)
     config_calibre_split_dir = Column(String)
     config_port = Column(Integer, default=constants.DEFAULT_PORT)
-    config_external_port = Column(Integer, default=constants.DEFAULT_PORT)
+    config_external_port = Column(Integer, default=None)
     config_certfile = Column(String)
     config_keyfile = Column(String)
     config_trustedhosts = Column(String, default='')

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -46,7 +46,7 @@ from sqlalchemy.exc import StatementError
 from . import config, logger, kobo_auth, db, calibre_db, helper, shelf as shelf_lib, ub, csrf, kobo_sync_status
 from . import isoLanguages, limiter
 from .epub import get_epub_layout
-from .constants import COVER_THUMBNAIL_SMALL, COVER_THUMBNAIL_MEDIUM, COVER_THUMBNAIL_LARGE, BASE_DIR
+from .constants import COVER_THUMBNAIL_SMALL, COVER_THUMBNAIL_MEDIUM, COVER_THUMBNAIL_LARGE, BASE_DIR, DEFAULT_PORT
 from .helper import get_download_link
 from .services import SyncToken as SyncToken
 from .web import download_required
@@ -357,10 +357,11 @@ def get_download_url_for_book(book_id, book_format):
         else:
             host = request.host
 
+        url_port = config.config_external_port or DEFAULT_PORT
         return "{url_scheme}://{url_base}:{url_port}/kobo/{auth_token}/download/{book_id}/{book_format}".format(
             url_scheme=request.scheme,
             url_base=host,
-            url_port=config.config_external_port,
+            url_port=url_port,
             auth_token=get_auth_token(),
             book_id=book_id,
             book_format=book_format.lower()
@@ -1095,10 +1096,11 @@ def HandleInitRequest():
             host = "".join(request.host.split(':')[:-1])
         else:
             host = request.host
+        url_port = config.config_external_port or DEFAULT_PORT
         calibre_web_url = "{url_scheme}://{url_base}:{url_port}".format(
             url_scheme=request.scheme,
             url_base=host,
-            url_port=config.config_external_port
+            url_port=url_port
         )
         log.debug('Kobo: Received unproxied request, changed request url to %s', calibre_web_url)
         kobo_resources["image_host"] = calibre_web_url

--- a/cps/reverseproxy.py
+++ b/cps/reverseproxy.py
@@ -71,9 +71,10 @@ class ReverseProxied(object):
             if path_info and path_info.startswith(script_name):
                 environ['PATH_INFO'] = path_info[len(script_name):]
 
-        scheme = environ.get('HTTP_X_SCHEME', '')
+        scheme = environ.get('HTTP_X_SCHEME', '') or environ.get('HTTP_X_FORWARDED_PROTO', '')
         if scheme:
             environ['wsgi.url_scheme'] = scheme
+            self.proxied = True
         servr = environ.get('HTTP_X_FORWARDED_HOST', '')
         if servr:
             environ['HTTP_HOST'] = servr

--- a/cps/templates/admin.html
+++ b/cps/templates/admin.html
@@ -117,10 +117,10 @@
             <div class="col-xs-6 col-sm-6">{{_('Port')}}</div>
             <div class="col-xs-6 col-sm-6">{{config.config_port}}</div>
         </div>
-        {% if kobo_support and config.config_port != config.config_external_port %}
+        {% if kobo_support %}
         <div class="row">
           <div class="col-xs-6 col-sm-6">{{_('External Port')}}</div>
-          <div class="col-xs-6 col-sm-6">{{config.config_external_port}}</div>
+          <div class="col-xs-6 col-sm-6">{% if config.config_external_port %}{{config.config_external_port}}{% elif is_proxied %}<em>Not set — reverse proxy detected</em>{% else %}8083{% endif %}</div>
         </div>
         {% endif %}
       </div>

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -147,7 +147,10 @@
       </div>
       <div class="form-group" style="margin-left:10px;">
         <label for="config_external_port">{{_('Server External Port (for port forwarded API calls)')}}</label>
-        <input type="number" min="1" max="65535" class="form-control" name="config_external_port" id="config_external_port" value="{% if config.config_external_port != None %}{{ config.config_external_port }}{% endif %}" autocomplete="off" required>
+        <input type="number" min="1" max="65535" class="form-control" name="config_external_port" id="config_external_port" value="{% if config.config_external_port != None %}{{ config.config_external_port }}{% endif %}" placeholder="8083" autocomplete="off">
+        {% if is_proxied %}
+        <span class="help-block">A reverse proxy was detected. Leave blank unless you need to override the port for direct access.</span>
+        {% endif %}
       </div>
     </div>
     {% endif %}


### PR DESCRIPTION
## Problem

When Calibre-Web is served through a **Cloudflare Tunnel** (or any reverse proxy that sends `X-Forwarded-Proto` without `X-Forwarded-Host`), the Kobo sync URL is generated with `localhost:8083` instead of the public HTTPS URL.

**Root cause:** `ReverseProxied.is_proxied` only returns `True` when `HTTP_X_FORWARDED_HOST` is present. Cloudflare Tunnel (and most standard reverse proxy configurations including nginx, Caddy, and Traefik in their default configs) sends `X-Forwarded-Proto` but **not** `X-Forwarded-Host`, so `is_proxied` stays `False`. This causes `kobo.py:get_download_url_for_book()` to fall back to an explicit `host:port` URL, appending the internal container port (default 8083) — e.g. `https://books.example.com:8083/kobo/...`. This breaks Kobo wireless sync silently: books appear in the library but fail to download.

## My Setup

- Raspberry Pi running Calibre-Web in Docker
- Cloudflare Tunnel exposing it externally (no port forwarding)
- Kobo Clara BW syncing via the external URL

## Changes

### 1. `cps/reverseproxy.py` — Core fix

Also check `X-Forwarded-Proto` when determining scheme, and set `self.proxied = True` whenever any proxy header is detected — consistent with the existing `X-Forwarded-Host` behaviour.

```python
# Before
scheme = environ.get('HTTP_X_SCHEME', '')
if scheme:
    environ['wsgi.url_scheme'] = scheme

# After
scheme = environ.get('HTTP_X_SCHEME', '') or environ.get('HTTP_X_FORWARDED_PROTO', '')
if scheme:
    environ['wsgi.url_scheme'] = scheme
    self.proxied = True
```

### 2. `cps/config_sql.py` — Schema default change

Changed `config_external_port` column default from `8083` to `None`. The old default was misleading behind a proxy — it caused the port to always be appended to URLs even when it shouldn't be.

### 3. `cps/kobo.py` — Runtime fallback

Fall back to `DEFAULT_PORT` (8083) at runtime when `config_external_port` is `None`, preserving existing behavior for non-proxied setups.

### 4. `cps/admin.py` — Blank port handling + proxy context

- Passes `is_proxied` to `config_edit.html` and `admin.html` templates
- Handles blank External Port submission as `NULL` instead of crashing (`int('')` threw `ValueError`)

### 5. `cps/templates/config_edit.html` — Port field UX

- Port field is no longer `required`; value is blank when `NULL`; placeholder shows `8083`
- Help text shown when proxy detected:
  > "A reverse proxy was detected. Leave blank unless you need to override the port for direct access."

### 6. `cps/templates/admin.html` — Config display

- Shows stored value if set
- Shows "Not set — reverse proxy detected" (italic) if proxied and not set
- Falls back to `8083` if not proxied and not set

## Notes

- `ProxyFix` in `__init__.py` already correctly handles `X-Forwarded-Proto` for scheme detection, and `TRUSTED_PROXY_COUNT` is documented for Cloudflare Tunnel. This closes the gap in `is_proxied`, which is a separate check used by `kobo.py`.
- `X-Forwarded-Proto` is the most universally forwarded proxy header — this fix broadens `is_proxied` detection to cover Cloudflare Tunnel and the majority of standard proxy setups that don't explicitly set `X-Forwarded-Host`.
- I've raised the same fix against Calibre-Web Automated: crocodilestick/Calibre-Web-Automated#1143.

## Verified

Tested end-to-end on a **fresh Docker install** behind a Cloudflare Tunnel:

| Test | Result |
|------|--------|
| Reverse proxy auto-detected via `X-Forwarded-Proto` | ✅ |
| Help text "A reverse proxy was detected..." shown on config page | ✅ |
| Port field blank by default with placeholder `8083` | ✅ |
| Config saves cleanly with blank port (previously crashed) | ✅ |
| Kobo Auth URL uses public hostname (`https://...`) | ✅ |
| Kobo download URLs use public hostname (not `localhost:8083`) | ✅ |
| E2E tested on fresh Docker install with empty library | ✅ |
| Kobo device sync confirmed — books downloaded to device (Kobo Clara BW) | ✅ |

---

**Note:** Python isn't my primary language so apologies if the implementation isn't idiomatic — happy to iterate based on feedback.