### PR TITLE
Persist Kobo reading state and sync position with the web reader

### DIFF
--- a/cps/constants.py
+++ b/cps/constants.py
@@ -98,6 +98,7 @@ SIDEBAR_FORMAT          = 1 << 14
 SIDEBAR_ARCHIVED        = 1 << 15
 SIDEBAR_DOWNLOAD        = 1 << 16
 SIDEBAR_LIST            = 1 << 17
+SIDEBAR_READING         = 1 << 18
 
 sidebar_settings = {
                 "detail_random": DETAIL_RANDOM,
@@ -116,11 +117,12 @@ sidebar_settings = {
                 "sidebar_archived": SIDEBAR_ARCHIVED,
                 "sidebar_download": SIDEBAR_DOWNLOAD,
                 "sidebar_list": SIDEBAR_LIST,
+                "sidebar_reading": SIDEBAR_READING,
             }
 
 
 ADMIN_USER_ROLES        = sum(r for r in ALL_ROLES.values()) & ~ROLE_ANONYMOUS
-ADMIN_USER_SIDEBAR      = (SIDEBAR_LIST << 1) - 1
+ADMIN_USER_SIDEBAR      = (SIDEBAR_READING << 1) - 1
 
 UPDATE_STABLE       = 0 << 0
 AUTO_UPDATE_STABLE  = 1 << 0

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -909,25 +909,17 @@ def get_current_bookmark_response(current_bookmark):
     loc_type = current_bookmark.location_type
     loc_source = current_bookmark.location_source
 
-    if loc_type == "CFI" and loc_source:
-        # Position was stored by the web reader as a CFI string.  The Kobo
-        # firmware cannot interpret CFI values, but it *can* use Location.Source
-        # (the chapter href) to open the correct spine item, then fall back to
-        # ContentSourceProgressPercent for in-chapter positioning when it finds
-        # no matching KoboSpan element.  Presenting the type as "KoboSpan" with
-        # an empty Value triggers exactly that fallback path.
-        resp["Location"] = {
-            "Value": "",
-            "Type": "KoboSpan",
-            "Source": loc_source,
-        }
+    # Browser-stored values (CFI strings or bare "#kobo.N.M" fragments) are not
+    # valid Kobo location URIs; send an empty Value so the Kobo falls back to
+    # ContentSourceProgressPercent.  Kobo-device values are sent back verbatim.
+    is_browser_value = (
+        loc_type == "CFI"
+        or (loc_type == "KoboSpan" and loc_value and loc_value.startswith("#"))
+    )
+    if is_browser_value and loc_source:
+        resp["Location"] = {"Value": "", "Type": "KoboSpan", "Source": loc_source}
     elif loc_value:
-        # Position was stored by a Kobo device — send it back verbatim.
-        resp["Location"] = {
-            "Value": loc_value,
-            "Type": loc_type,
-            "Source": loc_source,
-        }
+        resp["Location"] = {"Value": loc_value, "Type": loc_type, "Source": loc_source}
 
     return resp
 

--- a/cps/kobo.py
+++ b/cps/kobo.py
@@ -904,12 +904,31 @@ def get_current_bookmark_response(current_bookmark):
         resp["ProgressPercent"] = _clean_progress(current_bookmark.progress_percent)
     if current_bookmark.content_source_progress_percent is not None:
         resp["ContentSourceProgressPercent"] = _clean_progress(current_bookmark.content_source_progress_percent)
-    if current_bookmark.location_value:
+
+    loc_value = current_bookmark.location_value
+    loc_type = current_bookmark.location_type
+    loc_source = current_bookmark.location_source
+
+    if loc_type == "CFI" and loc_source:
+        # Position was stored by the web reader as a CFI string.  The Kobo
+        # firmware cannot interpret CFI values, but it *can* use Location.Source
+        # (the chapter href) to open the correct spine item, then fall back to
+        # ContentSourceProgressPercent for in-chapter positioning when it finds
+        # no matching KoboSpan element.  Presenting the type as "KoboSpan" with
+        # an empty Value triggers exactly that fallback path.
         resp["Location"] = {
-            "Value": current_bookmark.location_value,
-            "Type": current_bookmark.location_type,
-            "Source": current_bookmark.location_source,
+            "Value": "",
+            "Type": "KoboSpan",
+            "Source": loc_source,
         }
+    elif loc_value:
+        # Position was stored by a Kobo device — send it back verbatim.
+        resp["Location"] = {
+            "Value": loc_value,
+            "Type": loc_type,
+            "Source": loc_source,
+        }
+
     return resp
 
 

--- a/cps/main.py
+++ b/cps/main.py
@@ -46,11 +46,12 @@ def main():
     try:
         from .kobo import kobo, get_kobo_activated
         from .kobo_auth import kobo_auth
+        from .reading_progress import reading_progress
         from flask_limiter.util import get_remote_address
         kobo_available = get_kobo_activated()
     except (ImportError, AttributeError):  # Catch also error for not installed flask-WTF (missing csrf decorator)
         kobo_available = False
-        kobo = kobo_auth = get_remote_address = None
+        kobo = kobo_auth = reading_progress = get_remote_address = None
 
     try:
         from .oauth_bb import oauth
@@ -80,6 +81,7 @@ def main():
         limiter.limit("3/minute", key_func=get_remote_address)(kobo)
         app.register_blueprint(kobo)
         app.register_blueprint(kobo_auth)
+        app.register_blueprint(reading_progress)
     if oauth_available:
         app.register_blueprint(oauth)
     success = web_server.start()

--- a/cps/reading_progress.py
+++ b/cps/reading_progress.py
@@ -17,34 +17,13 @@
 #  along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 """
-REST API for reading progress sync.
+REST API for reading progress sync between the web reader and Kobo devices.
 
-Exposes per-user, per-book reading progress stored by the Kobo sync integration
-so that phone-based or other external EPUB readers can share a reading position
-with a Kobo device.
+Endpoints: GET and PUT /api/reading-progress/<book_id>
 
-Position format
----------------
-The ``location`` field carries a KoboSpan position string produced by the Kobo
-firmware, stored verbatim during Kobo sync.  A typical value looks like::
-
-    "file:///mnt/onboard/path/to/book.kepub.epub!OEBPS/chapter01.html#koboSpan-id"
-
-The ``location.type`` field will be ``"KoboSpan"`` for positions recorded by a
-Kobo device.  External readers that understand KoboSpan can use this directly;
-readers that only understand percentage-based progress can use
-``progress_percent`` instead.
-
-Endpoints
----------
-``GET /api/reading-progress/<book_id>``
-    Returns the current reading progress for the authenticated user.
-
-``PUT /api/reading-progress/<book_id>``
-    Accepts a JSON body to update reading progress.  All fields are optional;
-    omit any field you do not wish to change.  After a successful PUT the Kobo
-    device will receive the updated position on its next sync (via
-    ``/v1/library/sync`` or ``/v1/library/<uuid>/state``).
+The ``location`` field uses two formats depending on source:
+- type "KoboSpan": value is a Kobo device URI ending in a span ID (e.g. "#kobo.2.1")
+- type "CFI": value is an EPUB CFI string (plain EPUBs only)
 """
 
 from datetime import datetime, timezone
@@ -63,22 +42,7 @@ reading_progress = Blueprint("reading_progress", __name__, url_prefix="/api")
 @reading_progress.route("/reading-progress/<int:book_id>", methods=["GET"])
 @user_login_required
 def get_reading_progress(book_id):
-    """Return the stored reading progress for the current user and the given book.
-
-    Response JSON fields:
-        book_id                          — integer calibre book ID
-        status                           — "ReadyToRead", "Reading", or "Finished"
-        last_modified                    — ISO-8601 UTC timestamp of the last state change
-        progress_percent                 — float 0-100, overall book progress (may be absent)
-        content_source_progress_percent  — float 0-100, in-chapter progress (may be absent)
-        location                         — KoboSpan position object (may be absent):
-            value  — the raw KoboSpan position string
-            type   — position type, typically "KoboSpan"
-            source — source href of the spine item containing this span
-        statistics                       — reading time object (may be absent):
-            spent_reading_minutes        — cumulative minutes spent reading
-            remaining_time_minutes       — estimated minutes remaining
-    """
+    """Return the stored reading progress for the current user and book."""
     book = calibre_db.get_book(book_id)
     if not book:
         abort(404, description="Book not found")
@@ -121,23 +85,10 @@ def get_reading_progress(book_id):
 @reading_progress.route("/reading-progress/<int:book_id>", methods=["PUT"])
 @user_login_required
 def update_reading_progress(book_id):
-    """Update reading progress for the current user and the given book.
+    """Update reading progress for the current user and book.
 
-    All JSON body fields are optional; only the fields present in the request
-    are updated — omitted fields are left unchanged.
-
-    Request JSON fields:
-        status                           — "ReadyToRead", "Reading", or "Finished"
-        progress_percent                 — float 0-100
-        content_source_progress_percent  — float 0-100 (in-chapter progress)
-        location                         — KoboSpan position object:
-            value  — KoboSpan position string, e.g.
-                     "file:///mnt/onboard/...!OEBPS/ch01.html#koboSpan-id"
-            type   — position type; use "KoboSpan" for Kobo-compatible positions
-            source — source href of the spine item containing this span
-
-    After a successful response the Kobo device will pick up the updated
-    position on its next sync.
+    All JSON body fields are optional; omitted fields are left unchanged.
+    After a successful PUT the Kobo device picks up the position on its next sync.
     """
     book = calibre_db.get_book(book_id)
     if not book:
@@ -177,8 +128,6 @@ def update_reading_progress(book_id):
         ub.session.rollback()
         abort(400, description="Malformed request data")
 
-    # Advance priority_timestamp so the Kobo device picks up this update on
-    # next sync instead of overwriting it with an older position from the device.
     kobo_reading_state.priority_timestamp = datetime.now(timezone.utc)
 
     ub.session.merge(kobo_reading_state)

--- a/cps/reading_progress.py
+++ b/cps/reading_progress.py
@@ -1,0 +1,192 @@
+# -*- coding: utf-8 -*-
+
+#  This file is part of the Calibre-Web (https://github.com/janeczku/calibre-web)
+#    Copyright (C) 2024 contributors
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""
+REST API for reading progress sync.
+
+Exposes per-user, per-book reading progress stored by the Kobo sync integration
+so that phone-based or other external EPUB readers can share a reading position
+with a Kobo device.
+
+Position format
+---------------
+The ``location`` field carries a KoboSpan position string produced by the Kobo
+firmware, stored verbatim during Kobo sync.  A typical value looks like::
+
+    "file:///mnt/onboard/path/to/book.kepub.epub!OEBPS/chapter01.html#koboSpan-id"
+
+The ``location.type`` field will be ``"KoboSpan"`` for positions recorded by a
+Kobo device.  External readers that understand KoboSpan can use this directly;
+readers that only understand percentage-based progress can use
+``progress_percent`` instead.
+
+Endpoints
+---------
+``GET /api/reading-progress/<book_id>``
+    Returns the current reading progress for the authenticated user.
+
+``PUT /api/reading-progress/<book_id>``
+    Accepts a JSON body to update reading progress.  All fields are optional;
+    omit any field you do not wish to change.  After a successful PUT the Kobo
+    device will receive the updated position on its next sync (via
+    ``/v1/library/sync`` or ``/v1/library/<uuid>/state``).
+"""
+
+from datetime import datetime, timezone
+
+from flask import Blueprint, jsonify, request, abort
+from .cw_login import current_user
+from . import logger, ub, calibre_db, csrf
+from .kobo import get_or_create_reading_state, get_read_status_for_kobo, get_ub_read_status
+from .usermanagement import user_login_required
+
+log = logger.create()
+
+reading_progress = Blueprint("reading_progress", __name__, url_prefix="/api")
+
+
+@reading_progress.route("/reading-progress/<int:book_id>", methods=["GET"])
+@user_login_required
+def get_reading_progress(book_id):
+    """Return the stored reading progress for the current user and the given book.
+
+    Response JSON fields:
+        book_id                          — integer calibre book ID
+        status                           — "ReadyToRead", "Reading", or "Finished"
+        last_modified                    — ISO-8601 UTC timestamp of the last state change
+        progress_percent                 — float 0-100, overall book progress (may be absent)
+        content_source_progress_percent  — float 0-100, in-chapter progress (may be absent)
+        location                         — KoboSpan position object (may be absent):
+            value  — the raw KoboSpan position string
+            type   — position type, typically "KoboSpan"
+            source — source href of the spine item containing this span
+        statistics                       — reading time object (may be absent):
+            spent_reading_minutes        — cumulative minutes spent reading
+            remaining_time_minutes       — estimated minutes remaining
+    """
+    book = calibre_db.get_book(book_id)
+    if not book:
+        abort(404, description="Book not found")
+
+    kobo_reading_state = get_or_create_reading_state(book_id)
+    current_bookmark = kobo_reading_state.current_bookmark
+    book_read = kobo_reading_state.book_read_link
+    statistics = kobo_reading_state.statistics
+
+    response = {
+        "book_id": book_id,
+        "status": get_read_status_for_kobo(book_read),
+        "last_modified": kobo_reading_state.last_modified.strftime("%Y-%m-%dT%H:%M:%SZ")
+        if kobo_reading_state.last_modified else None,
+    }
+
+    if current_bookmark.progress_percent is not None:
+        response["progress_percent"] = current_bookmark.progress_percent
+    if current_bookmark.content_source_progress_percent is not None:
+        response["content_source_progress_percent"] = current_bookmark.content_source_progress_percent
+    if current_bookmark.location_value:
+        response["location"] = {
+            "value": current_bookmark.location_value,
+            "type": current_bookmark.location_type,
+            "source": current_bookmark.location_source,
+        }
+    if statistics:
+        stats = {}
+        if statistics.spent_reading_minutes is not None:
+            stats["spent_reading_minutes"] = statistics.spent_reading_minutes
+        if statistics.remaining_time_minutes is not None:
+            stats["remaining_time_minutes"] = statistics.remaining_time_minutes
+        if stats:
+            response["statistics"] = stats
+
+    return jsonify(response)
+
+
+@csrf.exempt
+@reading_progress.route("/reading-progress/<int:book_id>", methods=["PUT"])
+@user_login_required
+def update_reading_progress(book_id):
+    """Update reading progress for the current user and the given book.
+
+    All JSON body fields are optional; only the fields present in the request
+    are updated — omitted fields are left unchanged.
+
+    Request JSON fields:
+        status                           — "ReadyToRead", "Reading", or "Finished"
+        progress_percent                 — float 0-100
+        content_source_progress_percent  — float 0-100 (in-chapter progress)
+        location                         — KoboSpan position object:
+            value  — KoboSpan position string, e.g.
+                     "file:///mnt/onboard/...!OEBPS/ch01.html#koboSpan-id"
+            type   — position type; use "KoboSpan" for Kobo-compatible positions
+            source — source href of the spine item containing this span
+
+    After a successful response the Kobo device will pick up the updated
+    position on its next sync.
+    """
+    book = calibre_db.get_book(book_id)
+    if not book:
+        abort(404, description="Book not found")
+
+    data = request.get_json(force=True, silent=True)
+    if data is None:
+        abort(400, description="Request body must be valid JSON")
+
+    kobo_reading_state = get_or_create_reading_state(book_id)
+    current_bookmark = kobo_reading_state.current_bookmark
+    book_read = kobo_reading_state.book_read_link
+
+    try:
+        if "status" in data:
+            status_str = data["status"]
+            if status_str not in ("ReadyToRead", "Reading", "Finished"):
+                abort(400, description="Invalid status value; must be ReadyToRead, Reading, or Finished")
+            new_status = get_ub_read_status(status_str)
+            if new_status == ub.ReadBook.STATUS_IN_PROGRESS and new_status != book_read.read_status:
+                book_read.times_started_reading += 1
+                book_read.last_time_started_reading = datetime.now(timezone.utc)
+            book_read.read_status = new_status
+
+        if "progress_percent" in data:
+            current_bookmark.progress_percent = float(data["progress_percent"])
+
+        if "content_source_progress_percent" in data:
+            current_bookmark.content_source_progress_percent = float(data["content_source_progress_percent"])
+
+        location = data.get("location")
+        if location is not None:
+            current_bookmark.location_value = location.get("value")
+            current_bookmark.location_type = location.get("type")
+            current_bookmark.location_source = location.get("source")
+    except (KeyError, TypeError, ValueError):
+        ub.session.rollback()
+        abort(400, description="Malformed request data")
+
+    # Advance priority_timestamp so the Kobo device picks up this update on
+    # next sync instead of overwriting it with an older position from the device.
+    kobo_reading_state.priority_timestamp = datetime.now(timezone.utc)
+
+    ub.session.merge(kobo_reading_state)
+    ub.session_commit()
+
+    log.debug("Reading progress updated for book %d by user %s via external API", book_id, current_user.name)
+    return jsonify({
+        "result": "success",
+        "last_modified": kobo_reading_state.last_modified.strftime("%Y-%m-%dT%H:%M:%SZ")
+        if kobo_reading_state.last_modified else None,
+    })

--- a/cps/render_template.py
+++ b/cps/render_template.py
@@ -61,6 +61,10 @@ def get_sidebar_config(kwargs=None):
     sidebar.append({"glyph": "glyphicon-eye-open", "text": _('Read Books'), "link": 'web.books_list', "id": "read",
                     "visibility": constants.SIDEBAR_READ_AND_UNREAD, 'public': (not current_user.is_anonymous),
                     "page": "read", "show_text": _('Show Read and Unread'), "config_show": content})
+    sidebar.append({"glyph": "glyphicon-play", "text": _('Currently Reading'), "link": 'web.books_list',
+                    "id": "reading", "visibility": constants.SIDEBAR_READING,
+                    'public': (not current_user.is_anonymous),
+                    "page": "reading", "show_text": _('Show Currently Reading Books'), "config_show": content})
     sidebar.append(
         {"glyph": "glyphicon-eye-close", "text": _('Unread Books'), "link": 'web.books_list', "id": "unread",
          "visibility": constants.SIDEBAR_READ_AND_UNREAD, 'public': (not current_user.is_anonymous), "page": "unread",

--- a/cps/static/css/caliBlur.css
+++ b/cps/static/css/caliBlur.css
@@ -1600,6 +1600,11 @@ body > div.container-fluid > div.row-fluid > div.col-sm-10 > div.discover > form
     border-radius: 3px
 }
 
+.badge.progress-badge {
+    background-color: rgba(0, 120, 212, .75);
+    margin-left: 2px
+}
+
 #bookDetailsModal, .pagination, body > .container-fluid {
     min-width: 1px;
     min-height: 1px

--- a/cps/static/js/reading/epub.js
+++ b/cps/static/js/reading/epub.js
@@ -66,7 +66,76 @@ var reader;
         } catch (e) {}
     })();
 
-    reader.book.ready.then(() => {
+    /**
+     * Fetch reading progress from the server (Kobo sync API).
+     * Returns null on failure or if the URL is not configured.
+     * @returns {Promise<object|null>}
+     */
+    function fetchServerProgress() {
+        if (!calibre.readingProgressUrl) return Promise.resolve(null);
+        return fetch(calibre.readingProgressUrl, { credentials: "same-origin" })
+            .then(function (resp) {
+                return resp.ok ? resp.json() : null;
+            })
+            .catch(function () { return null; });
+    }
+
+    /**
+     * Push the current reading position to the server so it can be picked up
+     * by a Kobo device on the next sync.  The position is stored as a CFI with
+     * type "CFI" so the web reader can also restore it directly on the next load.
+     *
+     * Calls are debounced — the server is only hit once the reader has been
+     * idle for 3 seconds, avoiding a request on every single page turn.
+     *
+     * @param {string} cfi            - EPUB CFI of the current position
+     * @param {number} percentage     - Whole-book progress percentage 0–100
+     * @param {string} chapterHref    - Href of the current spine item (chapter)
+     * @param {number} inChapterPct   - Progress percentage within the current chapter 0–100
+     * @param {string} position_key   - localStorage key for storing the server timestamp
+     */
+    var _syncTimer = null;
+    function syncProgressToServer(cfi, percentage, chapterHref, inChapterPct, position_key) {
+        if (!calibre.readingProgressUrl) return;
+        clearTimeout(_syncTimer);
+        _syncTimer = setTimeout(function () {
+            fetch(calibre.readingProgressUrl, {
+                method: "PUT",
+                credentials: "same-origin",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    status: "Reading",
+                    progress_percent: percentage,
+                    content_source_progress_percent: inChapterPct,
+                    location: {
+                        // Store the CFI so browser-to-browser restore is exact.
+                        // Source (chapter href) lets the Kobo open the correct
+                        // chapter when it can't interpret the CFI value directly.
+                        value: cfi,
+                        type: "CFI",
+                        source: chapterHref
+                    }
+                })
+            })
+            .then(function (resp) { return resp.ok ? resp.json() : null; })
+            .then(function (data) {
+                // Record the server timestamp so we can compare freshness on the
+                // next load and avoid overwriting a more-recent Kobo position with
+                // a stale browser position.
+                if (data && data.last_modified) {
+                    try {
+                        var posStr = localStorage.getItem(position_key);
+                        var pos = posStr ? JSON.parse(posStr) : {};
+                        pos.serverTimestamp = new Date(data.last_modified).getTime();
+                        localStorage.setItem(position_key, JSON.stringify(pos));
+                    } catch (e) {}
+                }
+            })
+            .catch(function () {});
+        }, 3000);
+    }
+
+    reader.book.ready.then(async () => {
         let locations_key = reader.book.key() + "-locations";
         // Key to persist last-read position for this book in localStorage
         let position_key = "calibre.reader.position." + reader.book.key();
@@ -87,58 +156,139 @@ var reader;
                 );
             };
         }
-        make_locations
-            .then(() => {
-                // Try to restore last position (CFI) from localStorage if present
+
+        await make_locations;
+
+        // --- Position restoration (server vs. localStorage) ---
+        //
+        // We prefer whichever source has the most recent update.  The localStorage
+        // position object stores a `serverTimestamp` (ms since epoch) set after
+        // each successful server sync so the two clocks can be compared.
+        //
+        // Priority rules:
+        //   1. If the server has a position and its last_modified is newer than
+        //      the last time the browser synced with the server → use server position.
+        //   2. For server positions stored by this web reader (type "CFI"), navigate
+        //      directly to the CFI.
+        //   3. For server positions stored by a Kobo device (type "KoboSpan"), use
+        //      progress_percent to seek to the approximate position since the web
+        //      reader cannot interpret KoboSpan identifiers directly.
+        //   4. Fall back to the CFI stored in localStorage (pre-existing behaviour).
+
+        var serverProgress = await fetchServerProgress();
+        var navigated = false;
+
+        if (serverProgress && serverProgress.last_modified) {
+            var serverTime = new Date(serverProgress.last_modified).getTime();
+            var localServerTime = 0;
+            try {
+                var _savedPos = localStorage.getItem(position_key);
+                if (_savedPos) {
+                    var _p = JSON.parse(_savedPos);
+                    localServerTime = _p.serverTimestamp || 0;
+                }
+            } catch (e) {}
+
+            if (serverTime > localServerTime) {
+                // Server has a position that is newer than what the browser last
+                // synced — restore from server.
+                var loc = serverProgress.location;
                 try {
-                    var _savedPos = localStorage.getItem(position_key);
-                    if (_savedPos) {
-                        try {
-                            var _posObj = JSON.parse(_savedPos);
-                            if (_posObj && _posObj.cfi) {
-                                // Display the saved CFI location
-                                try {
-                                    reader.rendition.display(_posObj.cfi);
-                                } catch (e) {}
-                            }
-                        } catch (e) {}
+                    if (loc && loc.type === "CFI" && loc.value) {
+                        // Exact CFI from a previous browser session.
+                        reader.rendition.display(loc.value);
+                        navigated = true;
+                    } else if (serverProgress.progress_percent != null) {
+                        // KoboSpan position or percentage-only update from a Kobo
+                        // device: jump to the nearest CFI for that percentage.
+                        var targetCfi = reader.book.locations.cfiFromPercentage(
+                            serverProgress.progress_percent / 100
+                        );
+                        if (targetCfi) {
+                            reader.rendition.display(targetCfi);
+                            navigated = true;
+                        }
                     }
                 } catch (e) {}
+            }
+        }
 
-                reader.rendition.on("relocated", (location) => {
-                    let percentage = Math.round(location.end.percentage * 100);
-                    progressDiv.textContent = percentage + "%";
-
-                    // Pages based on generated EPUB locations (CFI positions)
-                    const cfi = location.start.cfi;
-                    const current =
-                        reader.book.locations.locationFromCfi(cfi) || 0; // 1-based index typically
-                    const total = reader.book.locations.length() || 0;
-
-                    if (total > 0) {
-                        pagesDiv.textContent = current + "/" + total;
-                        pagesDiv.style.visibility = "visible";
-                    } else {
-                        pagesDiv.textContent = "";
-                        pagesDiv.style.visibility = "hidden";
-                    }
-
-                    // Persist last position (CFI + percentage) to localStorage so reader can restore on next open
+        if (!navigated) {
+            // Fall back to localStorage position (pre-existing behaviour).
+            try {
+                var _savedPos = localStorage.getItem(position_key);
+                if (_savedPos) {
                     try {
-                        var posObj = {
-                            cfi: location.start.cfi,
-                            percentage: location.start.percentage,
-                        };
-                        localStorage.setItem(
-                            position_key,
-                            JSON.stringify(posObj)
-                        );
+                        var _posObj = JSON.parse(_savedPos);
+                        if (_posObj && _posObj.cfi) {
+                            try {
+                                reader.rendition.display(_posObj.cfi);
+                            } catch (e) {}
+                        }
                     } catch (e) {}
-                });
-                reader.rendition.reportLocation();
-                progressDiv.style.visibility = "visible";
-            })
-            .then(save_locations);
+                }
+            } catch (e) {}
+        }
+
+        reader.rendition.on("relocated", (location) => {
+            let percentage = Math.round(location.end.percentage * 100);
+            progressDiv.textContent = percentage + "%";
+
+            // Pages based on generated EPUB locations (CFI positions)
+            const cfi = location.start.cfi;
+            const current =
+                reader.book.locations.locationFromCfi(cfi) || 0; // 1-based index typically
+            const total = reader.book.locations.length() || 0;
+
+            if (total > 0) {
+                pagesDiv.textContent = current + "/" + total;
+                pagesDiv.style.visibility = "visible";
+            } else {
+                pagesDiv.textContent = "";
+                pagesDiv.style.visibility = "hidden";
+            }
+
+            // Persist last position (CFI + percentage) to localStorage so reader
+            // can restore on next open even without a server round-trip.
+            try {
+                var posStr = localStorage.getItem(position_key);
+                var posObj = posStr ? JSON.parse(posStr) : {};
+                posObj.cfi = location.start.cfi;
+                posObj.percentage = location.start.percentage;
+                localStorage.setItem(position_key, JSON.stringify(posObj));
+            } catch (e) {}
+
+            // Sync to server (debounced) so the position is visible to the Kobo
+            // device on its next sync.
+            //
+            // chapterHref: spine item href — lets the Kobo open the right chapter.
+            // inChapterPct: position within the chapter — lets the Kobo seek within it.
+            var chapterHref = (location.start && location.start.href) || "";
+            if (!chapterHref) {
+                try {
+                    var _sec = reader.book.spine.get(location.start.cfi);
+                    chapterHref = _sec ? (_sec.href || "") : "";
+                } catch (e) {}
+            }
+            var inChapterPct = Math.round(location.start.percentage * 100); // fallback
+            try {
+                var disp = location.start.displayed;
+                if (disp && disp.total > 0) {
+                    inChapterPct = Math.round((disp.page / disp.total) * 100);
+                }
+            } catch (e) {}
+            syncProgressToServer(
+                location.start.cfi,
+                Math.round(location.start.percentage * 100),
+                chapterHref,
+                inChapterPct,
+                position_key
+            );
+        });
+        reader.rendition.reportLocation();
+        progressDiv.style.visibility = "visible";
+
+        save_locations();
     });
 
     /**

--- a/cps/static/js/reading/epub.js
+++ b/cps/static/js/reading/epub.js
@@ -66,11 +66,6 @@ var reader;
         } catch (e) {}
     })();
 
-    /**
-     * Fetch reading progress from the server (Kobo sync API).
-     * Returns null on failure or if the URL is not configured.
-     * @returns {Promise<object|null>}
-     */
     function fetchServerProgress() {
         if (!calibre.readingProgressUrl) return Promise.resolve(null);
         return fetch(calibre.readingProgressUrl, { credentials: "same-origin" })
@@ -80,22 +75,62 @@ var reader;
             .catch(function () { return null; });
     }
 
-    /**
-     * Push the current reading position to the server so it can be picked up
-     * by a Kobo device on the next sync.  The position is stored as a CFI with
-     * type "CFI" so the web reader can also restore it directly on the next load.
-     *
-     * Calls are debounced — the server is only hit once the reader has been
-     * idle for 3 seconds, avoiding a request on every single page turn.
-     *
-     * @param {string} cfi            - EPUB CFI of the current position
-     * @param {number} percentage     - Whole-book progress percentage 0–100
-     * @param {string} chapterHref    - Href of the current spine item (chapter)
-     * @param {number} inChapterPct   - Progress percentage within the current chapter 0–100
-     * @param {string} position_key   - localStorage key for storing the server timestamp
-     */
+    // Extract the nearest Kobo span ID (e.g. "kobo.2.1") from a CFI string.
+    // EPUB.js encodes element IDs in CFI step assertions, so we can usually parse
+    // the ID directly from the CFI without touching the DOM.  Falls back to DOM
+    // traversal for cases where no kobo step assertion is present.
+    // Returns a Promise resolving to the span ID, or null for plain EPUBs.
+    function extractKoboSpanFromCfi(cfi) {
+        try {
+            var stepPattern = /\[([^\]]+)\]/g;
+            var match, lastKoboId = null;
+            var localPath = cfi.indexOf("!") !== -1 ? cfi.slice(cfi.indexOf("!")) : cfi;
+            while ((match = stepPattern.exec(localPath)) !== null) {
+                if (match[1].startsWith("kobo.")) lastKoboId = match[1];
+            }
+            if (lastKoboId) return Promise.resolve(lastKoboId);
+        } catch (e) {}
+
+        try {
+            var rangeResult = reader.rendition.getRange(cfi);
+            var p = (rangeResult && typeof rangeResult.then === "function")
+                ? rangeResult
+                : Promise.resolve(rangeResult);
+            return p.then(function (range) {
+                if (!range) return null;
+                var node = range.startContainer;
+                var el = (node.nodeType === Node.TEXT_NODE) ? node.parentElement : node;
+                while (el) {
+                    if (el.id && el.id.startsWith("kobo.")) return el.id;
+                    el = el.parentElement;
+                }
+                var doc = node.ownerDocument;
+                if (!doc) return null;
+                var walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_ELEMENT, {
+                    acceptNode: function (n) {
+                        return (n.id && n.id.startsWith("kobo."))
+                            ? NodeFilter.FILTER_ACCEPT
+                            : NodeFilter.FILTER_SKIP;
+                    }
+                }, false);
+                var startEl = (node.nodeType === Node.TEXT_NODE) ? node.parentElement : node;
+                var lastSpan = null, n;
+                while ((n = walker.nextNode())) {
+                    if (startEl.compareDocumentPosition(n) & Node.DOCUMENT_POSITION_FOLLOWING) break;
+                    lastSpan = n;
+                }
+                return lastSpan ? lastSpan.id : null;
+            }).catch(function () { return null; });
+        } catch (e) {
+            return Promise.resolve(null);
+        }
+    }
+
+    // Debounced sync of the current position to the server.
+    // For KEPUBs a kobo span ID is sent (type "KoboSpan"); for plain EPUBs a CFI
+    // string is sent (type "CFI").  Fires 3 s after the last page turn.
     var _syncTimer = null;
-    function syncProgressToServer(cfi, percentage, chapterHref, inChapterPct, position_key) {
+    function syncProgressToServer(cfi, percentage, chapterHref, inChapterPct, position_key, koboSpanId) {
         if (!calibre.readingProgressUrl) return;
         clearTimeout(_syncTimer);
         _syncTimer = setTimeout(function () {
@@ -107,10 +142,11 @@ var reader;
                     status: "Reading",
                     progress_percent: percentage,
                     content_source_progress_percent: inChapterPct,
-                    location: {
-                        // Store the CFI so browser-to-browser restore is exact.
-                        // Source (chapter href) lets the Kobo open the correct
-                        // chapter when it can't interpret the CFI value directly.
+                    location: koboSpanId ? {
+                        value: "#" + koboSpanId,
+                        type: "KoboSpan",
+                        source: chapterHref
+                    } : {
                         value: cfi,
                         type: "CFI",
                         source: chapterHref
@@ -119,9 +155,6 @@ var reader;
             })
             .then(function (resp) { return resp.ok ? resp.json() : null; })
             .then(function (data) {
-                // Record the server timestamp so we can compare freshness on the
-                // next load and avoid overwriting a more-recent Kobo position with
-                // a stale browser position.
                 if (data && data.last_modified) {
                     try {
                         var posStr = localStorage.getItem(position_key);
@@ -137,7 +170,6 @@ var reader;
 
     reader.book.ready.then(async () => {
         let locations_key = reader.book.key() + "-locations";
-        // Key to persist last-read position for this book in localStorage
         let position_key = "calibre.reader.position." + reader.book.key();
         let stored_locations = localStorage.getItem(locations_key);
         let make_locations, save_locations;
@@ -159,22 +191,6 @@ var reader;
 
         await make_locations;
 
-        // --- Position restoration (server vs. localStorage) ---
-        //
-        // We prefer whichever source has the most recent update.  The localStorage
-        // position object stores a `serverTimestamp` (ms since epoch) set after
-        // each successful server sync so the two clocks can be compared.
-        //
-        // Priority rules:
-        //   1. If the server has a position and its last_modified is newer than
-        //      the last time the browser synced with the server → use server position.
-        //   2. For server positions stored by this web reader (type "CFI"), navigate
-        //      directly to the CFI.
-        //   3. For server positions stored by a Kobo device (type "KoboSpan"), use
-        //      progress_percent to seek to the approximate position since the web
-        //      reader cannot interpret KoboSpan identifiers directly.
-        //   4. Fall back to the CFI stored in localStorage (pre-existing behaviour).
-
         var serverProgress = await fetchServerProgress();
         var navigated = false;
 
@@ -182,25 +198,41 @@ var reader;
             var serverTime = new Date(serverProgress.last_modified).getTime();
             var localServerTime = 0;
             try {
-                var _savedPos = localStorage.getItem(position_key);
-                if (_savedPos) {
-                    var _p = JSON.parse(_savedPos);
-                    localServerTime = _p.serverTimestamp || 0;
+                var savedPos = localStorage.getItem(position_key);
+                if (savedPos) {
+                    var savedPosObj = JSON.parse(savedPos);
+                    localServerTime = savedPosObj.serverTimestamp || 0;
                 }
             } catch (e) {}
 
+            // Use the server position if it is newer than the last browser sync
             if (serverTime > localServerTime) {
-                // Server has a position that is newer than what the browser last
-                // synced — restore from server.
                 var loc = serverProgress.location;
                 try {
                     if (loc && loc.type === "CFI" && loc.value) {
-                        // Exact CFI from a previous browser session.
                         reader.rendition.display(loc.value);
                         navigated = true;
+                    } else if (loc && loc.type === "KoboSpan" && loc.value && loc.source) {
+                        // Extract the fragment ID from the span value, which may be a
+                        // bare "#kobo.N.M" (stored by the browser) or a full Kobo device
+                        // URI ending in "#kobo.N.M"
+                        var hashIdx = loc.value.lastIndexOf("#");
+                        var fragmentId = hashIdx !== -1 ? loc.value.slice(hashIdx + 1) : null;
+                        var spanSource = loc.source;
+                        if (!spanSource && hashIdx !== -1) {
+                            var excl = loc.value.indexOf("!");
+                            if (excl !== -1) spanSource = loc.value.slice(excl + 1, hashIdx);
+                        }
+                        if (fragmentId && spanSource) {
+                            reader.rendition.display(spanSource + "#" + fragmentId);
+                            navigated = true;
+                        } else if (serverProgress.progress_percent != null) {
+                            var targetCfi = reader.book.locations.cfiFromPercentage(
+                                serverProgress.progress_percent / 100
+                            );
+                            if (targetCfi) { reader.rendition.display(targetCfi); navigated = true; }
+                        }
                     } else if (serverProgress.progress_percent != null) {
-                        // KoboSpan position or percentage-only update from a Kobo
-                        // device: jump to the nearest CFI for that percentage.
                         var targetCfi = reader.book.locations.cfiFromPercentage(
                             serverProgress.progress_percent / 100
                         );
@@ -214,15 +246,15 @@ var reader;
         }
 
         if (!navigated) {
-            // Fall back to localStorage position (pre-existing behaviour).
+            // Fall back to localStorage position
             try {
-                var _savedPos = localStorage.getItem(position_key);
-                if (_savedPos) {
+                var localPos = localStorage.getItem(position_key);
+                if (localPos) {
                     try {
-                        var _posObj = JSON.parse(_savedPos);
-                        if (_posObj && _posObj.cfi) {
+                        var localPosObj = JSON.parse(localPos);
+                        if (localPosObj && localPosObj.cfi) {
                             try {
-                                reader.rendition.display(_posObj.cfi);
+                                reader.rendition.display(localPosObj.cfi);
                             } catch (e) {}
                         }
                     } catch (e) {}
@@ -248,8 +280,7 @@ var reader;
                 pagesDiv.style.visibility = "hidden";
             }
 
-            // Persist last position (CFI + percentage) to localStorage so reader
-            // can restore on next open even without a server round-trip.
+            // Persist last position to localStorage
             try {
                 var posStr = localStorage.getItem(position_key);
                 var posObj = posStr ? JSON.parse(posStr) : {};
@@ -258,11 +289,6 @@ var reader;
                 localStorage.setItem(position_key, JSON.stringify(posObj));
             } catch (e) {}
 
-            // Sync to server (debounced) so the position is visible to the Kobo
-            // device on its next sync.
-            //
-            // chapterHref: spine item href — lets the Kobo open the right chapter.
-            // inChapterPct: position within the chapter — lets the Kobo seek within it.
             var chapterHref = (location.start && location.start.href) || "";
             if (!chapterHref) {
                 try {
@@ -277,13 +303,16 @@ var reader;
                     inChapterPct = Math.round((disp.page / disp.total) * 100);
                 }
             } catch (e) {}
-            syncProgressToServer(
-                location.start.cfi,
-                Math.round(location.start.percentage * 100),
-                chapterHref,
-                inChapterPct,
-                position_key
-            );
+            extractKoboSpanFromCfi(location.start.cfi).then(function (koboSpanId) {
+                syncProgressToServer(
+                    location.start.cfi,
+                    Math.round(location.start.percentage * 100),
+                    chapterHref,
+                    inChapterPct,
+                    position_key,
+                    koboSpanId
+                );
+            });
         });
         reader.rendition.reportLocation();
         progressDiv.style.visibility = "visible";

--- a/cps/templates/index.html
+++ b/cps/templates/index.html
@@ -95,6 +95,7 @@
             <span class="img" title="{{ entry.Books.title }}">
               {{ image.book_cover(entry.Books) }}
               {% if entry[2] == True %}<span class="badge read glyphicon glyphicon-ok"></span>{% endif %}
+              {% if progress_map is defined and entry.Books.id in progress_map %}<span class="badge progress-badge">{{ progress_map[entry.Books.id]|int }}%</span>{% endif %}
             </span>
           </a>
       </div>

--- a/cps/templates/read.html
+++ b/cps/templates/read.html
@@ -149,7 +149,8 @@
             bookmarkUrl: "{{ url_for('web.set_bookmark', book_id=bookid, book_format=book_format) }}",
             bookUrl: "{{ url_for('web.serve_book', book_id=bookid, book_format=book_format, anyname='file.epub') }}",
             bookmark: "{{ bookmark.bookmark_key if bookmark != None }}",
-            useBookmarks: "{{ current_user.is_authenticated | tojson }}"
+            useBookmarks: "{{ current_user.is_authenticated | tojson }}",
+            readingProgressUrl: {% if current_user.is_authenticated %}"{{ url_for('reading_progress.get_reading_progress', book_id=bookid) }}"{% else %}null{% endif %}
         };
 
       // load custom theme color from localStorage (if any)

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -602,7 +602,6 @@ def migrate_user_session_table(engine, _session):
 
 
 def migrate_kobo_bookmark_table(engine, _session):
-    """Add columns to kobo_bookmark that may be absent in databases predating their introduction."""
     try:
         _session.query(exists().where(KoboBookmark.content_source_progress_percent)).scalar()
         _session.commit()

--- a/cps/ub.py
+++ b/cps/ub.py
@@ -601,6 +601,28 @@ def migrate_user_session_table(engine, _session):
             trans.commit()
 
 
+def migrate_kobo_bookmark_table(engine, _session):
+    """Add columns to kobo_bookmark that may be absent in databases predating their introduction."""
+    try:
+        _session.query(exists().where(KoboBookmark.content_source_progress_percent)).scalar()
+        _session.commit()
+    except exc.OperationalError:  # Table exists but is missing the newer columns
+        with engine.connect() as conn:
+            trans = conn.begin()
+            for col_def in (
+                "ALTER TABLE kobo_bookmark ADD COLUMN 'location_source' String",
+                "ALTER TABLE kobo_bookmark ADD COLUMN 'location_type' String",
+                "ALTER TABLE kobo_bookmark ADD COLUMN 'location_value' String",
+                "ALTER TABLE kobo_bookmark ADD COLUMN 'progress_percent' Float",
+                "ALTER TABLE kobo_bookmark ADD COLUMN 'content_source_progress_percent' Float",
+            ):
+                try:
+                    conn.execute(text(col_def))
+                except exc.OperationalError:
+                    pass  # Column already exists; safe to ignore
+            trans.commit()
+
+
 # Migrate database to current version, has to be updated after every database change. Currently, migration from
 # maybe 4/5 versions back to current should work.
 # Migration is done by checking if relevant columns are existing, and then adding rows with SQL commands
@@ -609,6 +631,7 @@ def migrate_Database(_session):
     add_missing_tables(engine, _session)
     migrate_registration_table(engine, _session)
     migrate_user_session_table(engine, _session)
+    migrate_kobo_bookmark_table(engine, _session)
 
 
 def clean_database(_session):

--- a/cps/web.py
+++ b/cps/web.py
@@ -382,6 +382,8 @@ def render_books_list(data, sort_param, book_id, page):
         return render_read_books(page, False, order=order)
     elif data == "read":
         return render_read_books(page, True, order=order)
+    elif data == "reading":
+        return render_currently_reading(page, order)
     elif data == "hot":
         return render_hot_books(page, order)
     elif data == "download":
@@ -775,6 +777,44 @@ def render_read_books(page, are_read, as_xml=False, order=None):
                                      title=name, page=page_name, order=order[1])
 
 
+def render_currently_reading(page, order=None):
+    sort_param = order[0] if order else []
+    db_filter = and_(ub.ReadBook.user_id == int(current_user.id),
+                     ub.ReadBook.read_status == ub.ReadBook.STATUS_IN_PROGRESS)
+
+    entries, random, pagination = calibre_db.fill_indexpage(page, 0,
+                                                            db.Books,
+                                                            db_filter,
+                                                            sort_param,
+                                                            True, config.config_read_column,
+                                                            db.books_series_link,
+                                                            db.Books.id == db.books_series_link.c.book,
+                                                            db.Series)
+
+    book_ids = [entry.Books.id for entry in entries]
+    progress_map = {}
+    if book_ids:
+        try:
+            rows = (ub.session.query(ub.KoboReadingState.book_id,
+                                     ub.KoboBookmark.progress_percent)
+                    .join(ub.KoboBookmark,
+                          ub.KoboBookmark.kobo_reading_state_id == ub.KoboReadingState.id,
+                          isouter=True)
+                    .filter(ub.KoboReadingState.user_id == int(current_user.id),
+                            ub.KoboReadingState.book_id.in_(book_ids))
+                    .all())
+            for book_id, pct in rows:
+                if pct is not None:
+                    progress_map[book_id] = pct
+        except Exception:
+            pass
+
+    name = _('Currently Reading') + ' (' + str(pagination.total_count) + ')'
+    return render_title_template('index.html', random=random, entries=entries, pagination=pagination,
+                                 title=name, page="reading", order=order[1] if order else None,
+                                 progress_map=progress_map)
+
+
 def render_archived_books(page, sort_param):
     order = sort_param[0] or []
     archived_books = (ub.session.query(ub.ArchivedBook)
@@ -814,8 +854,8 @@ def books_list(data, sort_param, book_id, page):
     return render_books_list(data, sort_param, book_id, page)
 
 # Limit number of routes to avoid redirects
-data =["rated", "discover", "unread", "read", "hot", "download", "author", "publisher", "series", "ratings", "formats",
-       "category", "language", "archived", "search", "advsearch", "newest"]
+data =["rated", "discover", "unread", "read", "reading", "hot", "download", "author", "publisher", "series", "ratings",
+       "formats", "category", "language", "archived", "search", "advsearch", "newest"]
 for d in data:
     web.add_url_rule('/{}/<sort_param>'.format(d), view_func=books_list, defaults={'page': 1, 'book_id': 1, "data": d})
     web.add_url_rule('/{}/<sort_param>/'.format(d), view_func=books_list, defaults={'page': 1, 'book_id': 1, "data": d})


### PR DESCRIPTION
## Problem

There is no way to resume reading on another device or in the browser from where a Kobo device left off.

 ## Solution

 This PR stores the Kobo reading state and wires it into the built-in web reader so reading position is shared between a Kobo device and the browser.

1. **Database** — kobo_bookmark gains five new columns (location_value, location_type, location_source, progress_percent, content_source_progress_percent) with a migration that adds them to existing databases.

2. **Kobo sync** — HandleStateRequest now persists the full CurrentBookmark from the device, including the KoboSpan position string and both progress percentages. get_current_bookmark_response returns this data back to the device on subsequent syncs.

3. **REST API** — Two new endpoints under /api/:
  - GET `/api/reading-progress/<book_id>` — returns stored progress for the authenticated user
  - PUT `/api/reading-progress/<book_id>` — accepts a position update; the Kobo device picks it up on its next sync

4. **Web reader sync** — The built-in EPUB reader gains bidirectional position sync:
  - On load, it fetches the server position and navigates to it. For KEPUBs, it navigates directly to the KoboSpan element by ID anchor; for plain EPUBs it navigates by CFI.
  - On each page turn (debounced 3 s), it pushes the current position to the server. For KEPUBs, the KoboSpan ID is extracted from the CFI's step assertion rather than touching the DOM.
  - A serverTimestamp stored in localStorage prevents a stale browser position from overwriting a more recent Kobo position.

5. **Currently Reading view** — A new sidebar entry shows books with STATUS_IN_PROGRESS, with progress percentage badges on covers sourced from KoboReadingState.


## Notes
The sync works pretty well when the latest position is a new chapter. It's not perfect when the sync is happening in the middle of a chapter due to the whole KoboSpan / CFI translation.