### PR TITLE
Properly handle deactivated users

### DIFF
--- a/cps/cw_login/utils.py
+++ b/cps/cw_login/utils.py
@@ -374,6 +374,8 @@ def _get_user():
     if has_request_context():
         if "flask_httpauth_user" in g:
             if g.flask_httpauth_user is not None:
+                if not g.flask_httpauth_user.is_active:
+                    return None
                 return g.flask_httpauth_user
         if "_login_user" not in g:
             current_app.login_manager._load_user()


### PR DESCRIPTION
When g.flask_httpauth_user is set (by reverse proxy or HTTP basic auth), it is returned as current_user with no is_active check. Disabled/deactivated users can still access the application.