### PR TITLE
Use a sane permission for the encryption key file

### DIFF
--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -583,6 +583,7 @@ def get_encryption_key(key_path):
         try:
             with open(key_file, "wb") as f:
                 f.write(key)
+            os.chmod(key_file, 0o600)
         except PermissionError as e:
             error = e
     return key, error


### PR DESCRIPTION
The typical Linux umask of 0022, meaning the encrypted file is world-readable (-rw-r--r--). Any OS-level user on the same system can read the key and decrypt the encrypted credentials from app.db.