### PR TITLE
Properly serve data on serve_book

### DIFF
--- a/cps/web.py
+++ b/cps/web.py
@@ -1237,6 +1237,9 @@ def serve_book(book_id, book_format, anyname):
         # enable byte range read of pdf
         response = make_response(
             send_from_directory(os.path.join(config.get_book_path(), book.path), data.name + "." + book_format))
+        response.headers['Content-Disposition'] = 'inline'
+        response.headers['X-Content-Type-Options'] = 'nosniff'
+        response.headers['Content-Security-Policy'] = "script-src 'none'; object-src 'none'"
         if not range_header:
             response.headers['Accept-Ranges'] = 'bytes'
         return response


### PR DESCRIPTION
send_from_directory sets Content-Type based on the file extension. The app registers application/xhtml+xml for .xhtml at __init__.py. If xhtml, html, or svg are in `config_upload_formats`, uploaded files are served inline (no Content-Disposition: attachment) with an executable content type, enabling stored XSS in the Calibre-Web origin. Even with default formats, EPUB files contain XHTML that's served through the reader with unsafe-inline CSP.