### PR TITLE
Add configurable ComicVine API key setting

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -1841,6 +1841,9 @@ def _configuration_update_helper():
 
         # Google Books API configuration
         reboot_required |=_config_string(to_save, "config_googlebooks_api_key")
+
+        # ComicVine API configuration
+        reboot_required |=_config_string(to_save, "config_comicvine_api_key")
         
         _config_int(to_save, "config_updatechannel")
 

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -118,6 +118,7 @@ class _Settings(_Base):
     config_use_goodreads = Column(Boolean, default=False)
     config_goodreads_api_key = Column(String)
     config_googlebooks_api_key = Column(String, default='')
+    config_comicvine_api_key = Column(String, default='')
     config_register_email = Column(Boolean, default=False)
     config_login_type = Column(Integer, default=0)
 

--- a/cps/metadata_provider/comicvine.py
+++ b/cps/metadata_provider/comicvine.py
@@ -21,7 +21,7 @@ from typing import Dict, List, Optional
 from urllib.parse import quote
 
 import requests
-from cps import logger
+from cps import config, logger
 from cps.services.Metadata import MetaRecord, MetaSourceInfo, Metadata
 
 log = logger.create()
@@ -33,11 +33,9 @@ class ComicVine(Metadata):
     DESCRIPTION = "ComicVine Books"
     META_URL = "https://comicvine.gamespot.com/"
     API_KEY = "57558043c53943d5d1e96a9ad425b0eb85532ee6"
-    BASE_URL = (
-        f"https://comicvine.gamespot.com/api/search?api_key={API_KEY}"
-        f"&resources=issue&query="
-    )
-    QUERY_PARAMS = "&sort=name:desc&format=json"
+    BASE_URL = "https://comicvine.gamespot.com/api/search?api_key="
+    QUERY_PARAMS = "&resources=issue&query="
+    SORT_PARAMS = "&sort=name:desc&format=json"
     HEADERS = {"User-Agent": "Not Evil Browser"}
 
     def search(
@@ -45,15 +43,14 @@ class ComicVine(Metadata):
     ) -> Optional[List[MetaRecord]]:
         val = list()
         if self.active:
+            api_key = config.config_comicvine_api_key or ComicVine.API_KEY
             title_tokens = list(self.get_title_tokens(query, strip_joiners=False))
             if title_tokens:
                 tokens = [quote(t.encode("utf-8")) for t in title_tokens]
                 query = "%20".join(tokens)
             try:
-                result = requests.get(
-                    f"{ComicVine.BASE_URL}{query}{ComicVine.QUERY_PARAMS}",
-                    headers=ComicVine.HEADERS,
-                )
+                url = f"{ComicVine.BASE_URL}{api_key}{ComicVine.QUERY_PARAMS}{query}{ComicVine.SORT_PARAMS}"
+                result = requests.get(url, headers=ComicVine.HEADERS)
                 result.raise_for_status()
             except Exception as e:
                 log.warning(e)

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -168,6 +168,10 @@
       <input type="text" class="form-control" id="config_googlebooks_api_key" name="config_googlebooks_api_key" value="{% if config.config_googlebooks_api_key != '' %}{{ config.config_googlebooks_api_key }}{% endif %}" autocomplete="off">
     </div>
     <div class="form-group">
+      <label for="config_comicvine_api_key">{{_('ComicVine API Key')}}</label>
+      <input type="text" class="form-control" id="config_comicvine_api_key" name="config_comicvine_api_key" value="{% if config.config_comicvine_api_key != '' %}{{ config.config_comicvine_api_key }}{% endif %}" autocomplete="off">
+    </div>
+    <div class="form-group">
       <input type="checkbox" id="config_allow_reverse_proxy_header_login" name="config_allow_reverse_proxy_header_login" data-control="reverse-proxy-login-settings" {% if config.config_allow_reverse_proxy_header_login %}checked{% endif %}>
       <label for="config_allow_reverse_proxy_header_login">{{_('Allow Reverse Proxy Authentication')}}</label>
     </div>


### PR DESCRIPTION
## Problem

The ComicVine API key is hardcoded as a class constant in https://github.com/janeczku/calibre-web/blob/fca5805/cps/metadata_provider/comicvine.py#L35


```python
API_KEY = "5755..."
```

This means every calibre-web installation shares the same API key. With 17k+ stars and thousands of active instances, the key is under constant rate limit pressure which is why users regularly see HTTP 420 errors when searching ComicVine, even with light personal usage.

## Solution

Add a `config_comicvine_api_key` setting to the admin configuration page, following the same pattern already used by Google Books. The hardcoded key remains as a fallback so existing installations are completely unaffected. Users who want their own isolated rate limit can register a free key at comicvine.gamespot.com and enter it in the admin panel.

```python
api_key = config.config_comicvine_api_key or ComicVine.API_KEY
```

## Changes

- `cps/config_sql.py` — add `config_comicvine_api_key` column
- `cps/metadata_provider/comicvine.py` — read from config, fall back to hardcoded key
- `cps/admin.py` — save the field on config update
- `cps/templates/config_edit.html` — add input field next to Google Books API Key

## Testing

Tested on a live linuxserver/calibre-web instance:

1. Opened Admin → Configuration, confirmed the new **ComicVine API Key** field appears alongside the Google Books field
2. Set the field to an intentionally invalid value (`abcd`) and ran a metadata search — got "No results found" with no server crash, no 500, no hang. The 401 from ComicVine is caught and handled gracefully.
3. Set the field to a valid personal API key, ran a metadata search — results returned successfully
4. Cleared the field entirely — searches continued working using the original fallback key, confirming backwards compatibility

<img width="564" height="187" alt="image" src="https://github.com/user-attachments/assets/19359bfc-43df-44e4-96c6-5e05a5f7ed98" />
