### PR TITLE
Add sort by date added to Series list page

### DIFF
--- a/cps/static/js/filter_grid.js
+++ b/cps/static/js/filter_grid.js
@@ -21,7 +21,9 @@ var $list = $("#list").isotope({
     itemSelector: ".book",
     layoutMode: "fitRows",
     getSortData: {
-        title: ".title"
+        title: ".title",
+        name: "[data-name]",
+        newest: "[data-newest]"
     },
 });
 
@@ -31,6 +33,7 @@ $("#desc").click(function() {
         return;
     }
     $("#asc").removeClass("active");
+    $("#new").removeClass("active");
     $("#desc").addClass("active");
 
     var page = $(this).data("id");
@@ -41,10 +44,9 @@ $("#desc").click(function() {
         url: getPath() + "/ajax/view",
         data: "{\"" + page + "\": {\"dir\": \"desc\"}}",
     });
-    // invert sorting order to make already inverted start order working
     $list.isotope({
         sortBy: "name",
-        sortAscending: !$list.data('isotope').options.sortAscending
+        sortAscending: false
     });
     direction = 0;
 });
@@ -54,6 +56,7 @@ $("#asc").click(function() {
         return;
     }
     $("#desc").removeClass("active");
+    $("#new").removeClass("active");
     $("#asc").addClass("active");
 
     var page = $(this).data("id");
@@ -66,9 +69,32 @@ $("#asc").click(function() {
     });
     $list.isotope({
         sortBy: "name",
-        sortAscending: !$list.data('isotope').options.sortAscending
+        sortAscending: true
     });
     direction = 1;
+});
+
+$("#new").click(function() {
+    if (direction === 2) {
+        return;
+    }
+    $("#asc").removeClass("active");
+    $("#desc").removeClass("active");
+    $("#new").addClass("active");
+
+    var page = $(this).data("id");
+    $.ajax({
+        method:"post",
+        contentType: "application/json; charset=utf-8",
+        dataType: "json",
+        url: getPath() + "/ajax/view",
+        data: "{\"" + page + "\": {\"dir\": \"new\"}}",
+    });
+    $list.isotope({
+        sortBy: "newest",
+        sortAscending: false
+    });
+    direction = 2;
 });
 
 $("#all").click(function() {

--- a/cps/static/js/filter_list.js
+++ b/cps/static/js/filter_list.js
@@ -69,7 +69,9 @@ $("#desc").click(function() {
     if (direction === 0) {
         return;
     }
+    var wasNew = direction === 2;
     $("#asc").removeClass("active");
+    $("#new").removeClass("active");
     $("#desc").addClass("active");
 
     var page = $(this).data("id");
@@ -79,7 +81,11 @@ $("#desc").click(function() {
         dataType: "json",
         url: getPath() + "/ajax/view",
         data: "{\"" + page + "\": {\"dir\": \"desc\"}}",
+        complete: function() {
+            if (wasNew) { window.location.reload(); }
+        }
     });
+    if (wasNew) { direction = 0; return; }
     var index = 0;
     var list = $("#list");
     var second = $("#second");
@@ -119,7 +125,9 @@ $("#asc").click(function() {
     if (direction === 1) {
         return;
     }
+    var wasNew = direction === 2;
     $("#desc").removeClass("active");
+    $("#new").removeClass("active");
     $("#asc").addClass("active");
 
     var page = $(this).data("id");
@@ -129,7 +137,11 @@ $("#asc").click(function() {
         dataType: "json",
         url: getPath() + "/ajax/view",
         data: "{\"" + page + "\": {\"dir\": \"asc\"}}",
+        complete: function() {
+            if (wasNew) { window.location.reload(); }
+        }
     });
+    if (wasNew) { direction = 1; return; }
     var index = 0;
     var list = $("#list");
     var second = $("#second");
@@ -162,6 +174,28 @@ $("#asc").click(function() {
         list.append(reversed.slice(0, elementLength));
     }
     direction = 1;
+});
+
+$("#new").click(function() {
+    if (direction === 2) {
+        return;
+    }
+    $("#asc").removeClass("active");
+    $("#desc").removeClass("active");
+    $("#new").addClass("active");
+
+    var page = $(this).data("id");
+    $.ajax({
+        method:"post",
+        contentType: "application/json; charset=utf-8",
+        dataType: "json",
+        url: getPath() + "/ajax/view",
+        data: "{\"" + page + "\": {\"dir\": \"new\"}}",
+        complete: function() {
+            window.location.reload();
+        }
+    });
+    direction = 2;
 });
 
 $("#all").click(function() {

--- a/cps/templates/grid.html
+++ b/cps/templates/grid.html
@@ -10,6 +10,9 @@
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <div id="asc" data-id="series" data-order="{{ order }}" class="btn btn-primary{% if order == 1 %} active{% endif%}"><span class="glyphicon glyphicon-sort-by-alphabet"></span></div>
       <div id="desc" data-id="series" class="btn btn-primary{% if order == 0 %} active{% endif%}"><span class="glyphicon glyphicon-sort-by-alphabet-alt"></span></div>
+      {% if data == 'series' %}
+      <div id="new" data-id="series" data-toggle="tooltip" title="{{_('Sort according to date added, newest first')}}" class="btn btn-primary{% if order == 2 %} active{% endif%}"><span class="glyphicon glyphicon-calendar"></span><span class="glyphicon glyphicon-sort-by-order"></span></div>
+      {% endif %}
       {% if charlist|length %}
       <div id="all" class="active btn btn-primary {% if charlist|length > 9 %}hidden-sm{% endif %}">{{_('All')}}</div>
       {% endif %}
@@ -24,7 +27,7 @@
     {% if entries[0] %}
         <div id="list" class="row display-flex">
           {% for entry in entries %}
-              <div class="col-sm-3 col-lg-2 col-xs-6 book sortable" {% if entry[0].sort %}data-name="{{entry[0].series[0].name}}"{% endif %} data-id="{% if entry[0].series[0].name %}{{entry[0].series[0].name}}{% endif %}">
+              <div class="col-sm-3 col-lg-2 col-xs-6 book sortable" {% if entry[0].sort %}data-name="{{entry[0].series[0].name}}"{% endif %} data-id="{% if entry[0].series[0].name %}{{entry[0].series[0].name}}{% endif %}" data-newest="{{entry.newest.isoformat() if entry.newest else ''}}">
                   <div class="cover">
                       <a href="{{url_for('web.books_list', data=data, sort_param='stored', book_id=entry[0].series[0].id )}}">
                           <span class="img" title="{{entry[0].series[0].name}}">

--- a/cps/templates/list.html
+++ b/cps/templates/list.html
@@ -9,6 +9,9 @@
       {% endif %}
       <div id="asc" data-order="{{ order }}" data-id="{{ data }}" class="btn btn-primary {% if order == 1 %} active{% endif%}"><span class="glyphicon glyphicon-sort-by-alphabet"></span></div>
       <div id="desc" data-id="{{ data }}" class="btn btn-primary{% if order == 0 %} active{% endif%}"><span class="glyphicon glyphicon-sort-by-alphabet-alt"></span></div>
+      {% if data == 'series' %}
+      <div id="new" data-id="{{ data }}" data-toggle="tooltip" title="{{_('Sort according to date added, newest first')}}" class="btn btn-primary{% if order == 2 %} active{% endif%}"><span class="glyphicon glyphicon-calendar"></span><span class="glyphicon glyphicon-sort-by-order"></span></div>
+      {% endif %}
       {% if charlist|length %}
       <div id="all" class="active btn btn-primary {% if charlist|length > 9 %}hidden-sm{% endif %}">{{_('All')}}</div>
       {% endif %}

--- a/cps/web.py
+++ b/cps/web.py
@@ -1008,25 +1008,30 @@ def publisher_list():
 @login_required_if_no_ano
 def series_list():
     if current_user.check_visibility(constants.SIDEBAR_SERIES):
-        if current_user.get_view_property('series', 'dir') == 'desc':
-            order = db.Series.sort.desc()
+        series_dir = current_user.get_view_property('series', 'dir')
+        if series_dir == 'new':
+            order = [func.max(db.Books.timestamp).desc(), db.Series.sort]
+            order_no = 2
+        elif series_dir == 'desc':
+            order = [db.Series.sort.desc()]
             order_no = 0
         else:
-            order = db.Series.sort.asc()
+            order = [db.Series.sort.asc()]
             order_no = 1
         char_list = query_char_list(db.Series.sort, db.books_series_link)
         if current_user.get_view_property('series', 'series_view') == 'list':
             entries = calibre_db.session.query(db.Series, func.count('books_series_link.book').label('count')) \
                 .join(db.books_series_link).join(db.Books).filter(calibre_db.common_filters()) \
-                .group_by(text('books_series_link.series')).order_by(order).all()
-            no_series_count = (calibre_db.session.query(db.Books)
-                            .outerjoin(db.books_series_link).outerjoin(db.Series)
-                            .filter(db.Series.name == None)
-                            .filter(calibre_db.common_filters())
-                            .count())
-            if no_series_count:
-                entries.append([db.Category(_("None"), "-1"), no_series_count])
-            entries = sorted(entries, key=lambda x: (x[0].sort or x[0].name).lower(), reverse=not order_no)
+                .group_by(text('books_series_link.series')).order_by(*order).all()
+            if series_dir != 'new':
+                no_series_count = (calibre_db.session.query(db.Books)
+                                .outerjoin(db.books_series_link).outerjoin(db.Series)
+                                .filter(db.Series.name == None)
+                                .filter(calibre_db.common_filters())
+                                .count())
+                if no_series_count:
+                    entries.append([db.Category(_("None"), "-1"), no_series_count])
+                entries = sorted(entries, key=lambda x: (x[0].sort or x[0].name).lower(), reverse=not order_no)
             return render_title_template('list.html',
                                          entries=entries,
                                          folder='web.books_list',
@@ -1036,11 +1041,12 @@ def series_list():
                                          data="series", order=order_no)
         else:
             entries = (calibre_db.session.query(db.Books, func.count('books_series_link').label('count'),
-                                                func.max(db.Books.series_index), db.Books.id)
+                                                func.max(db.Books.series_index), db.Books.id,
+                                                func.max(db.Books.timestamp).label('newest'))
                        .join(db.books_series_link).join(db.Series).filter(calibre_db.common_filters())
                        .group_by(text('books_series_link.series'))
                        .having(or_(func.max(db.Books.series_index), db.Books.series_index==""))
-                       .order_by(order)
+                       .order_by(*order)
                        .all())
             return render_title_template('grid.html', entries=entries, folder='web.books_list', charlist=char_list,
                                          title=_("Series"), page="serieslist", data="series", bodyClass="grid-view",


### PR DESCRIPTION
On a library with a few hundred series, the alphabetical-only Series page makes it hard to spot what's been added recently. My wife (an avid user who gets through new series faster than the default landing page surfaces them) asked whether there was a way to see the most recently added series first, so this PR adds that option.

A third sort button (calendar + sort-by-order icons) on /series sorts series descending by the latest book timestamp in each series, with Series.sort as a tiebreaker for determinism. The preference persists via the existing set_view_property mechanism like the asc/desc buttons.

While implementing this I hit a latent bug in filter_grid.js: the #asc and #desc handlers use `sortBy: "name"` with no corresponding key in `getSortData`, so isotope silently fell back to "original DOM order" for the sort. This worked by accident because the server renders the DOM in the correct order at init, and the asc/desc handlers toggled between original and reversed. But once the new button re-sorts the DOM client-side by timestamp, subsequent asc/desc clicks toggled between timestamp order and its reverse instead of A-Z / Z-A. The fix is small: add `name: "[data-name]"` to getSortData, and replace the `!sortAscending` toggle with explicit true/false. Asc/desc behaviour on non-series pages that share this JS (authors, categories, ratings, etc.) is observably unchanged. They were already producing correct results via the fallback, and the explicit values produce the same output.

Default behaviour is unchanged. The new button follows the same ajax pattern as the existing sort buttons, and other list routes are untouched.

calibre-web has been central to how we share books as a family, and we're glad to contribute back.

Suggested addition to test/test_list_orders.py::test_series_sort if you'd like coverage:

    self.check_element_on_page((By.ID, "new")).click()
    time.sleep(1)
    list_element = self.get_list_books_displayed()
    self.assertEqual(list_element[0]['title'], "<newest_series>")
    self.driver.refresh()
    list_element = self.get_list_books_displayed()
    self.assertEqual(list_element[0]['title'], "<newest_series>")