### PR TITLE
Fix: Add nativeborrow property to allow OverDrive book borrowing

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -1802,6 +1802,7 @@ def _configuration_update_helper():
         reboot_required |= _config_checkbox_int(to_save, "config_kobo_sync")
         _config_int(to_save, "config_external_port")
         _config_checkbox_int(to_save, "config_kobo_proxy")
+        _config_checkbox_int(to_save, "config_kobo_nativeborrow")
 
         if "config_upload_formats" in to_save:
             to_save["config_upload_formats"] = ','.join(

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -122,6 +122,7 @@ class _Settings(_Base):
     config_login_type = Column(Integer, default=0)
 
     config_kobo_proxy = Column(Boolean, default=False)
+    config_kobo_nativeborrow = Column(Boolean, default=False)
 
     config_ldap_provider_url = Column(String, default='example.org')
     config_ldap_port = Column(SmallInteger, default=389)

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -1245,7 +1245,7 @@ def NATIVE_KOBO_RESOURCES():
         "kobo_dropbox_link_account_enabled": "False",
         "kobo_google_tax": "False",
         "kobo_googledrive_link_account_enabled": "False",
-        "kobo_nativeborrow_enabled": "False",
+        "kobo_nativeborrow_enabled": "True" if config.config_kobo_nativeborrow else "False",
         "kobo_onedrive_link_account_enabled": "False",
         "kobo_onestorelibrary_enabled": "False",
         "kobo_privacyCentre_url": "https://www.kobo.com/privacy",

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -146,6 +146,10 @@
         <label for="config_kobo_proxy">{{_('Proxy unknown requests to Kobo Store')}}</label>
       </div>
       <div class="form-group" style="margin-left:10px;">
+        <input type="checkbox" id="config_kobo_nativeborrow" name="config_kobo_nativeborrow"  {% if config.config_kobo_nativeborrow %}checked{% endif %}>
+        <label for="config_kobo_nativeborrow">{{_('Enable Kobo OverDrive/Library Borrowing')}}</label>
+      </div>
+      <div class="form-group" style="margin-left:10px;">
         <label for="config_external_port">{{_('Server External Port (for port forwarded API calls)')}}</label>
         <input type="number" min="1" max="65535" class="form-control" name="config_external_port" id="config_external_port" value="{% if config.config_external_port != None %}{{ config.config_external_port }}{% endif %}" autocomplete="off" required>
       </div>


### PR DESCRIPTION
# Bug

On top of Calibre web, I use OverDrive to borrow books from my local library. Right now the initialization endpoint is hardcoded to have nativeborrow false.

<img width="1684" height="104" alt="image" src="https://github.com/user-attachments/assets/b6b27d39-17e3-4454-9d74-ca3ac69dd8b7" />

That forces the Kobo Reader.config's value back to false, which in turn disables OverDrive. Now, you can connect to your Kobo with USB and update that value back to True, which makes it work again ; but a) my kid's Kobo seems to randomly hit that endpoint when synchronizing/rebooting, b) it's called everytime there's an update.

# Fix

There might be legitimate cases to have this off, in countries where library borrowing is deactivated. This fix introduces a new "Enable Overdrive/Library borrowing" option in the Kobo section of admin configuration:

<img width="814" height="270" alt="image" src="https://github.com/user-attachments/assets/23f36980-1a8c-4ce7-8d32-466c50c5e6e3" />

with that toggle selected, the value comes back as True:

<img width="1666" height="102" alt="image" src="https://github.com/user-attachments/assets/cec8e6f8-950e-4539-a870-57371458b994" />

I've tested that fix for a few days on my server, seems to be working fine.

_side note: I'm quite impressed by how easy the fix was to implement, this speaks lengths of how well this piece of software is built... congrats!_