### PR TITLE
Remove staged download from /tmp/calibre_web after response is sent

### DIFF
--- a/cps/helper.py
+++ b/cps/helper.py
@@ -30,7 +30,7 @@ import requests
 import unidecode
 from uuid import uuid4
 
-from flask import send_from_directory, make_response, abort, url_for, Response, request
+from flask import send_from_directory, make_response, abort, url_for, Response, request, after_this_request
 from flask_babel import gettext as _
 from flask_babel import lazy_gettext as N_
 from flask_babel import get_locale
@@ -956,6 +956,17 @@ def do_download_file(book, book_format, client, data, headers):
         else:
             download_name = book_name
 
+    # Clean up staged copies in /tmp/calibre_web after the response is sent
+    # (kepubify / calibre-export branches) so the temp dir does not grow unbounded.
+    if filename == get_temp_dir():
+        _tmp_path = os.path.join(filename, download_name + "." + book_format)
+        @after_this_request
+        def _cleanup_staged_download(resp):
+            try:
+                os.remove(_tmp_path)
+            except OSError as ex:
+                log.warning('Failed to remove staged download %s: %s', _tmp_path, ex)
+            return resp
     response = make_response(send_from_directory(filename, download_name + "." + book_format))
     # ToDo Check headers parameter
     for element in headers:


### PR DESCRIPTION
## Problem

When `config_embed_metadata` is enabled (with `config_binariesdir` or `config_kepubifypath` set), `do_download_file` in `cps/helper.py` stages a copy of every downloaded book under `get_temp_dir()` (`/tmp/calibre_web/<uuid>.<ext>`) and never removes it. The only cleanup is `TaskClean.run()` at startup and once daily, so the temp dir grows unbounded between runs and a bulk OPDS / Kobo / KOReader sync can fill the host filesystem in minutes. The effect is amplified for comic formats (CBZ/CBR), where each staged file can run to hundreds of MB or several GB.

Once the disk fills, subsequent download requests fail silently with HTTP 404 (`send_from_directory` swallows the I/O error). On containerized installs a restart does not recover the space because `/tmp` lives on the writable layer.

## Reproduction

1. Admin → Configuration: enable **Embed Metadata in Download** and set a Calibre binaries directory.
2. Pull a few dozen books in a row from any OPDS client (or with curl):
   ```sh
   for id in $(seq 1 50); do
     curl -s -u user:pass http://localhost:8083/opds/download/$id/epub/ -o /dev/null
   done
   ```
3. `du -sh /tmp/calibre_web`: grows by the full size of every download served.
4. Continue until `/tmp` fills; subsequent `/opds/download/*` requests then return 404.

## Root cause

In `cps/helper.py` `do_download_file`:

```python
elif book_format != "kepub" and config.config_binariesdir and config.config_embed_metadata:
    filename, download_name = do_calibre_export(book.id, book_format)   # → (get_temp_dir(), "<uuid>")
...
response = make_response(send_from_directory(filename, download_name + "." + book_format))
```

Both `do_calibre_export` (`cps/embed_helper.py`) and `do_kepubify_metadata_replace` (`cps/helper.py`) write into `get_temp_dir()` and return its path. Nothing in the request path removes the staged file after the response completes. The daily `TaskClean.run()` is too coarse to keep up with realistic usage.

## Fix

Adds an `@after_this_request` cleanup that removes the staged copy after the response is sent. Gated on `filename == get_temp_dir()`, so non-embed and gdrive-direct paths are untouched.
