### PR TITLE
Fix access bypass on /show/ (serve_book)

### DIFF
--- a/cps/web.py
+++ b/cps/web.py
@@ -1195,7 +1195,9 @@ def get_robots():
 @viewer_required
 def serve_book(book_id, book_format, anyname):
     book_format = book_format.split(".")[0]
-    book = calibre_db.get_book(book_id)
+    book = calibre_db.get_filtered_book(book_id)
+    if not book:
+        return "File not in Database"
     data = calibre_db.get_book_format(book_id, book_format.upper())
     if not data:
         return "File not in Database"


### PR DESCRIPTION
The `serve_book` function uses `get_book()` which performs no access filtering: it simply fetches by ID. Compare with `read_book` at web.py:1562 which correctly uses `get_filtered_book()`. The `common_filters()` function enforces per-user tag restrictions, language restrictions, and hidden-book rules.