### PR TITLE
Fix filename* parameter in Content-Disposition to preserve non-ASCII characters (RFC 6266)

### DIFF
--- a/cps/helper.py
+++ b/cps/helper.py
@@ -1091,8 +1091,9 @@ def get_download_link(book_id, book_format, client):
             file_name = book.title
             if len(book.authors) > 0:
                 file_name = file_name + ' - ' + book.authors[0].name
+            file_name_utf8 = file_name.replace("/", "_").replace(":", "_").strip('\0')
             file_name = get_valid_filename(file_name, replace_whitespace=False, force_unidecode=True)
-            quoted_file_name = file_name if client == "kindle" else quote(file_name)
+            quoted_file_name = file_name if client == "kindle" else quote(file_name_utf8)
             headers = Headers()
             headers["Content-Type"] = mimetypes.types_map.get('.' + book_format, "application/octet-stream")
             headers["Content-Disposition"] = ('attachment; filename="{}.{}"; filename*=UTF-8\'\'{}.{}').format(


### PR DESCRIPTION
## Problem

When downloading a book whose title or author contains non-ASCII characters
(e.g. Japanese, Arabic, accented Latin), the browser saves the file with a
transliterated ASCII name instead of the original characters.

This happens because `get_download_link` calls `get_valid_filename(...,
force_unidecode=True)` which strips unicode *before* building the
`Content-Disposition` header — so both the `filename=` fallback *and* the
`filename*=UTF-8''...` parameter receive the already-ASCII version. The
`filename*=` parameter exists precisely to carry the original unicode; using
a pre-transliterated value defeats its purpose.

Reported in #3571, #3590.

## Fix

Capture the title+author string *before* `get_valid_filename` strips it to
ASCII, then use that as the input to `quote()` for the `filename*=` value.

- `filename=` keeps the ASCII/unidecoded fallback (for old clients, Kindles)
- `filename*=UTF-8''...` now carries the correctly percent-encoded original UTF-8

Per [RFC 6266 §4.3](https://www.rfc-editor.org/rfc/rfc6266#section-4.3) and
[RFC 5987](https://www.rfc-editor.org/rfc/rfc5987):
Content-Disposition: attachment;
filename="Ri Ben Yu Tai Toru - Zhu Zhe Ming.epub";
filename*=UTF-8''%E6%97%A5%E6%9C%AC%E8%AA%9E%E3%82%BF%E3%82%A4%E3%83%88%E3%83%AB%20-%20%E8%91%97%E8%80%85%E5%90%8D.epub
Browser decodes `filename*=` and saves the file as `日本語タイトル - 著者名.epub`.

## Notes

- Kindle client path is unchanged (still uses ASCII `file_name` directly, no quoting)
- ASCII-only titles are completely unaffected (quoting ASCII produces the same result as before)
- No new dependencies, no schema changes