### PR TITLE
Composite column support and custom column ordering, links, and visibility

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -283,7 +283,7 @@ def view_configuration():
     restrict_columns = calibre_db.session.query(db.CustomColumns) \
         .filter(and_(db.CustomColumns.datatype == 'text', db.CustomColumns.mark_for_delete == 0)).all()
     all_cc_columns = calibre_db.session.query(db.CustomColumns) \
-        .filter(and_(db.CustomColumns.datatype.notin_(db.cc_exceptions), db.CustomColumns.mark_for_delete == 0)).all()
+        .filter(and_(db.CustomColumns.datatype != 'series', db.CustomColumns.mark_for_delete == 0)).all()
     if config.config_cc_display_order:
         try:
             order_ids = [int(x) for x in config.config_cc_display_order.split(',') if x.strip()]

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -610,6 +610,7 @@ def update_view_configuration():
     config.config_default_role &= ~constants.ROLE_ANONYMOUS
 
     config.config_default_show = sum(int(k[5:]) for k in to_save if k.startswith('show_'))
+    config.config_cc_link_columns = ','.join(k[8:] for k in to_save if k.startswith('cc_link_'))
     if "Show_detail_random" in to_save:
         config.config_default_show |= constants.DETAIL_RANDOM
 

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -611,6 +611,7 @@ def update_view_configuration():
 
     config.config_default_show = sum(int(k[5:]) for k in to_save if k.startswith('show_'))
     config.config_cc_link_columns = ','.join(k[8:] for k in to_save if k.startswith('cc_link_'))
+    config.config_cc_hidden_columns = ','.join(k[8:] for k in to_save if k.startswith('cc_hide_'))
     if "Show_detail_random" in to_save:
         config.config_default_show |= constants.DETAIL_RANDOM
 

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -282,10 +282,22 @@ def view_configuration():
         .filter(and_(db.CustomColumns.datatype == 'bool', db.CustomColumns.mark_for_delete == 0)).all()
     restrict_columns = calibre_db.session.query(db.CustomColumns) \
         .filter(and_(db.CustomColumns.datatype == 'text', db.CustomColumns.mark_for_delete == 0)).all()
+    all_cc_columns = calibre_db.session.query(db.CustomColumns) \
+        .filter(and_(db.CustomColumns.datatype.notin_(db.cc_exceptions), db.CustomColumns.mark_for_delete == 0)).all()
+    if config.config_cc_display_order:
+        try:
+            order_ids = [int(x) for x in config.config_cc_display_order.split(',') if x.strip()]
+            id_map = {col.id: col for col in all_cc_columns}
+            ordered = [id_map[i] for i in order_ids if i in id_map]
+            remaining = [col for col in all_cc_columns if col.id not in set(order_ids)]
+            all_cc_columns = ordered + remaining
+        except (ValueError, AttributeError):
+            pass
     languages = calibre_db.speaking_language()
     translations = get_available_locale()
     return render_title_template("config_view_edit.html", conf=config, readColumns=read_column,
                                  restrictColumns=restrict_columns,
+                                 allColumns=all_cc_columns,
                                  languages=languages,
                                  translations=translations,
                                  title=_("UI Configuration"), page="uiconfig")
@@ -571,6 +583,7 @@ def update_view_configuration():
 
     _config_string(to_save, "config_calibre_web_title")
     _config_string(to_save, "config_columns_to_ignore")
+    _config_string(to_save, "config_cc_display_order")
     if _config_string(to_save, "config_title_regex"):
         calibre_db.create_functions(config)
 

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -84,6 +84,7 @@ class _Settings(_Base):
     config_authors_max = Column(Integer, default=0)
     config_read_column = Column(Integer, default=0)
     config_cc_display_order = Column(String, default='')
+    config_cc_link_columns = Column(String, default='')
     config_title_regex = Column(String,
                                 default=r"^(A|The|An|Der|Die|Das|Den|Ein|Eine"
                                         r"|Einen|Dem|Des|Einem|Eines|Le|La|Les|L'|Un|Une)(\s+|(?<='))")

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -83,6 +83,7 @@ class _Settings(_Base):
     config_random_books = Column(Integer, default=4)
     config_authors_max = Column(Integer, default=0)
     config_read_column = Column(Integer, default=0)
+    config_cc_display_order = Column(String, default='')
     config_title_regex = Column(String,
                                 default=r"^(A|The|An|Der|Die|Das|Den|Ein|Eine"
                                         r"|Einen|Dem|Des|Einem|Eines|Le|La|Les|L'|Un|Une)(\s+|(?<='))")

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -85,6 +85,7 @@ class _Settings(_Base):
     config_read_column = Column(Integer, default=0)
     config_cc_display_order = Column(String, default='')
     config_cc_link_columns = Column(String, default='')
+    config_cc_hidden_columns = Column(String, default='')
     config_title_regex = Column(String,
                                 default=r"^(A|The|An|Der|Die|Das|Den|Ein|Eine"
                                         r"|Einen|Dem|Des|Einem|Eines|Le|La|Les|L'|Un|Une)(\s+|(?<='))")

--- a/cps/db.py
+++ b/cps/db.py
@@ -1070,6 +1070,16 @@ class CalibreDB:
                 continue
             cc.append(col)
 
+        if config.config_cc_display_order:
+            try:
+                order_ids = [int(x) for x in config.config_cc_display_order.split(',') if x.strip()]
+                id_to_col = {col.id: col for col in cc}
+                ordered = [id_to_col[i] for i in order_ids if i in id_to_col]
+                remaining = [col for col in cc if col.id not in set(order_ids)]
+                cc = ordered + remaining
+            except (ValueError, AttributeError):
+                pass
+
         return cc
 
     # read search results from calibre-database and return it (function is used for feed and simple search

--- a/cps/db.py
+++ b/cps/db.py
@@ -1056,17 +1056,22 @@ class CalibreDB:
 
         return base_query.filter(or_(*filter_expression))
 
-    def get_cc_columns(self, config, filter_config_custom_read=False):
+    def get_cc_columns(self, config, filter_config_custom_read=False, filter_hidden=True):
         tmp_cc = self.session.query(CustomColumns).filter(CustomColumns.datatype.notin_(cc_exceptions)).all()
         cc = []
         r = None
         if config.config_columns_to_ignore:
             r = re.compile(config.config_columns_to_ignore)
+        hidden_ids = set()
+        if filter_hidden and config.config_cc_hidden_columns:
+            hidden_ids = set(int(x) for x in config.config_cc_hidden_columns.split(',') if x.strip())
 
         for col in tmp_cc:
             if filter_config_custom_read and config.config_read_column and config.config_read_column == col.id:
                 continue
             if r and r.match(col.name):
+                continue
+            if col.id in hidden_ids:
                 continue
             cc.append(col)
 

--- a/cps/db.py
+++ b/cps/db.py
@@ -1048,7 +1048,7 @@ class CalibreDB:
         ]
 
         for c in cc:
-            if c.datatype not in ["datetime", "rating", "bool", "int", "float"]:
+            if c.datatype not in ["datetime", "rating", "bool", "int", "float", "composite"]:
                 filter_expression.append(
                     getattr(Books,
                             'custom_column_' + str(c.id)).any(
@@ -1057,7 +1057,7 @@ class CalibreDB:
         return base_query.filter(or_(*filter_expression))
 
     def get_cc_columns(self, config, filter_config_custom_read=False, filter_hidden=True):
-        tmp_cc = self.session.query(CustomColumns).filter(CustomColumns.datatype.notin_(cc_exceptions)).all()
+        tmp_cc = self.session.query(CustomColumns).filter(CustomColumns.datatype != 'series').all()
         cc = []
         r = None
         if config.config_columns_to_ignore:

--- a/cps/jinjia.py
+++ b/cps/jinjia.py
@@ -24,6 +24,7 @@
 
 from markupsafe import escape
 import datetime
+import json
 import mimetypes
 from uuid import uuid4
 
@@ -120,6 +121,20 @@ def formatfloat(value, decimals=1):
     if formated_value.endswith('.' + "0" * decimals):
         formated_value = formated_value.rstrip('0').rstrip('.')
     return formated_value
+
+
+@jinjia.app_template_filter('format_cc_number')
+def format_cc_number(value, display):
+    try:
+        display_dict = json.loads(display) if display else {}
+        number_format = display_dict.get('number_format', '')
+        if number_format:
+            return number_format.format(value)
+        if isinstance(value, float):
+            return formatfloat(value, display_dict.get('decimals', 2))
+    except (ValueError, KeyError):
+        pass
+    return value
 
 
 @jinjia.app_template_filter('escapedlink')

--- a/cps/search.py
+++ b/cps/search.py
@@ -404,7 +404,7 @@ def render_adv_search_results(term, offset=None, order=None, limit=None):
                                  entries=entries,
                                  result_count=result_count,
                                  title=_("Advanced Search"), page="advsearch",
-                                 order=order[1])
+                                 order=order[1] if order else None)
 
 
 def render_prepare_search_form(cc):

--- a/cps/search.py
+++ b/cps/search.py
@@ -95,6 +95,8 @@ def advanced_search_form():
 
 def adv_search_custom_columns(cc, term, q):
     for c in cc:
+        if c.datatype == "composite":
+            continue
         if c.datatype == "datetime":
             custom_start = term.get('custom_column_' + str(c.id) + '_start')
             custom_end = term.get('custom_column_' + str(c.id) + '_end')

--- a/cps/search.py
+++ b/cps/search.py
@@ -63,10 +63,26 @@ def advanced_search():
     return redirect(url_for('web.books_list', data="advsearch", sort_param='stored', query=""))
 
 
-@search.route("/ccsearch", methods=['GET'])
+@search.route("/cc", methods=['GET'])
 @login_required_if_no_ano
 def cc_search():
-    return render_adv_search_results(request.args.to_dict())
+    cc_id = request.args.get('column', '')
+    cc_val = request.args.get('value', '')
+    term = {
+        'authors': '', 'title': '', 'publisher': '',
+        'publishstart': '', 'publishend': '',
+        'ratinghigh': '', 'ratinglow': '',
+        'comments': '', 'read_status': 'Any',
+        'include_tag': [], 'exclude_tag': [],
+        'include_serie': [], 'exclude_serie': [],
+        'include_serie2': [], 'exclude_serie2': [],
+        'include_shelf': [], 'exclude_shelf': [],
+        'include_language': [], 'exclude_language': [],
+        'include_extension': [], 'exclude_extension': [],
+    }
+    if cc_id:
+        term['custom_column_' + cc_id] = cc_val
+    return render_adv_search_results(term)
 
 
 @search.route("/advsearch", methods=['GET'])

--- a/cps/search.py
+++ b/cps/search.py
@@ -63,6 +63,12 @@ def advanced_search():
     return redirect(url_for('web.books_list', data="advsearch", sort_param='stored', query=""))
 
 
+@search.route("/ccsearch", methods=['GET'])
+@login_required_if_no_ano
+def cc_search():
+    return render_adv_search_results(request.args.to_dict())
+
+
 @search.route("/advsearch", methods=['GET'])
 @login_required_if_no_ano
 def advanced_search_form():

--- a/cps/search.py
+++ b/cps/search.py
@@ -82,7 +82,7 @@ def cc_search():
     }
     if cc_id:
         term['custom_column_' + cc_id] = cc_val
-    return render_adv_search_results(term)
+    return render_adv_search_results(term, order=([db.Books.timestamp.desc()], 'new'))
 
 
 @search.route("/advsearch", methods=['GET'])

--- a/cps/static/css/style.css
+++ b/cps/static/css/style.css
@@ -4,26 +4,29 @@
 }
 
 .cc-order-item {
+  display: flex;
+  align-items: center;
   cursor: grab;
   user-select: none;
 }
 
-.cc-order-item::after {
-  content: '';
-  display: table;
-  clear: both;
+.cc-drag-handle {
+  margin-right: 10px;
+  color: #aaa;
+  flex-shrink: 0;
 }
 
-.cc-drag-handle {
-  margin-right: 8px;
-  color: #aaa;
+.cc-col-name {
+  flex: 1;
 }
 
 .cc-link-label {
-  float: right;
   font-weight: normal;
   margin-bottom: 0;
+  margin-left: 16px;
   cursor: pointer;
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 
 .tooltip.bottom .tooltip-inner {

--- a/cps/static/css/style.css
+++ b/cps/static/css/style.css
@@ -8,9 +8,22 @@
   user-select: none;
 }
 
+.cc-order-item::after {
+  content: '';
+  display: table;
+  clear: both;
+}
+
 .cc-drag-handle {
   margin-right: 8px;
   color: #aaa;
+}
+
+.cc-link-label {
+  float: right;
+  font-weight: normal;
+  margin-bottom: 0;
+  cursor: pointer;
 }
 
 .tooltip.bottom .tooltip-inner {

--- a/cps/static/css/style.css
+++ b/cps/static/css/style.css
@@ -3,6 +3,16 @@
   overflow-y: auto;
 }
 
+.cc-order-item {
+  cursor: grab;
+  user-select: none;
+}
+
+.cc-drag-handle {
+  margin-right: 8px;
+  color: #aaa;
+}
+
 .tooltip.bottom .tooltip-inner {
   font-size: 13px;
   font-family: Open Sans Semibold, Helvetica Neue, Helvetica, Arial, sans-serif;

--- a/cps/template_formatter.py
+++ b/cps/template_formatter.py
@@ -34,6 +34,64 @@ def _parse_args(text):
     return [re.sub(r'\\,', ',', a) for a in tokens]
 
 
+def _split_gpm_args(args_str):
+    """Split comma-separated GPM args respecting nested parens and quotes."""
+    args, depth, in_quote, current = [], 0, None, []
+    for ch in args_str:
+        if in_quote:
+            current.append(ch)
+            if ch == in_quote:
+                in_quote = None
+        elif ch in ("'", '"'):
+            in_quote = ch
+            current.append(ch)
+        elif ch == '(':
+            depth += 1
+            current.append(ch)
+        elif ch == ')':
+            depth -= 1
+            current.append(ch)
+        elif ch == ',' and depth == 0:
+            args.append(''.join(current).strip())
+            current = []
+        else:
+            current.append(ch)
+    if current:
+        args.append(''.join(current).strip())
+    return [a for a in args if a]
+
+
+def _eval_gpm_expr(expr, fields):
+    """Recursively evaluate a calibre General Program Mode expression."""
+    expr = expr.strip()
+    if not expr:
+        return ''
+    # String literal
+    if len(expr) >= 2 and expr[0] in ("'", '"') and expr[-1] == expr[0]:
+        return expr[1:-1]
+    # Function call: name(args...)
+    p = expr.find('(')
+    if p > 0 and expr.endswith(')'):
+        fname = expr[:p].strip()
+        evaled = [_eval_gpm_expr(a, fields) for a in _split_gpm_args(expr[p + 1:-1])]
+        if fname == 'field':
+            return fields.get(evaled[0], '') if evaled else ''
+        entry = _REGISTRY.get(fname)
+        if entry:
+            _, fn = entry
+            val = evaled[0] if evaled else ''
+            try:
+                result = fn(val, *evaled[1:])
+                return result if isinstance(result, str) else (str(result) if result is not None else '')
+            except Exception as ex:
+                log.warning("GPM function %r failed (args=%r): %s", fname, evaled, ex)
+                return ''
+        log.warning("GPM references unknown function %r", fname)
+        return ''
+    # Bare word — field name
+    return fields.get(expr, '')
+
+
 # ---------------------------------------------------------------------------
 # Function implementations — signatures: fn(val, *extra_args) -> str
 # ---------------------------------------------------------------------------
@@ -495,6 +553,10 @@ class CalibreTemplateFormatter(string.Formatter):
     def format_field(self, val, fmt):
         if not fmt:
             return val or ''
+
+        # GPM mode: calibre wraps the expression in single quotes
+        if len(fmt) >= 2 and fmt[0] == "'" and fmt[-1] == "'":
+            return _eval_gpm_expr(fmt[1:-1], self._fields)
 
         # Handle |prefix|fmt|suffix| conditional wrapper
         m = _format_string_re.match(fmt)

--- a/cps/template_formatter.py
+++ b/cps/template_formatter.py
@@ -547,4 +547,13 @@ class CalibreTemplateFormatter(string.Formatter):
 
 
 def evaluate_composite_template(template, book, cc_columns, column_name=None):
-    return CalibreTemplateFormatter(book, cc_columns).safe_format(template, column_name=column_name)
+    fmt = CalibreTemplateFormatter(book, cc_columns)
+    result = fmt.safe_format(template, column_name=column_name)
+    log.debug(
+        "Composite column %r: template=%r identifiers=%r result=%r",
+        column_name,
+        template,
+        fmt._fields.get('identifiers', ''),
+        result,
+    )
+    return result

--- a/cps/template_formatter.py
+++ b/cps/template_formatter.py
@@ -1,0 +1,541 @@
+"""
+Calibre composite column template evaluator.
+
+Ported from calibre/src/calibre/utils/formatter.py and formatter_functions.py.
+Supports simple-mode templates ({field}, {field:func(args)}, {#label}).
+Does not support program: or python: modes.
+"""
+
+import re
+import string
+from functools import lru_cache
+from math import ceil, floor, modf, trunc
+
+
+# ---------------------------------------------------------------------------
+# Argument scanner — ported from calibre's args_scanner()
+# ---------------------------------------------------------------------------
+
+@lru_cache(maxsize=2)
+def _args_scanner():
+    return re.Scanner([
+        (r',', lambda x, t: ''),
+        (r'.*?(?:(?<!\\),)', lambda x, t: t[:-1]),
+        (r'.*?\)', lambda x, t: t[:-1]),
+    ])
+
+
+def _parse_args(text):
+    tokens, _ = _args_scanner().scan(text)
+    return [re.sub(r'\\,', ',', a) for a in tokens]
+
+
+# ---------------------------------------------------------------------------
+# Function implementations — signatures: fn(val, *extra_args) -> str
+# ---------------------------------------------------------------------------
+
+def _strcmp_key(x):
+    return x.lower()
+
+
+def _fn_strcmp(val, x, y, lt, eq, gt):
+    lx, ly = x.lower(), y.lower()
+    return lt if lx < ly else (eq if lx == ly else gt)
+
+
+def _fn_strcmpcase(val, x, y, lt, eq, gt):
+    return lt if x < y else (eq if x == y else gt)
+
+
+def _fn_cmp(val, y, lt, eq, gt):
+    v = float(val or 0)
+    y = float(y or 0)
+    return lt if v < y else (eq if v == y else gt)
+
+
+def _fn_first_matching_cmp(val, *args):
+    if len(args) % 2 != 0:
+        raise ValueError('first_matching_cmp requires an even number of arguments')
+    v = float(val or 0)
+    for i in range(0, len(args) - 1, 2):
+        if v < float(args[i] or 0):
+            return args[i + 1]
+    return args[-1]
+
+
+def _fn_strcat(val, *args):
+    return val + ''.join(args)
+
+
+def _fn_strlen(val):
+    return str(len(val))
+
+
+def _fn_add(val, *args):
+    return str(float(val or 0) + sum(float(a or 0) for a in args))
+
+
+def _fn_subtract(val, y):
+    return str(float(val or 0) - float(y or 0))
+
+
+def _fn_multiply(val, *args):
+    result = float(val or 0)
+    for a in args:
+        result *= float(a or 0)
+    return str(result)
+
+
+def _fn_divide(val, y):
+    return str(float(val or 0) / float(y or 0))
+
+
+def _fn_ceiling(val):
+    return str(ceil(float(val or 0)))
+
+
+def _fn_floor(val):
+    return str(floor(float(val or 0)))
+
+
+def _fn_round(val):
+    return str(round(float(val or 0)))
+
+
+def _fn_mod(val, y):
+    return str(int(float(val or 0) % float(y or 0)))
+
+
+def _fn_fractional_part(val):
+    return str(modf(float(val or 0))[0])
+
+
+def _fn_substr(val, start, end):
+    s, e = int(start), int(end)
+    return val[s: len(val) if e == 0 else e]
+
+
+def _fn_test(val, text_if_set, text_if_empty):
+    return text_if_set if val else text_if_empty
+
+
+def _fn_contains(val, pattern, text_if_match, text_if_not):
+    return text_if_match if re.search(pattern, val, re.I) else text_if_not
+
+
+def _fn_re(val, pattern, replacement):
+    return re.sub(pattern, replacement, val, flags=re.I)
+
+
+def _fn_swap_around_comma(val):
+    return re.sub(r'^(.*?),\s*(.*$)', r'\2 \1', val, flags=re.I).strip()
+
+
+def _fn_ifempty(val, default):
+    return val if val else default
+
+
+def _fn_select(val, key):
+    if not val:
+        return ''
+    prefix = key + ':'
+    for part in (p.strip() for p in val.split(',')):
+        if part.startswith(prefix):
+            return part[len(prefix):]
+    return ''
+
+
+def _fn_list_count(val, sep):
+    return str(len([x for x in val.split(sep) if x]))
+
+
+def _fn_list_count_matching(val, pattern, sep):
+    return str(sum(1 for x in (x.strip() for x in val.split(sep) if x.strip())
+                   if re.search(pattern, x, re.I)))
+
+
+def _fn_list_item(val, index, sep):
+    if not val:
+        return ''
+    try:
+        return val.split(sep)[int(index)].strip()
+    except IndexError:
+        return ''
+
+
+def _fn_identifier_in_list(val, ident, *args):
+    if len(args) == 0:
+        fv_is_id, nfv = True, ''
+    elif len(args) == 2:
+        fv_is_id, fv, nfv = False, args[0], args[1]
+    else:
+        raise ValueError('identifier_in_list requires 2 or 4 arguments')
+    parts = [v.strip() for v in val.split(',') if v.strip()]
+    id_, _, regexp = ident.partition(':')
+    if not id_:
+        return nfv
+    for candidate in parts:
+        i, _, v = candidate.partition(':')
+        if v and i == id_:
+            if not regexp or re.search(regexp, v, re.I):
+                return candidate if fv_is_id else fv
+    return nfv
+
+
+def _fn_str_in_list(val, sep, *args):
+    if len(args) % 2 != 1:
+        raise ValueError('str_in_list requires an odd number of arguments')
+    l = [v.strip() for v in val.split(sep) if v.strip()]
+    i = 0
+    while i < len(args):
+        if i + 1 >= len(args):
+            return args[i]
+        sf, fv = args[i], args[i + 1]
+        candidates = [v.strip() for v in sf.split(sep) if v.strip()]
+        for v in l:
+            for c in candidates:
+                if c.lower() == v.lower():
+                    return fv
+        i += 2
+    return ''
+
+
+def _fn_list_contains(val, sep, *args):
+    if len(args) % 2 != 1:
+        raise ValueError('list_contains requires an odd number of arguments')
+    l = [v.strip() for v in val.split(sep) if v.strip()]
+    i = 0
+    while i < len(args):
+        if i + 1 >= len(args):
+            return args[i]
+        sf, fv = args[i], args[i + 1]
+        for v in l:
+            if re.search(sf, v, re.I):
+                return fv
+        i += 2
+    return ''
+
+
+def _fn_switch(val, *args):
+    if len(args) % 2 != 1:
+        raise ValueError('switch requires an odd number of arguments')
+    i = 0
+    while i < len(args):
+        if i + 1 >= len(args):
+            return args[i]
+        if re.search(args[i], val, re.I):
+            return args[i + 1]
+        i += 2
+    return ''
+
+
+def _fn_switch_if(val, *args):
+    if len(args) % 2 != 1:
+        raise ValueError('switch_if requires an odd number of arguments')
+    i = 0
+    while i < len(args):
+        if i + 1 >= len(args):
+            return args[i]
+        if args[i]:
+            return args[i + 1]
+        i += 2
+    return ''
+
+
+def _fn_strcat_max(val, *args):
+    if len(args) < 1 or len(args) % 2 != 1:
+        raise ValueError('strcat_max requires an odd number of arguments (max, str1, [pre, str]+)')
+    max_len = int(args[0])
+    result = args[1] if len(args) > 1 else val
+    i = 2
+    while i + 1 < len(args):
+        if len(result) + len(args[i]) + len(args[i + 1]) > max_len:
+            break
+        result += args[i] + args[i + 1]
+        i += 2
+    return result.strip()
+
+
+def _fn_shorten(val, leading, center_string, trailing):
+    l = max(0, int(leading))
+    t = max(0, int(trailing))
+    if len(val) > l + len(center_string) + t:
+        return val[:l] + center_string + ('' if t == 0 else val[-t:])
+    return val
+
+
+def _fn_sublist(val, start_index, end_index, sep):
+    if not val:
+        return ''
+    si, ei = int(start_index), int(end_index)
+    parts = [v.strip() for v in val.split(sep)]
+    joined_sep = ', ' if sep == ',' else sep
+    try:
+        return joined_sep.join(parts[si:] if ei == 0 else parts[si:ei])
+    except Exception:
+        return ''
+
+
+_period_pattern = re.compile(r'(?<=[^\.\s])\.(?=[^\.\s])', re.U)
+
+
+def _fn_subitems(val, start_index, end_index):
+    if not val:
+        return ''
+    si, ei = int(start_index), int(end_index)
+    has_periods = '.' in val
+    items = [v.strip() for v in val.split(',') if v.strip()]
+    rv = set()
+    for item in items:
+        components = _period_pattern.split(item) if has_periods and '.' in item else [item]
+        try:
+            t = '.'.join(components[si:] if ei == 0 else components[si:ei]).strip()
+            if t:
+                rv.add(t)
+        except Exception:
+            pass
+    return ', '.join(sorted(rv, key=str.casefold))
+
+
+def _fn_lookup(val, *args):
+    # Simplified: cannot recurse into formatter fields, just return matched value literal
+    if len(args) == 2:
+        return args[0] if val else args[1]
+    if len(args) % 2 != 1:
+        raise ValueError('lookup requires 2 or an odd number of arguments')
+    i = 0
+    while i < len(args):
+        if i + 1 >= len(args):
+            return args[i]
+        if re.search(args[i], val, re.I):
+            return args[i + 1]
+        i += 2
+    return ''
+
+
+def _fn_format_number(val, template):
+    if val in ('', 'None'):
+        return ''
+    if '{' not in template:
+        template = '{0:' + template + '}'
+    try:
+        v1 = float(val)
+    except Exception:
+        return ''
+    try:
+        return template.format(v1)
+    except Exception:
+        pass
+    try:
+        v2 = trunc(v1)
+        if v2 == v1:
+            return template.format(v2)
+    except Exception:
+        pass
+    return ''
+
+
+def _fn_uppercase(val):
+    return val.upper()
+
+
+def _fn_lowercase(val):
+    return val.lower()
+
+
+def _fn_capitalize(val):
+    return val.capitalize()
+
+
+def _fn_titlecase(val):
+    return val.title()
+
+
+# ---------------------------------------------------------------------------
+# Function registry: name -> (arg_count, fn, aliases)
+#   arg_count: total including val; -1 = variadic; 1 = val only, no extra args
+# ---------------------------------------------------------------------------
+
+_REGISTRY = {}
+
+
+def _reg(name, arg_count, fn, *aliases):
+    entry = (arg_count, fn)
+    _REGISTRY[name] = entry
+    for a in aliases:
+        _REGISTRY[a] = entry
+
+
+_reg('strcmp',              5,  _fn_strcmp)
+_reg('strcmpcase',          5,  _fn_strcmpcase)
+_reg('cmp',                 5,  _fn_cmp)
+_reg('first_matching_cmp', -1,  _fn_first_matching_cmp)
+_reg('strcat',             -1,  _fn_strcat)
+_reg('strlen',              1,  _fn_strlen)
+_reg('add',                -1,  _fn_add)
+_reg('subtract',            2,  _fn_subtract)
+_reg('multiply',           -1,  _fn_multiply)
+_reg('divide',              2,  _fn_divide)
+_reg('ceiling',             1,  _fn_ceiling)
+_reg('floor',               1,  _fn_floor)
+_reg('round',               1,  _fn_round)
+_reg('mod',                 2,  _fn_mod)
+_reg('fractional_part',     1,  _fn_fractional_part)
+_reg('substr',              3,  _fn_substr)
+_reg('test',                3,  _fn_test)
+_reg('contains',            4,  _fn_contains)
+_reg('re',                  3,  _fn_re)
+_reg('swap_around_comma',   1,  _fn_swap_around_comma)
+_reg('ifempty',             2,  _fn_ifempty)
+_reg('select',              2,  _fn_select)
+_reg('list_count',          2,  _fn_list_count,         'count')
+_reg('list_count_matching', 3,  _fn_list_count_matching, 'count_matching')
+_reg('list_item',           3,  _fn_list_item)
+_reg('identifier_in_list', -1,  _fn_identifier_in_list)
+_reg('str_in_list',        -1,  _fn_str_in_list)
+_reg('list_contains',      -1,  _fn_list_contains,      'in_list')
+_reg('switch',             -1,  _fn_switch)
+_reg('switch_if',          -1,  _fn_switch_if)
+_reg('strcat_max',         -1,  _fn_strcat_max)
+_reg('shorten',             4,  _fn_shorten)
+_reg('sublist',             4,  _fn_sublist)
+_reg('subitems',            3,  _fn_subitems)
+_reg('lookup',             -1,  _fn_lookup)
+_reg('format_number',       2,  _fn_format_number)
+_reg('uppercase',           1,  _fn_uppercase)
+_reg('lowercase',           1,  _fn_lowercase)
+_reg('capitalize',          1,  _fn_capitalize)
+_reg('titlecase',           1,  _fn_titlecase)
+
+
+# ---------------------------------------------------------------------------
+# Book field value extraction
+# ---------------------------------------------------------------------------
+
+def _book_fields(book, cc_columns):
+    identifiers_str = ', '.join(
+        sorted(
+            ('{0}:{1}'.format(i.type, i.val) for i in (book.identifiers or [])),
+            key=str.casefold,
+        )
+    )
+    isbn_val = next((i.val for i in (book.identifiers or []) if i.type == 'isbn'), '')
+
+    fields = {
+        'title':         book.title or '',
+        'sort':          book.sort or '',
+        'title_sort':    book.sort or '',
+        'authors':       ' & '.join(a.name for a in book.authors) if book.authors else '',
+        'author_sort':   book.author_sort or '',
+        'series':        book.series[0].name if book.series else '',
+        'series_index':  str(book.series_index) if book.series_index else '',
+        'publisher':     book.publishers[0].name if book.publishers else '',
+        'publishers':    book.publishers[0].name if book.publishers else '',
+        'pubdate':       str(book.pubdate.date()) if book.pubdate else '',
+        'timestamp':     str(book.timestamp.date()) if book.timestamp else '',
+        'last_modified': str(book.last_modified.date()) if book.last_modified else '',
+        'tags':          ', '.join(t.name for t in book.tags) if book.tags else '',
+        'languages':     ', '.join(lang.lang_code for lang in book.languages) if book.languages else '',
+        'identifiers':   identifiers_str,
+        'isbn':          isbn_val,
+        'uuid':          book.uuid or '',
+        'rating':        (str(book.ratings[0].rating // 2) if book.ratings else ''),
+        'comments':      (book.comments[0].text if book.comments else ''),
+        'description':   (book.comments[0].text if book.comments else ''),
+    }
+
+    for col in cc_columns:
+        if col.datatype == 'composite':
+            continue
+        attr = getattr(book, 'custom_column_' + str(col.id), None)
+        if isinstance(attr, list):
+            val = str(attr[0].value) if attr and attr[0].value is not None else ''
+        elif attr is not None:
+            val = str(attr.value) if attr.value is not None else ''
+        else:
+            val = ''
+        fields['#' + col.label] = val
+
+    return fields
+
+
+# ---------------------------------------------------------------------------
+# Formatter
+# ---------------------------------------------------------------------------
+
+_format_string_re = re.compile(r'^(.*)\|([^\|]*)\|(.*)$', re.DOTALL)
+_compress_spaces = re.compile(r'\s+')
+
+
+class CalibreTemplateFormatter(string.Formatter):
+    """
+    Evaluates calibre simple-mode templates against a calibre-web book.
+
+    Ported from calibre's TemplateFormatter / SafeFormat. Handles:
+      {field}                   — standard book field
+      {field:func(args)}        — field with function applied
+      {#label}                  — custom column
+      {#label:func(args)}       — custom column with function
+      {field|prefix|suffix|}    — conditional prefix/suffix wrapper
+    """
+
+    def __init__(self, book, cc_columns):
+        super().__init__()
+        self._fields = _book_fields(book, cc_columns)
+
+    def get_value(self, key, args, kwargs):
+        if not key or not isinstance(key, str):
+            return ''
+        return self._fields.get(key, self._fields.get(key.lower(), ''))
+
+    def format_field(self, val, fmt):
+        if not fmt:
+            return val or ''
+
+        # Handle |prefix|fmt|suffix| conditional wrapper
+        m = _format_string_re.match(fmt)
+        if m:
+            fmt, prefix, suffix = m.groups()
+        else:
+            prefix = suffix = ''
+
+        p = fmt.find('(')
+        if p >= 0 and fmt.endswith(')'):
+            colon = fmt[:p].find(':')
+            colon = 0 if colon < 0 else colon + 1
+            fname = fmt[colon:p].strip()
+
+            entry = _REGISTRY.get(fname)
+            if entry:
+                arg_count, fn = entry
+                if arg_count == 1:
+                    # No extra args — just val
+                    extra_args = []
+                elif arg_count == 2:
+                    # One extra arg; don't scan (avoids needing to escape commas)
+                    extra_args = [fmt[p + 1:-1]]
+                else:
+                    extra_args = _parse_args(fmt[p + 1:])
+                try:
+                    val = fn(val, *extra_args)
+                    if not isinstance(val, str):
+                        val = str(val) if val is not None else ''
+                except Exception:
+                    val = ''
+
+        if not val:
+            return ''
+        if prefix or suffix:
+            return prefix + val + suffix
+        return val
+
+    def safe_format(self, template):
+        try:
+            ans = self.vformat(template, [], self._fields)
+            return _compress_spaces.sub(' ', ans).strip()
+        except Exception:
+            return ''
+
+
+def evaluate_composite_template(template, book, cc_columns):
+    return CalibreTemplateFormatter(book, cc_columns).safe_format(template)

--- a/cps/template_formatter.py
+++ b/cps/template_formatter.py
@@ -11,6 +11,10 @@ import string
 from functools import lru_cache
 from math import ceil, floor, modf, trunc
 
+from . import logger
+
+log = logger.create()
+
 
 # ---------------------------------------------------------------------------
 # Argument scanner — ported from calibre's args_scanner()
@@ -520,8 +524,11 @@ class CalibreTemplateFormatter(string.Formatter):
                     val = fn(val, *extra_args)
                     if not isinstance(val, str):
                         val = str(val) if val is not None else ''
-                except Exception:
+                except Exception as ex:
+                    log.warning("Template function %r failed (args=%r): %s", fname, extra_args, ex)
                     val = ''
+            elif fname:
+                log.warning("Template references unknown function %r", fname)
 
         if not val:
             return ''
@@ -529,13 +536,15 @@ class CalibreTemplateFormatter(string.Formatter):
             return prefix + val + suffix
         return val
 
-    def safe_format(self, template):
+    def safe_format(self, template, column_name=None):
         try:
             ans = self.vformat(template, [], self._fields)
             return _compress_spaces.sub(' ', ans).strip()
-        except Exception:
+        except Exception as ex:
+            ctx = ' (column %r)' % column_name if column_name else ''
+            log.warning("Composite template evaluation failed%s for template %r: %s", ctx, template, ex)
             return ''
 
 
-def evaluate_composite_template(template, book, cc_columns):
-    return CalibreTemplateFormatter(book, cc_columns).safe_format(template)
+def evaluate_composite_template(template, book, cc_columns, column_name=None):
+    return CalibreTemplateFormatter(book, cc_columns).safe_format(template, column_name=column_name)

--- a/cps/templates/config_view_edit.html
+++ b/cps/templates/config_view_edit.html
@@ -90,7 +90,6 @@
         {% set hide_col_ids = (conf.config_cc_hidden_columns or '').split(',') %}
         <ul id="cc-order-list" class="list-group">
           {% for col in allColumns %}
-          {% if col.id != conf.config_subtitle_column %}
           <li class="list-group-item cc-order-item" data-id="{{ col.id }}">
             <span class="glyphicon glyphicon-move cc-drag-handle"></span>
             <span class="cc-col-name">{{ col.name }}</span>
@@ -103,7 +102,6 @@
               {{_('Link')}}
             </label>
           </li>
-          {% endif %}
           {% endfor %}
         </ul>
       </div>

--- a/cps/templates/config_view_edit.html
+++ b/cps/templates/config_view_edit.html
@@ -72,6 +72,32 @@
         </div>
       </div>
     </div>
+  {% if allColumns|length > 0 %}
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h4 class="panel-title">
+        <a class="accordion-toggle" data-toggle="collapse" href="#collapseeight">
+          <span class="glyphicon glyphicon-plus"></span>
+          {{_('Custom Column Display Order')}}
+        </a>
+      </h4>
+    </div>
+    <div id="collapseeight" class="panel-collapse collapse">
+      <div class="panel-body">
+        <p class="help-block">{{_('Drag to set the display order of custom columns in book details.')}}</p>
+        <input type="hidden" name="config_cc_display_order" id="config_cc_display_order" value="">
+        <ul id="cc-order-list" class="list-group">
+          {% for col in allColumns %}
+          <li class="list-group-item cc-order-item" data-id="{{ col.id }}">
+            <span class="glyphicon glyphicon-move cc-drag-handle"></span>
+            {{ col.name }}
+          </li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+  </div>
+  {% endif %}
   <div class="panel panel-default">
     <div class="panel-heading">
       <h4 class="panel-title">
@@ -181,6 +207,24 @@
 {{ restrict_modal() }}
 {% endblock %}
 {% block js %}
+<script src="{{ url_for('static', filename='js/libs/Sortable.min.js') }}"></script>
+<script>
+(function() {
+  var list = document.getElementById('cc-order-list');
+  var orderInput = document.getElementById('config_cc_display_order');
+  if (!list || !orderInput) return;
+  function updateOrder() {
+    var items = list.querySelectorAll('.cc-order-item');
+    var ids = Array.prototype.map.call(items, function(el) { return el.getAttribute('data-id'); });
+    orderInput.value = ids.join(',');
+  }
+  updateOrder();
+  Sortable.create(list, {
+    animation: 150,
+    onEnd: updateOrder
+  });
+})();
+</script>
 <script src="{{ url_for('static', filename='js/libs/bootstrap-table/bootstrap-table.min.js') }}"></script>
 <script src="{{ url_for('static', filename='js/libs/bootstrap-table/bootstrap-table-editable.min.js') }}"></script>
 <script src="{{ url_for('static', filename='js/libs/bootstrap-table/bootstrap-editable.min.js') }}"></script>

--- a/cps/templates/config_view_edit.html
+++ b/cps/templates/config_view_edit.html
@@ -87,6 +87,7 @@
         <p class="help-block">{{_('Drag to set the display order of custom columns in book details.')}}</p>
         <input type="hidden" name="config_cc_display_order" id="config_cc_display_order" value="">
         {% set link_col_ids = (conf.config_cc_link_columns or '').split(',') %}
+        {% set hide_col_ids = (conf.config_cc_hidden_columns or '').split(',') %}
         <ul id="cc-order-list" class="list-group">
           {% for col in allColumns %}
           {% if col.id != conf.config_subtitle_column %}
@@ -96,6 +97,10 @@
             <label class="cc-link-label">
               <input type="checkbox" name="cc_link_{{ col.id }}" {% if col.id|string in link_col_ids %}checked{% endif %}>
               {{_('Link')}}
+            </label>
+            <label class="cc-link-label">
+              <input type="checkbox" name="cc_hide_{{ col.id }}" {% if col.id|string in hide_col_ids %}checked{% endif %}>
+              {{_('Hide')}}
             </label>
           </li>
           {% endif %}

--- a/cps/templates/config_view_edit.html
+++ b/cps/templates/config_view_edit.html
@@ -93,14 +93,14 @@
           {% if col.id != conf.config_subtitle_column %}
           <li class="list-group-item cc-order-item" data-id="{{ col.id }}">
             <span class="glyphicon glyphicon-move cc-drag-handle"></span>
-            {{ col.name }}
-            <label class="cc-link-label">
-              <input type="checkbox" name="cc_link_{{ col.id }}" {% if col.id|string in link_col_ids %}checked{% endif %}>
-              {{_('Link')}}
-            </label>
+            <span class="cc-col-name">{{ col.name }}</span>
             <label class="cc-link-label">
               <input type="checkbox" name="cc_hide_{{ col.id }}" {% if col.id|string in hide_col_ids %}checked{% endif %}>
               {{_('Hide')}}
+            </label>
+            <label class="cc-link-label">
+              <input type="checkbox" name="cc_link_{{ col.id }}" {% if col.id|string in link_col_ids %}checked{% endif %}>
+              {{_('Link')}}
             </label>
           </li>
           {% endif %}

--- a/cps/templates/config_view_edit.html
+++ b/cps/templates/config_view_edit.html
@@ -86,12 +86,19 @@
       <div class="panel-body">
         <p class="help-block">{{_('Drag to set the display order of custom columns in book details.')}}</p>
         <input type="hidden" name="config_cc_display_order" id="config_cc_display_order" value="">
+        {% set link_col_ids = (conf.config_cc_link_columns or '').split(',') %}
         <ul id="cc-order-list" class="list-group">
           {% for col in allColumns %}
+          {% if col.id != conf.config_subtitle_column %}
           <li class="list-group-item cc-order-item" data-id="{{ col.id }}">
             <span class="glyphicon glyphicon-move cc-drag-handle"></span>
             {{ col.name }}
+            <label class="cc-link-label">
+              <input type="checkbox" name="cc_link_{{ col.id }}" {% if col.id|string in link_col_ids %}checked{% endif %}>
+              {{_('Link')}}
+            </label>
           </li>
+          {% endif %}
           {% endfor %}
         </ul>
       </div>
@@ -221,6 +228,8 @@
   updateOrder();
   Sortable.create(list, {
     animation: 150,
+    filter: 'input, label',
+    preventOnFilter: false,
     onEnd: updateOrder
   });
 })();

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -236,7 +236,9 @@
                                         {% elif c.datatype == 'series' %}
                                             {{ '%s [%s]' % (column.value, column.extra|formatfloat(2)) }}
                                         {% elif c.datatype == 'text' %}
-                                            {{ column.value.strip() }}{% if not loop.last %}, {% endif %}
+                                            {% if c.id in cc_link_cols %}<a href="{{ url_for('web.books_list', data='search', sort_param='stored', query=column.value.strip()) }}">{{ column.value.strip() }}</a>{% else %}{{ column.value.strip() }}{% endif %}{% if not loop.last %}, {% endif %}
+                                            {% elif c.datatype == 'enumeration' %}
+                                                {% if c.id in cc_link_cols %}<a href="{{ url_for('web.books_list', data='search', sort_param='stored', query=column.value) }}">{{ column.value }}</a>{% else %}{{ column.value }}{% endif %}
                                         {% else %}
                                             {{ column.value }}
                                         {% endif %}

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -239,8 +239,8 @@
                                             <span class="glyphicon glyphicon-remove"></span>
                                         {% endif %}
                                     {% else %}
-                                        {% if c.datatype == 'float' %}
-                                            {{ column.value|formatfloat(2) }}
+                                        {% if c.datatype == 'float' or c.datatype == 'int' %}
+                                            {{ column.value|format_cc_number(c.display) }}
                                         {% elif c.datatype == 'datetime' %}
                                             {{ column.value|formatdate }}
                                         {% elif c.datatype == 'comments' %}

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -236,9 +236,9 @@
                                         {% elif c.datatype == 'series' %}
                                             {{ '%s [%s]' % (column.value, column.extra|formatfloat(2)) }}
                                         {% elif c.datatype == 'text' %}
-                                            {% if c.id in cc_link_cols %}<a href="{{ url_for('search.advanced_search') }}?custom_column_{{ c.id }}={{ column.value.strip() }}">{{ column.value.strip() }}</a>{% else %}{{ column.value.strip() }}{% endif %}{% if not loop.last %}, {% endif %}
+                                            {% if c.id in cc_link_cols %}<a href="{{ url_for('search.cc_search') }}?custom_column_{{ c.id }}={{ column.value.strip() }}">{{ column.value.strip() }}</a>{% else %}{{ column.value.strip() }}{% endif %}{% if not loop.last %}, {% endif %}
                                             {% elif c.datatype == 'enumeration' %}
-                                                {% if c.id in cc_link_cols %}<a href="{{ url_for('search.advanced_search') }}?custom_column_{{ c.id }}={{ column.value }}">{{ column.value }}</a>{% else %}{{ column.value }}{% endif %}
+                                                {% if c.id in cc_link_cols %}<a href="{{ url_for('search.cc_search') }}?custom_column_{{ c.id }}={{ column.value }}">{{ column.value }}</a>{% else %}{{ column.value }}{% endif %}
                                         {% else %}
                                             {{ column.value }}
                                         {% endif %}

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -236,9 +236,9 @@
                                         {% elif c.datatype == 'series' %}
                                             {{ '%s [%s]' % (column.value, column.extra|formatfloat(2)) }}
                                         {% elif c.datatype == 'text' %}
-                                            {% if c.id in cc_link_cols %}<a href="{{ url_for('search.cc_search') }}?custom_column_{{ c.id }}={{ column.value.strip() }}">{{ column.value.strip() }}</a>{% else %}{{ column.value.strip() }}{% endif %}{% if not loop.last %}, {% endif %}
+                                            {% if c.id in cc_link_cols %}<a href="{{ url_for('search.cc_search', column=c.id, value=column.value.strip()) }}">{{ column.value.strip() }}</a>{% else %}{{ column.value.strip() }}{% endif %}{% if not loop.last %}, {% endif %}
                                             {% elif c.datatype == 'enumeration' %}
-                                                {% if c.id in cc_link_cols %}<a href="{{ url_for('search.cc_search') }}?custom_column_{{ c.id }}={{ column.value }}">{{ column.value }}</a>{% else %}{{ column.value }}{% endif %}
+                                                {% if c.id in cc_link_cols %}<a href="{{ url_for('search.cc_search', column=c.id, value=column.value) }}">{{ column.value }}</a>{% else %}{{ column.value }}{% endif %}
                                         {% else %}
                                             {{ column.value }}
                                         {% endif %}

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -213,7 +213,19 @@
 
 
                 {% for c in cc %}
-                    {% if entry['custom_column_' ~ c.id]|length > 0 %}
+                    {% if c.datatype == 'composite' %}
+                            {% set cval = composite_vals.get(c.id) %}
+                            {% if cval and cval.value %}
+                                <div class="real_custom_columns">
+                                    {{ c.name }}:
+                                    {% if cval.contains_html %}
+                                        {{ cval.value|safe }}
+                                    {% else %}
+                                        {{ cval.value }}
+                                    {% endif %}
+                                </div>
+                            {% endif %}
+                        {% elif entry['custom_column_' ~ c.id]|length > 0 %}
                         <div class="real_custom_columns">
                             {{ c.name }}:
                             {% for column in entry['custom_column_' ~ c.id] %}

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -236,9 +236,9 @@
                                         {% elif c.datatype == 'series' %}
                                             {{ '%s [%s]' % (column.value, column.extra|formatfloat(2)) }}
                                         {% elif c.datatype == 'text' %}
-                                            {% if c.id in cc_link_cols %}<a href="{{ url_for('web.books_list', data='search', sort_param='stored', query=column.value.strip()) }}">{{ column.value.strip() }}</a>{% else %}{{ column.value.strip() }}{% endif %}{% if not loop.last %}, {% endif %}
+                                            {% if c.id in cc_link_cols %}<a href="{{ url_for('search.advanced_search') }}?custom_column_{{ c.id }}={{ column.value.strip() }}">{{ column.value.strip() }}</a>{% else %}{{ column.value.strip() }}{% endif %}{% if not loop.last %}, {% endif %}
                                             {% elif c.datatype == 'enumeration' %}
-                                                {% if c.id in cc_link_cols %}<a href="{{ url_for('web.books_list', data='search', sort_param='stored', query=column.value) }}">{{ column.value }}</a>{% else %}{{ column.value }}{% endif %}
+                                                {% if c.id in cc_link_cols %}<a href="{{ url_for('search.advanced_search') }}?custom_column_{{ c.id }}={{ column.value }}">{{ column.value }}</a>{% else %}{{ column.value }}{% endif %}
                                         {% else %}
                                             {{ column.value }}
                                         {% endif %}

--- a/cps/templates/feed.xml
+++ b/cps/templates/feed.xml
@@ -76,7 +76,7 @@
 
     {% if cc|length > 0 %}
         {% for c in cc %}
-            {% if entry.Books['custom_column_' ~ c.id]|length > 0 %}
+            {% if c.datatype != 'composite' and entry.Books['custom_column_' ~ c.id]|length > 0 %}
                 {{ c.name }}:
                 {% for column in entry.Books['custom_column_' ~ c.id] %}
                     {% if c.datatype == 'rating' %}

--- a/cps/templates/listenmp3.html
+++ b/cps/templates/listenmp3.html
@@ -115,6 +115,7 @@
 
 
         {% for c in cc %}
+        {% if c.datatype != 'composite' %}
         <div class="real_custom_columns">
           {% if entry['custom_column_' ~ c.id]|length > 0 %}
             {{ c.name }}:
@@ -147,6 +148,7 @@
             {% endfor %}
           {% endif %}
         </div>
+        {% endif %}
         {% endfor %}
       {% endif %}
       {% if not current_user.is_anonymous %}

--- a/cps/templates/search_form.html
+++ b/cps/templates/search_form.html
@@ -157,6 +157,7 @@
 
     {% if cc|length > 0 %}
     {% for c in cc %}
+    {% if c.datatype != 'composite' %}
     <div class="form-group">
       <!--input type="number" step="1" class="form-control" name="{{ 'custom_column_' ~ c.id }}" id="{{ 'custom_column_' ~ c.id }}" value=""-->
       <label for="{{ 'custom_column_' ~ c.id }}">{{ c.name }}</label>
@@ -241,6 +242,7 @@
       <input type="number" min="1" max="5" step="0.5" class="form-control" name="{{ 'custom_column_' ~ c.id }}" id="{{ 'custom_column_' ~ c.id }}">
       {% endif %}
     </div>
+    {% endif %}
     {% endfor %}
     {% endif %}
 

--- a/cps/web.py
+++ b/cps/web.py
@@ -19,6 +19,7 @@
 #  along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import re
 import json
 import mimetypes
 import chardet  # dependency of requests
@@ -1615,6 +1616,23 @@ def read_book(book_id, book_format):
         return redirect(url_for("web.index"))
 
 
+def _evaluate_composite_template(template, book, cc_columns):
+    """Substitute {#label} references in a composite column template with actual column values."""
+    label_to_value = {}
+    for col in cc_columns:
+        if col.datatype == 'composite':
+            continue
+        attr = getattr(book, 'custom_column_' + str(col.id), None)
+        if isinstance(attr, list):
+            val = str(attr[0].value) if attr and attr[0].value is not None else ''
+        elif attr is not None:
+            val = str(attr.value) if attr.value is not None else ''
+        else:
+            val = ''
+        label_to_value[col.label] = val
+    return re.sub(r'\{#(\w+)\}', lambda m: label_to_value.get(m.group(1), ''), template)
+
+
 @web.route("/book/<int:book_id>")
 @login_required_if_no_ano
 def show_book(book_id):
@@ -1630,6 +1648,19 @@ def show_book(book_id):
                 lang_index].lang_code)
         cc = calibre_db.get_cc_columns(config, filter_config_custom_read=True)
         cc_link_cols = set(int(x) for x in (config.config_cc_link_columns or '').split(',') if x.strip())
+        composite_vals = {}
+        for col in cc:
+            if col.datatype == 'composite':
+                try:
+                    display = col.get_display_dict()
+                    template = display.get('composite_template', '')
+                    contains_html = display.get('contains_html', False)
+                    composite_vals[col.id] = {
+                        'value': _evaluate_composite_template(template, entry, cc),
+                        'contains_html': contains_html,
+                    }
+                except Exception as ex:
+                    log.debug("Failed to evaluate composite column %r (id=%s): %s", col.name, col.id, ex)
         book_in_shelves = []
         shelves = ub.session.query(ub.BookShelf).filter(ub.BookShelf.book_id == book_id).all()
         for sh in shelves:
@@ -1656,6 +1687,7 @@ def show_book(book_id):
                                      entry=entry,
                                      cc=cc,
                                      cc_link_cols=cc_link_cols,
+                                     composite_vals=composite_vals,
                                      is_xhr=request.headers.get('X-Requested-With') == 'XMLHttpRequest',
                                      title=entry.title,
                                      books_shelfs=book_in_shelves,

--- a/cps/web.py
+++ b/cps/web.py
@@ -1629,6 +1629,7 @@ def show_book(book_id):
             entry.languages[lang_index].language_name = isoLanguages.get_language_name(get_locale(), entry.languages[
                 lang_index].lang_code)
         cc = calibre_db.get_cc_columns(config, filter_config_custom_read=True)
+        cc_link_cols = set(int(x) for x in (config.config_cc_link_columns or '').split(',') if x.strip())
         book_in_shelves = []
         shelves = ub.session.query(ub.BookShelf).filter(ub.BookShelf.book_id == book_id).all()
         for sh in shelves:
@@ -1654,6 +1655,7 @@ def show_book(book_id):
         return render_title_template('detail.html',
                                      entry=entry,
                                      cc=cc,
+                                     cc_link_cols=cc_link_cols,
                                      is_xhr=request.headers.get('X-Requested-With') == 'XMLHttpRequest',
                                      title=entry.title,
                                      books_shelfs=book_in_shelves,

--- a/cps/web.py
+++ b/cps/web.py
@@ -1631,6 +1631,8 @@ def show_book(book_id):
             entry.languages[lang_index].language_name = isoLanguages.get_language_name(get_locale(), entry.languages[
                 lang_index].lang_code)
         cc = calibre_db.get_cc_columns(config, filter_config_custom_read=True)
+        log.debug("show_book %d: cc columns=%r", book_id,
+                  [(c.id, c.label, c.datatype) for c in cc])
         cc_link_cols = set(int(x) for x in (config.config_cc_link_columns or '').split(',') if x.strip())
         composite_vals = {}
         for col in cc:

--- a/cps/web.py
+++ b/cps/web.py
@@ -1634,6 +1634,9 @@ def show_book(book_id):
         log.debug("show_book %d: cc columns=%r", book_id,
                   [(c.id, c.label, c.datatype) for c in cc])
         cc_link_cols = set(int(x) for x in (config.config_cc_link_columns or '').split(',') if x.strip())
+        # Pass all columns (including hidden) to composite evaluation so that
+        # templates referencing hidden columns still resolve correctly.
+        all_cc_for_composite = calibre_db.get_cc_columns(config, filter_config_custom_read=True, filter_hidden=False)
         composite_vals = {}
         for col in cc:
             if col.datatype == 'composite':
@@ -1642,7 +1645,7 @@ def show_book(book_id):
                     template = display.get('composite_template', '')
                     contains_html = display.get('contains_html', False)
                     composite_vals[col.id] = {
-                        'value': evaluate_composite_template(template, entry, cc, column_name=col.name),
+                        'value': evaluate_composite_template(template, entry, all_cc_for_composite, column_name=col.name),
                         'contains_html': contains_html,
                     }
                 except Exception as ex:

--- a/cps/web.py
+++ b/cps/web.py
@@ -1640,11 +1640,11 @@ def show_book(book_id):
                     template = display.get('composite_template', '')
                     contains_html = display.get('contains_html', False)
                     composite_vals[col.id] = {
-                        'value': evaluate_composite_template(template, entry, cc),
+                        'value': evaluate_composite_template(template, entry, cc, column_name=col.name),
                         'contains_html': contains_html,
                     }
                 except Exception as ex:
-                    log.debug("Failed to evaluate composite column %r (id=%s): %s", col.name, col.id, ex)
+                    log.warning("Failed to set up composite column %r (id=%s): %s", col.name, col.id, ex)
         book_in_shelves = []
         shelves = ub.session.query(ub.BookShelf).filter(ub.BookShelf.book_id == book_id).all()
         for sh in shelves:

--- a/cps/web.py
+++ b/cps/web.py
@@ -59,6 +59,7 @@ from .services.worker import WorkerThread
 from .tasks_status import render_task_status
 from .usermanagement import user_login_required
 from .string_helper import strip_whitespaces
+from .template_formatter import evaluate_composite_template
 
 
 feature_support = {
@@ -1616,23 +1617,6 @@ def read_book(book_id, book_format):
         return redirect(url_for("web.index"))
 
 
-def _evaluate_composite_template(template, book, cc_columns):
-    """Substitute {#label} references in a composite column template with actual column values."""
-    label_to_value = {}
-    for col in cc_columns:
-        if col.datatype == 'composite':
-            continue
-        attr = getattr(book, 'custom_column_' + str(col.id), None)
-        if isinstance(attr, list):
-            val = str(attr[0].value) if attr and attr[0].value is not None else ''
-        elif attr is not None:
-            val = str(attr.value) if attr.value is not None else ''
-        else:
-            val = ''
-        label_to_value[col.label] = val
-    return re.sub(r'\{#(\w+)\}', lambda m: label_to_value.get(m.group(1), ''), template)
-
-
 @web.route("/book/<int:book_id>")
 @login_required_if_no_ano
 def show_book(book_id):
@@ -1656,7 +1640,7 @@ def show_book(book_id):
                     template = display.get('composite_template', '')
                     contains_html = display.get('contains_html', False)
                     composite_vals[col.id] = {
-                        'value': _evaluate_composite_template(template, entry, cc),
+                        'value': evaluate_composite_template(template, entry, cc),
                         'contains_html': contains_html,
                     }
                 except Exception as ex:


### PR DESCRIPTION
- Adding composite columns, using the code from calibre desktop.
- Use formatting field from custom columns when displaying their data.
- Add a new UI config section with drag-and-drop ordering of custom columns, along with option to make a column show as a link, which navigates to a search for books with matching values for that column.
- Also adds an option to hide a custom column from the details view.

<img width="907" height="534" alt="image" src="https://github.com/user-attachments/assets/492bd9f3-50c0-48ce-a92f-ffa91504a15e" />

Issue: #2459
