### PR TITLE
Prevent SQLI via dbpath

### DIFF
--- a/cps/db.py
+++ b/cps/db.py
@@ -640,8 +640,8 @@ class CalibreDB:
                                          connect_args={'check_same_thread': False},
                                          poolclass=StaticPool)
             with check_engine.begin() as connection:
-                connection.execute(text("attach database '{}' as calibre;".format(dbpath)))
-                connection.execute(text("attach database '{}' as app_settings;".format(app_db_path)))
+                connection.execute(text("attach database '{}' as calibre;".format(dbpath.replace("'", "''"))))
+                connection.execute(text("attach database '{}' as app_settings;".format(app_db_path.replace("'", "''"))))
                 local_session = scoped_session(sessionmaker())
                 local_session.configure(bind=connection)
                 database_uuid = local_session().query(Library_Id).one_or_none()
@@ -694,8 +694,8 @@ class CalibreDB:
                                        poolclass=StaticPool)
             with engine.begin() as connection:
                 connection.execute(text('PRAGMA cache_size = 10000;'))
-                connection.execute(text("attach database '{}' as calibre;".format(dbpath)))
-                connection.execute(text("attach database '{}' as app_settings;".format(app_db_path)))
+                connection.execute(text("attach database '{}' as calibre;".format(dbpath.replace("'", "''"))))
+                connection.execute(text("attach database '{}' as app_settings;".format(app_db_path.replace("'", "''"))))
 
             conn = engine.connect()
             # conn.text_factory = lambda b: b.decode(errors = 'ignore') possible fix for #1302


### PR DESCRIPTION
This is reachable only by the admin users, but is still a straightforward RCE vector, if only via SQLite's `ATTACH DATABASE` trick