### PR TITLE
Don't write a cover sibling per download (--dont-save-cover)

### DIFF
--- a/cps/embed_helper.py
+++ b/cps/embed_helper.py
@@ -36,7 +36,8 @@ def do_calibre_export(book_id, book_format):
         if config.config_calibre_split:
             my_env['CALIBRE_OVERRIDE_DATABASE_PATH'] = os.path.join(config.config_calibre_dir, "metadata.db")
         library_path = config.get_book_path()
-        opf_command = [calibredb_binarypath, 'export', '--dont-write-opf', '--with-library', library_path,
+        opf_command = [calibredb_binarypath, 'export', '--dont-write-opf', '--dont-save-cover',
+                       '--with-library', library_path,
                        '--to-dir', tmp_dir, '--formats', book_format, "--template", "{}".format(temp_file_name),
                        str(book_id)]
         p = process_open(opf_command, quotes, my_env)


### PR DESCRIPTION
## Problem

`calibredb export` writes `<uuid>.jpg` next to `<uuid>.<format>` by default, leaving an unused cover image in `/tmp/calibre_web` for every download that goes through `do_calibre_export` in `cps/embed_helper.py`. The cover file is never read by calibre-web (cover serving uses a separate path: `<book_path>/cover.jpg` from the Calibre library, or the thumbnail cache), so it is pure waste of disk space and I/O.

## Fix

Pass `--dont-save-cover` to `calibredb export`, paired with the existing `--dont-write-opf`, to skip the unwanted side-effect at the source.

`--dont-save-cover` suppresses only the **external** cover sibling file. Cover embedding into the EPUB itself is handled by `calibredb export`'s `--update-metadata` flag (on by default, unchanged), which writes the updated cover into the EPUB's internal `cover_image.jpg`. Verified empirically: after applying this patch, the EPUB's embedded `cover_image.jpg` is byte-identical (same sha256) to the source `cover.jpg` in the Calibre library.

Also verified: the only other `calibredb` invocation in the codebase uses `show_metadata --as-opf`, a different subcommand that `--dont-save-cover` does not affect.

## Companion

Companion to #3631; same `/tmp/calibre_web` disk-fill problem, complementary fix. This one prevents the unwanted write at the source; #3631 removes the intentionally-staged book file after the response is sent.
