### PR TITLE
fix(opds): atom:updated reflects last modification, not date added

### DIFF
--- a/cps/db.py
+++ b/cps/db.py
@@ -449,7 +449,16 @@ class Books(Base):
 
     @property
     def atom_timestamp(self):
-        return self.timestamp.strftime('%Y-%m-%dT%H:%M:%S+00:00') or ''
+        # OPDS atom:updated is defined as "the most recent instant in time
+        # when the entry was modified". Books.timestamp is the date added and
+        # never changes after import, so metadata and cover edits were
+        # invisible to OPDS sync clients. Use last_modified, which Calibre
+        # updates on every metadata or cover change; fall back to timestamp
+        # only if last_modified happens to be missing.
+        t = self.last_modified or self.timestamp
+        if t is None:
+            return ''
+        return t.strftime('%Y-%m-%dT%H:%M:%S+00:00') or ''
 
 
 class CustomColumns(Base):


### PR DESCRIPTION
## Problem

`Books.atom_timestamp` returns `Books.timestamp` (date added), which is set at import and never changes. OPDS clients use `atom:updated` to decide whether a book has changed on the server, so cover swaps, metadata edits, and any other post-import change are invisible to sync clients; they keep serving the stale cover and title until a manual refresh.

## Fix

Atom [RFC 4287 §4.2.15](https://datatracker.ietf.org/doc/html/rfc4287#section-4.2.15) defines `updated` as "the most recent instant in time when an entry or feed was modified". Calibre already tracks that as `last_modified`, bumping it on every metadata and cover change.

This PR switches `atom_timestamp` to return `last_modified`, falling back to `timestamp` when `last_modified` happens to be `NULL`.

## Scope

Only the OPDS feed's `atom:updated` element is affected. Kobo sync uses its own `last_modified` comparison path and is unaffected.