### PR TITLE
Fix a dumb type condition in gdrive.py

### DIFF
--- a/cps/gdrive.py
+++ b/cps/gdrive.py
@@ -140,7 +140,7 @@ try:
             if response:
                 dbpath = os.path.join(config.config_calibre_dir, "metadata.db").encode()
                 if not response['deleted'] and response['file']['title'] == 'metadata.db' \
-                  and response['file']['md5Checksum'] != hashlib.md5(dbpath):  # nosec
+                  and response['file']['md5Checksum'] != hashlib.md5(dbpath).hexdigest():  # nosec
                     tmp_dir = get_temp_dir()
 
                     log.info('Database file updated')


### PR DESCRIPTION
hashlib.md5(dbpath) returns a hash object, not a hex string. Comparing a string (md5Checksum) to a hash object with != always returns True. This means the DB-replacement code path is always entered, allowing an attacker who sends a forged notification (with the known static token) to trigger an arbitrary metadata.db download from GDrive, replacing the live database.