### PR TITLE
Fix: Remaining  Kobo "Sync to last page read?" popup on sync

### DIFF
--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -35,7 +35,8 @@ from flask import (
     current_app,
     url_for,
     redirect,
-    abort
+    abort,
+    g
 )
 from .cw_login import current_user
 from werkzeug.datastructures import Headers
@@ -775,6 +776,13 @@ def HandleStateRequest(book_uuid):
             request_data = request.json
             request_reading_state = request_data["ReadingStates"][0]
 
+            # Use the device's own timestamp so the GET response mirrors it back,
+            # preventing the "newer PT" conflict popup. Official Kobo cloud does the same.
+            lm_str = request_reading_state.get("LastModified")
+            request_lm = (datetime.strptime(lm_str, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+                          if lm_str else datetime.now(timezone.utc))
+            g.kobo_reading_state_lm = request_lm
+
             request_bookmark = request_reading_state["CurrentBookmark"]
             if request_bookmark:
                 current_bookmark = kobo_reading_state.current_bookmark
@@ -785,6 +793,7 @@ def HandleStateRequest(book_uuid):
                     current_bookmark.location_value = location["Value"]
                     current_bookmark.location_type = location["Type"]
                     current_bookmark.location_source = location["Source"]
+                current_bookmark.last_modified = request_lm
                 update_results_response["CurrentBookmarkResult"] = {"Result": "Success"}
 
             request_statistics = request_reading_state["Statistics"]
@@ -792,17 +801,19 @@ def HandleStateRequest(book_uuid):
                 statistics = kobo_reading_state.statistics
                 statistics.spent_reading_minutes = int(request_statistics["SpentReadingMinutes"])
                 statistics.remaining_time_minutes = int(request_statistics["RemainingTimeMinutes"])
+                statistics.last_modified = request_lm
                 update_results_response["StatisticsResult"] = {"Result": "Success"}
 
             request_status_info = request_reading_state["StatusInfo"]
             if request_status_info:
                 book_read = kobo_reading_state.book_read_link
                 new_book_read_status = get_ub_read_status(request_status_info["Status"])
-                if new_book_read_status == ub.ReadBook.STATUS_IN_PROGRESS \
-                        and new_book_read_status != book_read.read_status:
-                    book_read.times_started_reading += 1
-                    book_read.last_time_started_reading = datetime.now(timezone.utc)
-                book_read.read_status = new_book_read_status
+                if new_book_read_status != book_read.read_status:
+                    if new_book_read_status == ub.ReadBook.STATUS_IN_PROGRESS:
+                        book_read.times_started_reading += 1
+                        book_read.last_time_started_reading = datetime.now(timezone.utc)
+                    book_read.read_status = new_book_read_status
+                    book_read.last_modified = request_lm
                 update_results_response["StatusInfoResult"] = {"Result": "Success"}
         except (KeyError, TypeError, ValueError, StatementError):
             log.debug("Received malformed v1/library/<book_uuid>/state request.")

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -811,8 +811,6 @@ def HandleStateRequest(book_uuid):
 
         ub.session.merge(kobo_reading_state)
         ub.session_commit()
-        update_results_response["LastModified"] = convert_to_kobo_timestamp_string(kobo_reading_state.last_modified)
-        update_results_response["PriorityTimestamp"] = convert_to_kobo_timestamp_string(kobo_reading_state.priority_timestamp)
         return jsonify({
             "RequestResult": "Success",
             "UpdateResults": [update_results_response],

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -460,7 +460,7 @@ class KoboReadingState(Base):
     user_id = Column(Integer, ForeignKey('user.id'))
     book_id = Column(Integer)
     last_modified = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
-    priority_timestamp = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+    priority_timestamp = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     current_bookmark = relationship("KoboBookmark", uselist=False, backref="kobo_reading_state", cascade="all, delete")
     statistics = relationship("KoboStatistics", uselist=False, backref="kobo_reading_state", cascade="all, delete")
 
@@ -494,7 +494,9 @@ def receive_before_flush(session, flush_context, instances):
     for change in itertools.chain(session.new, session.dirty):
         if isinstance(change, (ReadBook, KoboStatistics, KoboBookmark)):
             if change.kobo_reading_state:
-                change.kobo_reading_state.last_modified = datetime.now(timezone.utc)
+                now = datetime.now(timezone.utc)
+                change.kobo_reading_state.last_modified = now
+                change.kobo_reading_state.priority_timestamp = now
     # Maintain the last_modified_bit for the Shelf table.
     for change in itertools.chain(session.new, session.deleted):
         if isinstance(change, BookShelf):

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -23,7 +23,7 @@ import sys
 from datetime import datetime, timezone, timedelta
 import itertools
 import uuid
-from flask import session as flask_session
+from flask import session as flask_session, has_request_context, g
 from binascii import hexlify
 
 from .cw_login import AnonymousUserMixin, current_user
@@ -494,9 +494,11 @@ def receive_before_flush(session, flush_context, instances):
     for change in itertools.chain(session.new, session.dirty):
         if isinstance(change, (ReadBook, KoboStatistics, KoboBookmark)):
             if change.kobo_reading_state:
-                now = datetime.now(timezone.utc)
-                change.kobo_reading_state.last_modified = now
-                change.kobo_reading_state.priority_timestamp = now
+                ts = (g.kobo_reading_state_lm
+                      if has_request_context() and getattr(g, 'kobo_reading_state_lm', None)
+                      else datetime.now(timezone.utc))
+                change.kobo_reading_state.last_modified = ts
+                change.kobo_reading_state.priority_timestamp = ts
     # Maintain the last_modified_bit for the Shelf table.
     for change in itertools.chain(session.new, session.deleted):
         if isinstance(change, BookShelf):


### PR DESCRIPTION
## TLDR
The server stamped PriorityTimestamp with datetime.now() on every PUT, so the next GET handed the Kobo a timestamp it had never seen and it offered to sync a position it already was at. Sending back the device's own LastModified (what the real Kobo cloud does) fixes it.

## Problem
When reading with a synced Kobo, users sometimes see a "Sync to last page read?" popup even though they've only been reading on that one device. The answer is always "no" and even when selecting "yes" it takes you to the same position. Previous fixes addressed related popup triggers but some still persisted. Fixes  #3596 , which is still reported occurring https://github.com/janeczku/calibre-web/issues/3596#issuecomment-5242380964 

## Background

The device uses `GET /v1/library/<uuid>/state` to fetch reading state when opening a book, and `PUT` to push progress updates while reading. GETs and PUTs are interspersed during a session; which one the session ends on appears to vary.
The popup decision happens on GET.

Two relevant timestamp fields on `KoboReadingState`:

- **`LastModified` (LM)** - generated by the device, sent in every PUT body, stored on each sub-record (bookmark, statistics, read status) and propagated to the parent row.
- **`PriorityTimestamp` (PT)** - conflict-detection field on the parent row only. Based on observed behavior, the device stores the PT from each GET response. If the next GET returns a newer PT, the device assumes another client made changes and could show the popup (e.g. the intended use case is syncing position across a Kobo device and the Kobo app, not something calibre-web supports.)

Observed via proxy: official Kobo cloud appears to always return PT = LM = the device's own `LastModified`, so the device always gets back a timestamp it recognizes.

## Root cause
Our server was stamping PT with `datetime.now()` on every PUT. When the device next did a GET it saw a server-generated PT newer than its last confirmed one, which triggered the popup despite no real conflict or change on another client. If a session ended with a GET the device would confirm the new PT and the next open was fine; if it ended with a PUT, the next GET would show the mismatch and trigger the popup. That is why it was intermittent.

## Fix
**Commit 2 (core fix):** Read `LastModified` from the PUT request body and use it as both LM and PT for all state saved in that request. The subsequent GET returns the device's own timestamp back, eliminating the mismatch. When state is changed outside a Kobo PUT, the flush hook falls back to `datetime.now()`, so PT still advances as before. Also fixes a minor issue where `book_read.last_modified` was being written on every PUT even when read status hadn't changed.

**Commit 1 (prerequisite):** Two things that would otherwise undermine commit 2:
- `priority_timestamp` had its own `onupdate=datetime.now()` independent of LM, so PT and LM could drift apart, which is itself a popup trigger. Removed `onupdate` from PT; the flush hook now sets both fields together.
- Commit `2d4ca23d` added LM and PT to the PUT response `UpdateResults` to let the device confirm the new PT without a GET. Based on observed behavior, that does not appear to work. The device seems not to persist reading-state timestamps from PUT responses. This change removes that response data again and instead keeps PT/LM aligned through the normal GET path, matching observed official Kobo cloud behavior.

##Testing
I've been running this for 5 months now  locally and have not seen an erroneous popup. 