### PR TITLE
Use 128 bits of entropy instead of only 32 in csp/ub.py

### DIFF
--- a/cps/ub.py
+++ b/cps/ub.py
@@ -537,7 +537,7 @@ class RemoteAuthToken(Base):
 
     def __init__(self):
         super().__init__()
-        self.auth_token = (hexlify(os.urandom(4))).decode('utf-8')
+        self.auth_token = (hexlify(os.urandom(16))).decode('utf-8')
         self.expiration = datetime.now() + timedelta(minutes=10)  # 10 min from now
 
     def __repr__(self):


### PR DESCRIPTION
Remote login tokens are generated from only 4 bytes of randomness (32 bits = ~4 billion possibilities, 8 hex characters). The /ajax/verify_token endpoint at remotelogin.py:98 has no rate limiting. The token is valid for 10 minutes.

At even modest request rates (10,000 req/sec), an attacker can test ~6 million tokens during the 10-minute window , which isn't enough to exhaust the full space, sure, but combined with multiple concurrent login sessions (each generating a new token), or if the attacker can trigger the victim to initiate remote login, the attack becomes more feasible. Compare with the Kobo auth token which uses urandom(16) (128 bits).