### PR TITLE
Kobo: include PriorityTimestamp in PUT /state response

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -811,6 +811,8 @@ def HandleStateRequest(book_uuid):
 
         ub.session.merge(kobo_reading_state)
         ub.session_commit()
+        update_results_response["LastModified"] = convert_to_kobo_timestamp_string(kobo_reading_state.last_modified)
+        update_results_response["PriorityTimestamp"] = convert_to_kobo_timestamp_string(kobo_reading_state.priority_timestamp)
         return jsonify({
             "RequestResult": "Success",
             "UpdateResults": [update_results_response],


### PR DESCRIPTION
Kobo devices can show a spurious “Return to last page read?” prompt after auto-sleep/wake.
The server advances priority_timestamp when handling PUT /v1/library//state, but the PUT response did not include the updated PriorityTimestamp. If the device updates its cached timestamp from GET responses, this leaves a window where the next GET returns a “new” timestamp the device hasn’t been told about, triggering the prompt.
This change adds PriorityTimestamp (and LastModified) to the PUT UpdateResults so the device can update its cached value immediately.