### PR TITLE
Fix TypeError crash in metadata_search when provider returns None

### DIFF
--- a/cps/search_metadata.py
+++ b/cps/search_metadata.py
@@ -135,5 +135,5 @@ def metadata_search():
                 if active.get(c.__id__, True)
             }
             for future in concurrent.futures.as_completed(meta):
-                data.extend([asdict(x) for x in future.result() if x])
+                data.extend([asdict(x) for x in (future.result() or []) if x])
     return  make_response(jsonify(data))


### PR DESCRIPTION
When a metadata provider returns None instead of an empty list on failure (e.g. Amazon returning 503, ComicVine returning 420), the result aggregation crashes with TypeError: 'NoneType' object is not iterable, causing the entire search to fail even if other providers like Google Books succeeded.

This is line 138 of cps/search_metadata.py:

    data.extend([asdict(x) for x in future.result() if x])

The fix is:

    data.extend([asdict(x) for x in (future.result() or []) if x])

Verified working on 0.6.26. Related issues: #2552, #2562, #2657, #3188