### PR TITLE
Escape comment columns names

### DIFF
--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -232,7 +232,7 @@
                                         {% elif c.datatype == 'datetime' %}
                                             {{ column.value|formatdate }}
                                         {% elif c.datatype == 'comments' %}
-                                            {{ column.value|safe }}
+                                            {{ column.value|clean_string|safe }}
                                         {% elif c.datatype == 'series' %}
                                             {{ '%s [%s]' % (column.value, column.extra|formatfloat(2)) }}
                                         {% elif c.datatype == 'text' %}

--- a/cps/templates/feed.xml
+++ b/cps/templates/feed.xml
@@ -94,7 +94,7 @@
                             {% elif c.datatype == 'datetime' %}
                                 {{ column.value|formatdate }}
                             {% elif c.datatype == 'comments' %}
-                                {{ column.value|safe }}
+                                {{ column.value|clean_string|safe }}
                             {% elif c.datatype == 'series' %}
                                 {{ '%s [%s]' % (column.value, column.extra|formatfloat(2)) }}
                             {% elif c.datatype == 'text' %}

--- a/cps/templates/listenmp3.html
+++ b/cps/templates/listenmp3.html
@@ -134,7 +134,7 @@
                 {% elif c.datatype == 'datetime' %}
                   {{ column.value|formatdate }}
                 {% elif c.datatype == 'comments' %}
-                  {{column.value|safe}}
+                  {{column.value|clean_string|safe}}
                 {% elif c.datatype == 'series' %}
                   {{ '%s [%s]' % (column.value, column.extra|formatfloat(2)) }}
                 {% elif c.datatype == 'text' %}


### PR DESCRIPTION
Custom columns of type comments are rendered with `|safe` (disabling Jinja2 auto-escaping) and no `clean_string` sanitization. Compare with regular book comments which correctly use `{{ entry.comments[0].text|clean_string|safe }}`.

Any user with edit permissions can set a custom comment column to `<script>alert(document.cookie)</script>` and it will execute for every user who views the book detail page or the OPDS feed. This is stored XSS with no authentication barrier beyond edit permission.