### PR TITLE
Fix series list view ignoring sort field, causing incorrect article-inclusive sorting

### DIFF
--- a/cps/web.py
+++ b/cps/web.py
@@ -1026,7 +1026,7 @@ def series_list():
                             .count())
             if no_series_count:
                 entries.append([db.Category(_("None"), "-1"), no_series_count])
-            entries = sorted(entries, key=lambda x: x[0].name.lower(), reverse=not order_no)
+            entries = sorted(entries, key=lambda x: (x[0].sort or x[0].name).lower(), reverse=not order_no)
             return render_title_template('list.html',
                                          entries=entries,
                                          folder='web.books_list',


### PR DESCRIPTION
## Problem

When viewing the Series list in list mode, series titles with
leading articles (A, An, The) sort by the article instead of the
word that follows it. For example, "A Collins-Burke Mystery"
appears under "A" rather than "C". Reported in #3583.

## Root Cause

`series_list()` in `cps/web.py` queries the database ordered by
`Series.sort` (the correct field), but then re-sorts the result
in Python using `Series.name` as the key. This Python sort
overwrites the DB ordering and ignores the `sort` field entirely.

The Python re-sort exists to correctly place the synthetic "None"
category entry after it is appended to the list. The sort key just referenced the wrong field.

## Fix

Change the Python re-sort key from `x[0].name.lower()` to
`(x[0].sort or x[0].name).lower()`, making it consistent with
the DB query. The `or x[0].name` fallback handles the edge case
of a NULL sort value.

## Changes

- `cps/web.py` line 1029: one-line fix

## Testing

- Series with titles beginning with "A", "An", "The" now appear under their meaningful first word in list view
- Sort direction (asc/desc) continues to work correctly
- The "None" category entry continues to sort correctly
- Grid/cover view is unaffected (no Python re-sort in that path)
- OPDS feed is unaffected (already used Series.sort correctly)