### PR TITLE
Fix metadata search crash when ComicVine or Douban return None on error

### DIFF
--- a/cps/metadata_provider/comicvine.py
+++ b/cps/metadata_provider/comicvine.py
@@ -57,7 +57,7 @@ class ComicVine(Metadata):
                 result.raise_for_status()
             except Exception as e:
                 log.warning(e)
-                return None
+                return []
             for result in result.json()["results"]:
                 match = self._parse_search_result(
                     result=result, generic_cover=generic_cover, locale=locale

--- a/cps/metadata_provider/douban.py
+++ b/cps/metadata_provider/douban.py
@@ -155,7 +155,7 @@ class Douban(Metadata):
             r.raise_for_status()
         except Exception as e:
             log.warning(e)
-            return None
+            return []
 
         match = MetaRecord(
             id=id,


### PR DESCRIPTION
## Summary

Fixes the \"Search error!!\" reported in #3606, where the metadata search crashes entirely when ComicVine or Douban fail with an HTTP error.

## Root cause

`comicvine.py` and `douban.py` both `return None` on HTTP error instead of an empty list. The consumer in `search_metadata.py` iterates `future.result()` directly:

```python
data.extend([asdict(x) for x in (future.result() or []) if x])
```

The `or []` guard handles a `None` return correctly, but only if the provider actually returns `None` rather than raising, which is what both of these providers do. Tthe resulting `TypeError: 'NoneType' object is not iterable` causing issues with the Flask app, making the UI unresponsive until a restart. (In my experience)

## Why it appears intermittent

ComicVine only returns `None` on certain HTTP failures (rate limiting, timeouts) rather than on every request, which is why users see it work sometimes and fail unpredictably other times.

## Changes

- `cps/metadata_provider/comicvine.py` - `return None` → `return []` on HTTP error
- `cps/metadata_provider/douban.py` - same fix

Both providers already return `[]` in other error paths. This makes the HTTP error path consistent.

Closes #3606