### PR TITLE
Correctly filter results kobo API

### DIFF
--- a/cps/db.py
+++ b/cps/db.py
@@ -746,7 +746,8 @@ class CalibreDB:
                 .filter(self.common_filters(allow_show_archived)).first())
 
     def get_book_by_uuid(self, book_uuid):
-        return self.session.query(Books).filter(Books.uuid == book_uuid).first()
+        return self.session.query(Books).filter(Books.uuid == book_uuid). \
+            filter(self.common_filters()).first()
 
     def get_book_format(self, book_id, file_format):
         return self.session.query(Data).filter(Data.book == book_id).filter(Data.format == file_format).first()


### PR DESCRIPTION
Multiple Kobo API endpoints use calibre_db.get_book_by_uuid() at db.py:748-749, which performs a raw unfiltered query, meaning that common_filters() isn't applied, so tag-based ACLs, language restrictions, and archived-book filtering are all bypassed.