### PR TITLE
Configurable second series field

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -46,6 +46,7 @@ from sqlalchemy.sql.expression import func, or_, text
 from . import constants, logger, helper, services, cli_param
 from . import db, calibre_db, ub, web_server, config, updater_thread, gdriveutils, \
     kobo_sync_status, schedule
+from .web import _s2_key
 from .helper import check_valid_domain, send_test_mail, reset_password, generate_password_hash, check_email, \
     valid_email, check_username
 from .embed_helper import get_calibre_binarypath
@@ -171,7 +172,7 @@ def before_request():
     g.config_authors_max = config.config_authors_max
     g.config_show_series2_on_book_list = config.config_show_series2_on_book_list
     g.config_series2_label = config.config_series2_label
-    g.series2_key = (config.config_series2_slug or config.config_series2_label or '').strip() or 'series2'
+    g.series2_key = _s2_key
     if ('/static/' not in request.path and not config.db_configured and
         request.endpoint not in ('admin.ajax_db_config',
                                  'admin.simulatedbchange',

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -59,6 +59,56 @@ from .string_helper import strip_whitespaces
 
 log = logger.create()
 
+_SERIES2_ICON_NAMES = [
+    'adjust', 'alert', 'align-center', 'align-justify', 'align-left', 'align-right',
+    'apple', 'arrow-down', 'arrow-left', 'arrow-right', 'arrow-up', 'asterisk',
+    'baby-formula', 'backward', 'ban-circle', 'barcode', 'bed', 'bell', 'bishop',
+    'bitcoin', 'blackboard', 'bold', 'book', 'bookmark', 'briefcase', 'btc',
+    'bullhorn', 'calendar', 'camera', 'cd', 'certificate', 'check', 'chevron-down',
+    'chevron-left', 'chevron-right', 'chevron-up', 'circle-arrow-down',
+    'circle-arrow-left', 'circle-arrow-right', 'circle-arrow-up', 'cloud',
+    'cloud-download', 'cloud-upload', 'cog', 'collapse-down', 'collapse-up',
+    'comment', 'compressed', 'console', 'copy', 'copyright-mark', 'credit-card',
+    'cutlery', 'dashboard', 'download', 'download-alt', 'duplicate', 'earphone',
+    'edit', 'education', 'eject', 'envelope', 'equalizer', 'erase', 'eur', 'euro',
+    'exclamation-sign', 'expand', 'export', 'eye-close', 'eye-open', 'facetime-video',
+    'fast-backward', 'fast-forward', 'file', 'film', 'filter', 'fire', 'flag',
+    'flash', 'floppy-disk', 'floppy-open', 'floppy-remove', 'floppy-save',
+    'floppy-saved', 'folder-close', 'folder-open', 'font', 'forward', 'fullscreen',
+    'gbp', 'gift', 'glass', 'globe', 'grain', 'hand-down', 'hand-left', 'hand-right',
+    'hand-up', 'hdd', 'hd-video', 'header', 'headphones', 'heart', 'heart-empty',
+    'home', 'hourglass', 'ice-lolly', 'ice-lolly-tasted', 'import', 'inbox',
+    'indent-left', 'indent-right', 'info-sign', 'italic', 'jpy', 'king', 'knight',
+    'lamp', 'leaf', 'level-up', 'link', 'list', 'list-alt', 'lock', 'log-in',
+    'log-out', 'magnet', 'map-marker', 'menu-down', 'menu-hamburger', 'menu-left',
+    'menu-right', 'menu-up', 'minus', 'minus-sign', 'modal-window', 'move', 'music',
+    'new-window', 'object-align-bottom', 'object-align-horizontal', 'object-align-left',
+    'object-align-right', 'object-align-top', 'object-align-vertical', 'off', 'oil',
+    'ok', 'ok-circle', 'ok-sign', 'open', 'open-file', 'option-horizontal',
+    'option-vertical', 'paperclip', 'paste', 'pause', 'pawn', 'pencil', 'phone',
+    'phone-alt', 'picture', 'piggy-bank', 'plane', 'play', 'play-circle', 'plus',
+    'plus-sign', 'print', 'pushpin', 'qrcode', 'queen', 'question-sign', 'random',
+    'record', 'refresh', 'registration-mark', 'remove', 'remove-circle', 'remove-sign',
+    'repeat', 'resize-full', 'resize-horizontal', 'resize-small', 'resize-vertical',
+    'retweet', 'road', 'rub', 'ruble', 'save', 'saved', 'save-file', 'scale',
+    'scissors', 'screenshot', 'sd-video', 'search', 'send', 'share', 'share-alt',
+    'shopping-cart', 'signal', 'sort', 'sort-by-alphabet', 'sort-by-alphabet-alt',
+    'sort-by-attributes', 'sort-by-attributes-alt', 'sort-by-order', 'sort-by-order-alt',
+    'sound-5-1', 'sound-6-1', 'sound-7-1', 'sound-dolby', 'sound-stereo', 'star',
+    'star-empty', 'stats', 'step-backward', 'step-forward', 'stop', 'subscript',
+    'subtitles', 'sunglasses', 'superscript', 'tag', 'tags', 'tasks', 'tent',
+    'text-background', 'text-color', 'text-height', 'text-size', 'text-width', 'th',
+    'th-large', 'th-list', 'thumbs-down', 'thumbs-up', 'time', 'tint', 'tower',
+    'transfer', 'trash', 'tree-conifer', 'tree-deciduous', 'triangle-bottom',
+    'triangle-left', 'triangle-right', 'triangle-top', 'unchecked', 'upload', 'usd',
+    'user', 'volume-down', 'volume-off', 'volume-up', 'warning-sign', 'wrench', 'xbt',
+    'yen', 'zoom-in', 'zoom-out',
+]
+SERIES2_ICON_OPTIONS = [
+    ('glyphicon-' + n, ' '.join(w.capitalize() for w in n.split('-')))
+    for n in _SERIES2_ICON_NAMES
+]
+
 feature_support = {
     'ldap': bool(services.ldap),
     'goodreads': bool(services.goodreads_support),
@@ -291,6 +341,7 @@ def view_configuration():
     return render_title_template("config_view_edit.html", conf=config, readColumns=read_column,
                                  restrictColumns=restrict_columns,
                                  series2Columns=series2_columns,
+                                 series2Icons=SERIES2_ICON_OPTIONS,
                                  languages=languages,
                                  translations=translations,
                                  title=_("UI Configuration"), page="uiconfig")
@@ -591,6 +642,7 @@ def update_view_configuration():
         return view_configuration()
     _config_int(to_save, "config_series2_column")
     _config_string(to_save, "config_series2_label")
+    _config_string(to_save, "config_series2_icon")
     _config_checkbox(to_save, "config_show_series2_on_book_list")
 
     if not check_valid_restricted_column(to_save.get("config_restricted_column", "0")):

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -119,6 +119,8 @@ def before_request():
     g.allow_upload = config.config_uploading
     g.current_theme = config.config_theme
     g.config_authors_max = config.config_authors_max
+    g.config_show_series2_on_book_list = config.config_show_series2_on_book_list
+    g.config_series2_label = config.config_series2_label
     if ('/static/' not in request.path and not config.db_configured and
         request.endpoint not in ('admin.ajax_db_config',
                                  'admin.simulatedbchange',
@@ -589,6 +591,7 @@ def update_view_configuration():
         return view_configuration()
     _config_int(to_save, "config_series2_column")
     _config_string(to_save, "config_series2_label")
+    _config_checkbox(to_save, "config_show_series2_on_book_list")
 
     if not check_valid_restricted_column(to_save.get("config_restricted_column", "0")):
         flash(_("Invalid Restricted Column"), category="error")

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -171,7 +171,7 @@ def before_request():
     g.config_authors_max = config.config_authors_max
     g.config_show_series2_on_book_list = config.config_show_series2_on_book_list
     g.config_series2_label = config.config_series2_label
-    g.series2_key = (config.config_series2_slug or '').strip() or 'series2'
+    g.series2_key = (config.config_series2_slug or config.config_series2_label or '').strip() or 'series2'
     if ('/static/' not in request.path and not config.db_configured and
         request.endpoint not in ('admin.ajax_db_config',
                                  'admin.simulatedbchange',

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -282,10 +282,13 @@ def view_configuration():
         .filter(and_(db.CustomColumns.datatype == 'bool', db.CustomColumns.mark_for_delete == 0)).all()
     restrict_columns = calibre_db.session.query(db.CustomColumns) \
         .filter(and_(db.CustomColumns.datatype == 'text', db.CustomColumns.mark_for_delete == 0)).all()
+    series2_columns = calibre_db.session.query(db.CustomColumns) \
+        .filter(and_(db.CustomColumns.datatype == 'series', db.CustomColumns.mark_for_delete == 0)).all()
     languages = calibre_db.speaking_language()
     translations = get_available_locale()
     return render_title_template("config_view_edit.html", conf=config, readColumns=read_column,
                                  restrictColumns=restrict_columns,
+                                 series2Columns=series2_columns,
                                  languages=languages,
                                  translations=translations,
                                  title=_("UI Configuration"), page="uiconfig")
@@ -579,6 +582,13 @@ def update_view_configuration():
         log.debug("Invalid Read column")
         return view_configuration()
     _config_int(to_save, "config_read_column")
+
+    if not check_valid_series2_column(to_save.get("config_series2_column", "0")):
+        flash(_("Invalid Second Series Column"), category="error")
+        log.debug("Invalid Series2 column")
+        return view_configuration()
+    _config_int(to_save, "config_series2_column")
+    _config_string(to_save, "config_series2_label")
 
     if not check_valid_restricted_column(to_save.get("config_restricted_column", "0")):
         flash(_("Invalid Restricted Column"), category="error")
@@ -958,6 +968,14 @@ def check_valid_read_column(column):
     if column != "0":
         if not calibre_db.session.query(db.CustomColumns).filter(db.CustomColumns.id == column) \
           .filter(and_(db.CustomColumns.datatype == 'bool', db.CustomColumns.mark_for_delete == 0)).all():
+            return False
+    return True
+
+
+def check_valid_series2_column(column):
+    if column != "0":
+        if not calibre_db.session.query(db.CustomColumns).filter(db.CustomColumns.id == column) \
+          .filter(and_(db.CustomColumns.datatype == 'series', db.CustomColumns.mark_for_delete == 0)).all():
             return False
     return True
 

--- a/cps/admin.py
+++ b/cps/admin.py
@@ -171,6 +171,7 @@ def before_request():
     g.config_authors_max = config.config_authors_max
     g.config_show_series2_on_book_list = config.config_show_series2_on_book_list
     g.config_series2_label = config.config_series2_label
+    g.series2_key = (config.config_series2_slug or '').strip() or 'series2'
     if ('/static/' not in request.path and not config.db_configured and
         request.endpoint not in ('admin.ajax_db_config',
                                  'admin.simulatedbchange',
@@ -642,6 +643,7 @@ def update_view_configuration():
         return view_configuration()
     _config_int(to_save, "config_series2_column")
     _config_string(to_save, "config_series2_label")
+    _config_string(to_save, "config_series2_slug")
     _config_string(to_save, "config_series2_icon")
     _config_checkbox(to_save, "config_show_series2_on_book_list")
 

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -83,6 +83,8 @@ class _Settings(_Base):
     config_random_books = Column(Integer, default=4)
     config_authors_max = Column(Integer, default=0)
     config_read_column = Column(Integer, default=0)
+    config_series2_column = Column(Integer, default=0)
+    config_series2_label = Column(String, default='')
     config_title_regex = Column(String,
                                 default=r"^(A|The|An|Der|Die|Das|Den|Ein|Eine"
                                         r"|Einen|Dem|Des|Einem|Eines|Le|La|Les|L'|Un|Une)(\s+|(?<='))")

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -85,6 +85,7 @@ class _Settings(_Base):
     config_read_column = Column(Integer, default=0)
     config_series2_column = Column(Integer, default=0)
     config_series2_label = Column(String, default='')
+    config_show_series2_on_book_list = Column(Boolean, default=True)
     config_title_regex = Column(String,
                                 default=r"^(A|The|An|Der|Die|Das|Den|Ein|Eine"
                                         r"|Einen|Dem|Des|Einem|Eines|Le|La|Les|L'|Un|Une)(\s+|(?<='))")

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -85,6 +85,7 @@ class _Settings(_Base):
     config_read_column = Column(Integer, default=0)
     config_series2_column = Column(Integer, default=0)
     config_series2_label = Column(String, default='')
+    config_series2_slug = Column(String, default='series2')
     config_series2_icon = Column(String, default='glyphicon-bookmark')
     config_show_series2_on_book_list = Column(Boolean, default=True)
     config_title_regex = Column(String,

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -85,6 +85,7 @@ class _Settings(_Base):
     config_read_column = Column(Integer, default=0)
     config_series2_column = Column(Integer, default=0)
     config_series2_label = Column(String, default='')
+    config_series2_icon = Column(String, default='glyphicon-bookmark')
     config_show_series2_on_book_list = Column(Boolean, default=True)
     config_title_regex = Column(String,
                                 default=r"^(A|The|An|Der|Die|Das|Den|Ein|Eine"

--- a/cps/constants.py
+++ b/cps/constants.py
@@ -98,7 +98,6 @@ SIDEBAR_FORMAT          = 1 << 14
 SIDEBAR_ARCHIVED        = 1 << 15
 SIDEBAR_DOWNLOAD        = 1 << 16
 SIDEBAR_LIST            = 1 << 17
-SIDEBAR_SERIES2         = 1 << 18
 
 sidebar_settings = {
                 "detail_random": DETAIL_RANDOM,
@@ -117,12 +116,11 @@ sidebar_settings = {
                 "sidebar_archived": SIDEBAR_ARCHIVED,
                 "sidebar_download": SIDEBAR_DOWNLOAD,
                 "sidebar_list": SIDEBAR_LIST,
-                "sidebar_series2": SIDEBAR_SERIES2,
             }
 
 
 ADMIN_USER_ROLES        = sum(r for r in ALL_ROLES.values()) & ~ROLE_ANONYMOUS
-ADMIN_USER_SIDEBAR      = (SIDEBAR_SERIES2 << 1) - 1
+ADMIN_USER_SIDEBAR      = (SIDEBAR_LIST << 1) - 1
 
 UPDATE_STABLE       = 0 << 0
 AUTO_UPDATE_STABLE  = 1 << 0

--- a/cps/constants.py
+++ b/cps/constants.py
@@ -98,6 +98,7 @@ SIDEBAR_FORMAT          = 1 << 14
 SIDEBAR_ARCHIVED        = 1 << 15
 SIDEBAR_DOWNLOAD        = 1 << 16
 SIDEBAR_LIST            = 1 << 17
+SIDEBAR_SERIES2         = 1 << 18
 
 sidebar_settings = {
                 "detail_random": DETAIL_RANDOM,
@@ -116,11 +117,12 @@ sidebar_settings = {
                 "sidebar_archived": SIDEBAR_ARCHIVED,
                 "sidebar_download": SIDEBAR_DOWNLOAD,
                 "sidebar_list": SIDEBAR_LIST,
+                "sidebar_series2": SIDEBAR_SERIES2,
             }
 
 
 ADMIN_USER_ROLES        = sum(r for r in ALL_ROLES.values()) & ~ROLE_ANONYMOUS
-ADMIN_USER_SIDEBAR      = (SIDEBAR_LIST << 1) - 1
+ADMIN_USER_SIDEBAR      = (SIDEBAR_SERIES2 << 1) - 1
 
 UPDATE_STABLE       = 0 << 0
 AUTO_UPDATE_STABLE  = 1 << 0

--- a/cps/db.py
+++ b/cps/db.py
@@ -56,7 +56,56 @@ log = logger.create()
 cc_exceptions = ['composite', 'series']
 cc_classes = {}
 
+# Set by setup_series2_classes(); used by web routes and templates
+series2_cc_class = None
+series2_link_class = None
+
 Base = declarative_base()
+
+
+def setup_series2_classes(cc_id):
+    """Create ORM classes for the configured series2 custom column and attach
+    a Books.series2 relationship, mirroring setup_db_cc_classes for series type."""
+    global series2_cc_class, series2_link_class
+
+    if not cc_id:
+        return
+
+    cc_table_name = 'custom_column_' + str(cc_id)
+    link_table_name = 'books_custom_column_' + str(cc_id) + '_link'
+
+    # Build the value table class (custom_column_<id>)
+    if cc_table_name in Base.metadata.tables:
+        existing = cc_classes.get(cc_id)
+        if existing is None:
+            return
+        series2_cc_class = existing
+    else:
+        ccdict = {'__tablename__': cc_table_name,
+                  'id': Column(Integer, primary_key=True),
+                  'value': Column(String)}
+        series2_cc_class = type(str(cc_table_name), (Base,), ccdict)
+        cc_classes[cc_id] = series2_cc_class
+
+    # Build the link table class (books_custom_column_<id>_link)
+    if link_table_name in Base.metadata.tables:
+        return
+    dicttable = {
+        '__tablename__': link_table_name,
+        'id': Column(Integer, primary_key=True),
+        'book': Column(Integer, ForeignKey('books.id'), primary_key=True),
+        'map_value': Column('value', Integer,
+                            ForeignKey(cc_table_name + '.id'),
+                            primary_key=True),
+        'extra': Column(Float),
+        'asoc': relationship(cc_table_name, uselist=False),
+        'value': association_proxy('asoc', 'value'),
+    }
+    series2_link_class = type(str(link_table_name), (Base,), dicttable)
+
+    # Attach series2 relationship to Books
+    if not hasattr(Books, 'series2'):
+        setattr(Books, 'series2', relationship(series2_link_class))
 
 books_authors_link = Table('books_authors_link', Base.metadata,
                            Column('book', Integer, ForeignKey('books.id'), primary_key=True),
@@ -424,6 +473,7 @@ class Books(Base):
     comments = relationship(Comments, backref='books')
     data = relationship(Data, backref='books')
     series = relationship(Series, secondary=books_series_link, backref='books')
+    series2 = []  # replaced by setup_series2_classes() when config_series2_column is set
     ratings = relationship(Ratings, secondary=books_ratings_link, backref='books')
     languages = relationship(Languages, secondary=books_languages_link, backref='books')
     publishers = relationship(Publishers, secondary=books_publishers_link, backref='books')
@@ -632,6 +682,11 @@ class CalibreDB:
                         relationship(cc_classes[cc_id[0]],
                                      secondary=books_custom_column_links[cc_id[0]],
                                      backref='books'))
+
+        # Set up series2 custom column if configured
+        series2_col_id = getattr(cls.config, 'config_series2_column', 0)
+        if series2_col_id:
+            setup_series2_classes(series2_col_id)
 
     @classmethod
     def check_valid_db(cls, config_calibre_dir, app_db_path, config_calibre_uuid):

--- a/cps/db.py
+++ b/cps/db.py
@@ -103,9 +103,10 @@ def setup_series2_classes(cc_id):
     }
     series2_link_class = type(str(link_table_name), (Base,), dicttable)
 
-    # Attach series2 relationship to Books
-    if not hasattr(Books, 'series2'):
-        setattr(Books, 'series2', relationship(series2_link_class))
+    # Attach series2 relationship to Books, overriding the [] placeholder
+    setattr(Books, 'series2', relationship(series2_link_class))
+    log.debug("setup_series2_classes: cc_id=%s, cc_class=%s, link_class=%s",
+              cc_id, series2_cc_class, series2_link_class)
 
 books_authors_link = Table('books_authors_link', Base.metadata,
                            Column('book', Integer, ForeignKey('books.id'), primary_key=True),

--- a/cps/render_template.py
+++ b/cps/render_template.py
@@ -76,7 +76,8 @@ def get_sidebar_config(kwargs=None):
                     "show_text": _('Show Series Section'), "config_show": True})
     if config.config_series2_column:
         series2_label = config.config_series2_label or 'World'
-        sidebar.append({"glyph": "glyphicon-bookmark", "text": series2_label, "link": 'web.series2_list',
+        series2_icon = config.config_series2_icon or 'glyphicon-bookmark'
+        sidebar.append({"glyph": series2_icon, "text": series2_label, "link": 'web.series2_list',
                         "id": "serie2", "visibility": constants.SIDEBAR_SERIES, 'public': True,
                         "page": "series2", "no_param": True,
                         "show_text": _('Show %(label)s Section', label=series2_label), "config_show": True})

--- a/cps/render_template.py
+++ b/cps/render_template.py
@@ -74,6 +74,12 @@ def get_sidebar_config(kwargs=None):
     sidebar.append({"glyph": "glyphicon-bookmark", "text": _('Series'), "link": 'web.series_list', "id": "serie",
                     "visibility": constants.SIDEBAR_SERIES, 'public': True, "page": "series", "no_param":True,
                     "show_text": _('Show Series Section'), "config_show": True})
+    if config.config_series2_column:
+        series2_label = config.config_series2_label or 'World'
+        sidebar.append({"glyph": "glyphicon-bookmark", "text": series2_label, "link": 'web.series2_list',
+                        "id": "serie2", "visibility": constants.SIDEBAR_SERIES2, 'public': True,
+                        "page": "series2", "no_param": True,
+                        "show_text": _('Show %(label)s Section', label=series2_label), "config_show": True})
     sidebar.append({"glyph": "glyphicon-user", "text": _('Authors'), "link": 'web.author_list', "id": "author",
                     "visibility": constants.SIDEBAR_AUTHOR, 'public': True, "page": "author", "no_param":True,
                     "show_text": _('Show Author Section'), "config_show": True})

--- a/cps/render_template.py
+++ b/cps/render_template.py
@@ -77,7 +77,7 @@ def get_sidebar_config(kwargs=None):
     if config.config_series2_column:
         series2_label = config.config_series2_label or 'World'
         sidebar.append({"glyph": "glyphicon-bookmark", "text": series2_label, "link": 'web.series2_list',
-                        "id": "serie2", "visibility": constants.SIDEBAR_SERIES2, 'public': True,
+                        "id": "serie2", "visibility": constants.SIDEBAR_SERIES, 'public': True,
                         "page": "series2", "no_param": True,
                         "show_text": _('Show %(label)s Section', label=series2_label), "config_show": True})
     sidebar.append({"glyph": "glyphicon-user", "text": _('Authors'), "link": 'web.author_list', "id": "author",

--- a/cps/render_template.py
+++ b/cps/render_template.py
@@ -39,7 +39,7 @@ def get_sidebar_config(kwargs=None):
         content = 'conf' in kwargs
     sidebar = list()
     sidebar.append({"glyph": "glyphicon-book", "text": _('Books'), "link": 'web.index', "id": "new",
-                    "visibility": constants.SIDEBAR_RECENT, 'public': True, "page": "root",
+                    "visibility": constants.SIDEBAR_RECENT, 'public': True, "page": "root", "no_param": True,
                     "show_text": _('Show recent books'), "config_show":False})
     sidebar.append({"glyph": "glyphicon-fire", "text": _('Hot Books'), "link": 'web.books_list', "id": "hot",
                     "visibility": constants.SIDEBAR_HOT, 'public': True, "page": "hot",

--- a/cps/search.py
+++ b/cps/search.py
@@ -55,8 +55,9 @@ def simple_search():
 @login_required_if_no_ano
 def advanced_search():
     values = dict(request.form)
-    params = ['include_tag', 'exclude_tag', 'include_serie', 'exclude_serie', 'include_shelf', 'exclude_shelf',
-              'include_language', 'exclude_language', 'include_extension', 'exclude_extension']
+    params = ['include_tag', 'exclude_tag', 'include_serie', 'exclude_serie', 'include_serie2', 'exclude_serie2',
+              'include_shelf', 'exclude_shelf', 'include_language', 'exclude_language',
+              'include_extension', 'exclude_extension']
     for param in params:
         values[param] = list(request.form.getlist(param))
     flask_session['query'] = json.dumps(values)
@@ -178,6 +179,16 @@ def adv_search_serie(q, include_series_inputs, exclude_series_inputs):
     return q
 
 
+def adv_search_serie2(q, include_inputs, exclude_inputs):
+    if db.series2_link_class is None:
+        return q
+    for serie2 in include_inputs:
+        q = q.filter(db.Books.series2.any(db.series2_link_class.map_value == serie2))
+    for serie2 in exclude_inputs:
+        q = q.filter(not_(db.Books.series2.any(db.series2_link_class.map_value == serie2)))
+    return q
+
+
 def adv_search_shelf(q, include_shelf_inputs, exclude_shelf_inputs):
     if len(include_shelf_inputs):
         in_shelf = (
@@ -265,7 +276,7 @@ def render_adv_search_results(term, offset=None, order=None, limit=None):
 
     # parse multi selects to a complete dict
     tags = dict()
-    elements = ['tag', 'serie', 'shelf', 'language', 'extension']
+    elements = ['tag', 'serie', 'serie2', 'shelf', 'language', 'extension']
     for element in elements:
         tags['include_' + element] = term.get('include_' + element)
         tags['exclude_' + element] = term.get('exclude_' + element)
@@ -347,6 +358,7 @@ def render_adv_search_results(term, offset=None, order=None, limit=None):
             q = q.filter(db.Books.publishers.any(func.lower(db.Publishers.name).ilike("%" + publisher + "%")))
         q = adv_search_tag(q, tags['include_tag'], tags['exclude_tag'])
         q = adv_search_serie(q, tags['include_serie'], tags['exclude_serie'])
+        q = adv_search_serie2(q, tags['include_serie2'], tags['exclude_serie2'])
         q = adv_search_shelf(q, tags['include_shelf'], tags['exclude_shelf'])
         q = adv_search_extension(q, tags['include_extension'], tags['exclude_extension'])
         q = adv_search_language(q, tags['include_language'], tags['exclude_language'])
@@ -412,8 +424,18 @@ def render_prepare_search_form(cc):
         languages = calibre_db.speaking_language()
     else:
         languages = None
+    series2 = []
+    if config.config_series2_column and db.series2_cc_class is not None and db.series2_link_class is not None:
+        series2 = (calibre_db.session.query(db.series2_cc_class)
+                   .join(db.series2_link_class, db.series2_link_class.map_value == db.series2_cc_class.id)
+                   .join(db.Books, db.Books.id == db.series2_link_class.book)
+                   .filter(calibre_db.common_filters())
+                   .group_by(db.series2_link_class.map_value)
+                   .order_by(db.series2_cc_class.value)
+                   .all())
     return render_title_template('search_form.html', tags=tags, languages=languages, extensions=extensions,
-                                 series=series,shelves=shelves, title=_("Advanced Search"), cc=cc, page="advsearch")
+                                 series=series, series2=series2,
+                                 shelves=shelves, title=_("Advanced Search"), cc=cc, page="advsearch")
 
 
 def render_search_results(term, offset=None, order=None, limit=None):

--- a/cps/search.py
+++ b/cps/search.py
@@ -435,6 +435,7 @@ def render_prepare_search_form(cc):
                    .all())
     return render_title_template('search_form.html', tags=tags, languages=languages, extensions=extensions,
                                  series=series, series2=series2,
+                                 series2_label=config.config_series2_label or _("Series"),
                                  shelves=shelves, title=_("Advanced Search"), cc=cc, page="advsearch")
 
 

--- a/cps/static/css/caliBlur.css
+++ b/cps/static/css/caliBlur.css
@@ -260,6 +260,18 @@ body.blur .row-fluid .col-sm-10 {
     pointer-events: none
 }
 
+.series-section {
+    margin-bottom: 10px;
+}
+
+.series-section p {
+    margin-bottom: 5px;
+}
+
+.series-section p:last-child {
+    margin-bottom: 0;
+}
+
 #scnd-nav > li.active a, .authorlist #nav_author a, .catlist #nav_cat a, .langlist #nav_lang a, .serieslist #nav_serie a {
     color: var(--color-primary)
 }

--- a/cps/static/css/caliBlur.css
+++ b/cps/static/css/caliBlur.css
@@ -260,18 +260,6 @@ body.blur .row-fluid .col-sm-10 {
     pointer-events: none
 }
 
-.series-section {
-    margin-bottom: 10px;
-}
-
-.series-section p {
-    margin-bottom: 5px;
-}
-
-.series-section p:last-child {
-    margin-bottom: 0;
-}
-
 #scnd-nav > li.active a, .authorlist #nav_author a, .catlist #nav_cat a, .langlist #nav_lang a, .serieslist #nav_serie a {
     color: var(--color-primary)
 }

--- a/cps/static/css/style.css
+++ b/cps/static/css/style.css
@@ -485,3 +485,11 @@ body > div.container-fluid > div.row-fluid > div.col-sm-2::-webkit-scrollbar {
 body > div.container-fluid  {
   padding-right: 0px;
 }
+
+.series-section {
+    margin-bottom: 10px;
+}
+
+.series-section p {
+    margin-bottom: 5px;
+}

--- a/cps/static/js/main.js
+++ b/cps/static/js/main.js
@@ -856,6 +856,8 @@ $(function() {
 
     $(".update-view").click(function(e) {
         var view = $(this).data("view");
+        var page = $(this).data("page") || "series";
+        var target = $(this).data("target") || "series_view";
         e.preventDefault();
         e.stopPropagation();
         $.ajax({
@@ -863,7 +865,7 @@ $(function() {
             contentType: "application/json; charset=utf-8",
             dataType: "json",
             url: getPath() + "/ajax/view",
-            data: "{\"series\": {\"series_view\": \""+ view +"\"}}",
+            data: "{\"" + page + "\": {\"" + target + "\": \""+ view +"\"}}",
             success: function success() {
                 location.reload();
             }

--- a/cps/templates/author.html
+++ b/cps/templates/author.html
@@ -74,6 +74,14 @@
           ({{entry.Books.series_index|formatfloat(2)}})
         </p>
         {% endif %}
+        {% if g.config_show_series2_on_book_list and entry.Books.series2.__len__() > 0 %}
+        <p class="series">
+          <a href="{{url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
+            {{entry.Books.series2[0].value}}
+          </a>
+          ({{entry.Books.series2[0].extra|formatfloat(2)}})
+        </p>
+        {% endif %}
         {% if entry.Books.ratings.__len__() > 0 %}
         <div class="rating">
           {% for number in range((entry.Books.ratings[0].rating/2)|int(2)) %}

--- a/cps/templates/author.html
+++ b/cps/templates/author.html
@@ -76,7 +76,7 @@
         {% endif %}
         {% if g.config_show_series2_on_book_list and entry.Books.series2.__len__() > 0 %}
         <p class="series">
-          <a href="{{url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
+          <a href="{{url_for('web.books_list', data=g.series2_key, sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
             {{entry.Books.series2[0].value}}
           </a>
           ({{entry.Books.series2[0].extra|formatfloat(2)}})

--- a/cps/templates/config_view_edit.html
+++ b/cps/templates/config_view_edit.html
@@ -2,6 +2,7 @@
 {% block header %}
 <link href="{{ url_for('static', filename='css/libs/bootstrap-table.min.css') }}" rel="stylesheet">
 <link href="{{ url_for('static', filename='css/libs/bootstrap-editable.css') }}" rel="stylesheet">
+<link href="{{ url_for('static', filename='css/libs/bootstrap-select.min.css') }}" rel="stylesheet">
 {% endblock %}
 {% block body %}
 <div class="discover">
@@ -70,6 +71,18 @@
                   <input type="checkbox" name="config_show_series2_on_book_list" id="config_show_series2_on_book_list" {% if conf.config_show_series2_on_book_list %}checked{% endif %}>
                   {{_('Show Second Series on book list pages')}}
                 </label>
+              </div>
+              {% set series2_icon = conf.config_series2_icon or 'glyphicon-bookmark' %}
+              <div id="series2_icon_group" {% if not conf.config_series2_column %}hidden{% endif %}>
+                <label for="config_series2_icon">{{_('Sidebar Icon')}}</label>
+                <select name="config_series2_icon" id="config_series2_icon"
+                        class="selectpicker" data-live-search="true" data-width="100%">
+                  {% for icon_value, icon_label in series2Icons %}
+                  <option value="{{ icon_value }}"
+                          data-content="<span class='glyphicon {{ icon_value }}'></span> {{ icon_label }}"
+                          {% if icon_value == series2_icon %}selected{% endif %}>{{ icon_label }}</option>
+                  {% endfor %}
+                </select>
               </div>
         </div>
         <div class="form-group">
@@ -197,9 +210,14 @@
 {{ restrict_modal() }}
 {% endblock %}
 {% block js %}
+<script src="{{ url_for('static', filename='js/libs/bootstrap-select.min.js') }}"></script>
 <script>
 function updateSeries2Label(sel) {
   document.getElementById('config_series2_label').value = sel.options[sel.selectedIndex].getAttribute('data-name') || '';
+  var group = document.getElementById('series2_icon_group');
+  if (group) {
+    group.hidden = (sel.value === '0' || sel.value === '');
+  }
 }
 (function() {
   var sel = document.getElementById('config_series2_column');

--- a/cps/templates/config_view_edit.html
+++ b/cps/templates/config_view_edit.html
@@ -57,6 +57,16 @@
               </select>
         </div>
         <div class="form-group">
+          <label for="config_series2_column">{{_('Second Series Column')}}</label>
+              <select name="config_series2_column" id="config_series2_column" class="form-control" onchange="updateSeries2Label(this)">
+                <option value="0" data-name="" {% if conf.config_series2_column == 0 %}selected{% endif %}></option>
+                {% for series2Column in series2Columns %}
+                <option value="{{ series2Column.id }}" data-name="{{ series2Column.name }}" {% if series2Column.id == conf.config_series2_column %}selected{% endif %}>{{ series2Column.name }}</option>
+                {% endfor %}
+              </select>
+              <input type="hidden" name="config_series2_label" id="config_series2_label" value="">
+        </div>
+        <div class="form-group">
           <label for="config_restricted_column">{{_('View Restrictions based on Calibre column')}}</label>
               <select name="config_restricted_column" id="config_restricted_column" class="form-control">
                 <option value="0" {% if conf.config_restricted_column == 0 %}selected{% endif %}>{{ _('None') }}</option>
@@ -181,6 +191,15 @@
 {{ restrict_modal() }}
 {% endblock %}
 {% block js %}
+<script>
+function updateSeries2Label(sel) {
+  document.getElementById('config_series2_label').value = sel.options[sel.selectedIndex].getAttribute('data-name') || '';
+}
+(function() {
+  var sel = document.getElementById('config_series2_column');
+  if (sel) { updateSeries2Label(sel); }
+})();
+</script>
 <script src="{{ url_for('static', filename='js/libs/bootstrap-table/bootstrap-table.min.js') }}"></script>
 <script src="{{ url_for('static', filename='js/libs/bootstrap-table/bootstrap-table-editable.min.js') }}"></script>
 <script src="{{ url_for('static', filename='js/libs/bootstrap-table/bootstrap-editable.min.js') }}"></script>

--- a/cps/templates/config_view_edit.html
+++ b/cps/templates/config_view_edit.html
@@ -65,6 +65,12 @@
                 {% endfor %}
               </select>
               <input type="hidden" name="config_series2_label" id="config_series2_label" value="">
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox" name="config_show_series2_on_book_list" id="config_show_series2_on_book_list" {% if conf.config_show_series2_on_book_list %}checked{% endif %}>
+                  {{_('Show Second Series on book list pages')}}
+                </label>
+              </div>
         </div>
         <div class="form-group">
           <label for="config_restricted_column">{{_('View Restrictions based on Calibre column')}}</label>

--- a/cps/templates/config_view_edit.html
+++ b/cps/templates/config_view_edit.html
@@ -60,12 +60,13 @@
         <div class="form-group">
           <label for="config_series2_column">{{_('Second Series Column')}}</label>
               <select name="config_series2_column" id="config_series2_column" class="form-control" onchange="updateSeries2Label(this)">
-                <option value="0" data-name="" {% if conf.config_series2_column == 0 %}selected{% endif %}></option>
+                <option value="0" data-name="" data-label="" {% if conf.config_series2_column == 0 %}selected{% endif %}></option>
                 {% for series2Column in series2Columns %}
-                <option value="{{ series2Column.id }}" data-name="{{ series2Column.name }}" {% if series2Column.id == conf.config_series2_column %}selected{% endif %}>{{ series2Column.name }}</option>
+                <option value="{{ series2Column.id }}" data-name="{{ series2Column.name }}" data-label="{{ series2Column.label }}" {% if series2Column.id == conf.config_series2_column %}selected{% endif %}>{{ series2Column.name }}</option>
                 {% endfor %}
               </select>
               <input type="hidden" name="config_series2_label" id="config_series2_label" value="">
+              <input type="hidden" name="config_series2_slug" id="config_series2_slug" value="">
               <div class="checkbox">
                 <label>
                   <input type="checkbox" name="config_show_series2_on_book_list" id="config_show_series2_on_book_list" {% if conf.config_show_series2_on_book_list %}checked{% endif %}>
@@ -213,7 +214,9 @@
 <script src="{{ url_for('static', filename='js/libs/bootstrap-select.min.js') }}"></script>
 <script>
 function updateSeries2Label(sel) {
-  document.getElementById('config_series2_label').value = sel.options[sel.selectedIndex].getAttribute('data-name') || '';
+  var opt = sel.options[sel.selectedIndex];
+  document.getElementById('config_series2_label').value = opt.getAttribute('data-name') || '';
+  document.getElementById('config_series2_slug').value = opt.getAttribute('data-label') || '';
   var group = document.getElementById('series2_icon_group');
   if (group) {
     group.hidden = (sel.value === '0' || sel.value === '');

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -160,7 +160,7 @@
                 <p class="series-entry">{{_('Series')}}: <a href="{{ url_for('web.books_list', data='series', sort_param='stored', book_id=entry.series[0].id) }}">{{ entry.series[0].name }}</a>, {{_('Book')}} {{ entry.series_index|formatfloat(2) }}</p>
                 {% endif %}
                 {% if entry.series2|length > 0 %}
-                <p class="series2-entry">{{ series2_label }}: <a href="{{ url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.series2[0].map_value) }}">{{ entry.series2[0].value }}</a>, {{_('Book')}} {{ entry.series2[0].extra|formatfloat(2) }}</p>
+                <p class="series2-entry">{{ series2_label }}: <a href="{{ url_for('web.books_list', data=g.series2_key, sort_param='stored', book_id=entry.series2[0].map_value) }}">{{ entry.series2[0].value }}</a>, {{_('Book')}} {{ entry.series2[0].extra|formatfloat(2) }}</p>
                 {% endif %}
             </div>
             {% endif %}

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -154,12 +154,15 @@
                     </p>
                 </div>
             {% endif %}
-            {% if entry.series|length > 0 %}
-                <p>{{ _("Book %(index)s of %(range)s", index=entry.series_index|formatfloat(2), range=(url_for('web.books_list', data='series', sort_param='stored', book_id=entry.series[0].id)|escapedlink(entry.series[0].name))|safe) }}</p>
-
-            {% endif %}
-            {% if entry.series2|length > 0 %}
-                <p>{{ _("Book %(index)s of %(range)s", index=entry.series2[0].extra|formatfloat(2), range=(url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.series2[0].map_value)|escapedlink(entry.series2[0].value))|safe) }}</p>
+            {% if entry.series|length > 0 or entry.series2|length > 0 %}
+            <div class="series-section">
+                {% if entry.series|length > 0 %}
+                <p class="series-entry">{{_('Series')}}: <a href="{{ url_for('web.books_list', data='series', sort_param='stored', book_id=entry.series[0].id) }}">{{ entry.series[0].name }}</a>, {{_('Book')}} {{ entry.series_index|formatfloat(2) }}</p>
+                {% endif %}
+                {% if entry.series2|length > 0 %}
+                <p class="series2-entry">{{ series2_label }}: <a href="{{ url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.series2[0].map_value) }}">{{ entry.series2[0].value }}</a>, {{_('Book')}} {{ entry.series2[0].extra|formatfloat(2) }}</p>
+                {% endif %}
+            </div>
             {% endif %}
 
             {% if entry.languages|length > 0 %}

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -158,6 +158,9 @@
                 <p>{{ _("Book %(index)s of %(range)s", index=entry.series_index|formatfloat(2), range=(url_for('web.books_list', data='series', sort_param='stored', book_id=entry.series[0].id)|escapedlink(entry.series[0].name))|safe) }}</p>
 
             {% endif %}
+            {% if entry.series2|length > 0 %}
+                <p>{{ _("Book %(index)s of %(range)s", index=entry.series2[0].extra|formatfloat(2), range=(url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.series2[0].map_value)|escapedlink(entry.series2[0].value))|safe) }}</p>
+            {% endif %}
 
             {% if entry.languages|length > 0 %}
                 <div class="languages">

--- a/cps/templates/grid.html
+++ b/cps/templates/grid.html
@@ -18,7 +18,7 @@
         <div class="btn btn-primary char">{{char.char}}</div>
         {% endfor %}
       </div>
-        <div class="update-view btn btn-primary" data-target="series_view" id="list-button" data-view="list">{{_('List')}}</div>
+        <div class="update-view btn btn-primary" data-page="series" data-target="series_view" id="list-button" data-view="list">{{_('List')}}</div>
     </div>
 
     {% if entries[0] %}

--- a/cps/templates/grid2.html
+++ b/cps/templates/grid2.html
@@ -1,0 +1,39 @@
+{% import 'image.html' as image %}
+{% extends "layout.html" %}
+{% block body %}
+<h1 class="{{page}}">{{_(title)}}</h1>
+
+    <div class="filterheader hidden-xs">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <div id="asc" data-id="series2" data-order="{{ order }}" class="btn btn-primary{% if order == 1 %} active{% endif%}"><span class="glyphicon glyphicon-sort-by-alphabet"></span></div>
+      <div id="desc" data-id="series2" class="btn btn-primary{% if order == 0 %} active{% endif%}"><span class="glyphicon glyphicon-sort-by-alphabet-alt"></span></div>
+        <div class="update-view btn btn-primary" data-page="series2" data-target="series2_view" id="list-button" data-view="list">{{_('List')}}</div>
+    </div>
+
+    {% if entries[0] %}
+        <div id="list" class="row display-flex">
+          {% for entry in entries %}
+              <div class="col-sm-3 col-lg-2 col-xs-6 book sortable" data-name="{{entry.s2_name}}" data-id="{{entry.s2_name}}">
+                  <div class="cover">
+                      <a href="{{url_for('web.books_list', data=data, sort_param='stored', book_id=entry.s2_id )}}">
+                          <span class="img" title="{{entry.s2_name}}">
+                              {{ image.book_cover(entry[0])}}
+                              <span class="badge">{{entry.count}}</span>
+                            </span>
+                      </a>
+                  </div>
+                  <div class="meta">
+                      <a href="{{url_for('web.books_list', data=data, sort_param='stored', book_id=entry.s2_id )}}">
+                          <p title="{{entry.s2_name|shortentitle}}" class="title">{{entry.s2_name|shortentitle}}</p>
+                      </a>
+                  </div>
+              </div>
+        {% endfor %}
+        </div>
+    {% endif %}
+
+
+{% endblock %}
+{% block js %}
+<script src="{{ url_for('static', filename='js/filter_grid.js') }}"></script>
+{% endblock %}

--- a/cps/templates/index.html
+++ b/cps/templates/index.html
@@ -45,6 +45,14 @@
           ({{entry.Books.series_index|formatfloat(2)}})
         </p>
         {% endif %}
+        {% if g.config_show_series2_on_book_list and entry.Books.series2.__len__() > 0 %}
+        <p class="series">
+          <a href="{{url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
+            {{entry.Books.series2[0].value}}
+          </a>
+          ({{entry.Books.series2[0].extra|formatfloat(2)}})
+        </p>
+        {% endif %}
         {% if entry.Books.ratings.__len__() > 0 %}
         <div class="rating">
           {% for number in range((entry.Books.ratings[0].rating/2)|int(2)) %}
@@ -133,6 +141,18 @@
             <span>{{entry.Books.series[0].name}}</span>
         {% endif %}
           ({{entry.Books.series_index|formatfloat(2)}})
+        </p>
+        {% endif %}
+        {% if g.config_show_series2_on_book_list and entry.Books.series2.__len__() > 0 %}
+        <p class="series">
+        {% if page != "series2" %}
+          <a href="{{url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
+            {{entry.Books.series2[0].value}}
+          </a>
+        {% else %}
+            <span>{{entry.Books.series2[0].value}}</span>
+        {% endif %}
+          ({{entry.Books.series2[0].extra|formatfloat(2)}})
         </p>
         {% endif %}
         {% if entry.Books.ratings.__len__() > 0 %}

--- a/cps/templates/index.html
+++ b/cps/templates/index.html
@@ -47,7 +47,7 @@
         {% endif %}
         {% if g.config_show_series2_on_book_list and entry.Books.series2.__len__() > 0 %}
         <p class="series">
-          <a href="{{url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
+          <a href="{{url_for('web.books_list', data=g.series2_key, sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
             {{entry.Books.series2[0].value}}
           </a>
           ({{entry.Books.series2[0].extra|formatfloat(2)}})
@@ -146,7 +146,7 @@
         {% if g.config_show_series2_on_book_list and entry.Books.series2.__len__() > 0 %}
         <p class="series">
         {% if page != "series2" %}
-          <a href="{{url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
+          <a href="{{url_for('web.books_list', data=g.series2_key, sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
             {{entry.Books.series2[0].value}}
           </a>
         {% else %}

--- a/cps/templates/layout.html
+++ b/cps/templates/layout.html
@@ -147,7 +147,7 @@
               <li class="nav-head hidden-xs">{{_('Browse')}}</li>
               {% for element in sidebar %}
                 {% if current_user.check_visibility(element['visibility']) and element['public'] %}
-                    <li id="nav_{{element['id']}}" {% if page == element['page'] %}class="active"{% endif %}><a href="{% if element['no_param'] %}{{url_for(element['link'], data=element['page'])}}{%else%}{{url_for(element['link'], data=element['page'], sort_param='stored')}}{% endif %}"><span class="glyphicon {{element['glyph']}}"></span> {{_(element['text'])}}</a></li>
+                    <li id="nav_{{element['id']}}" {% if page == element['page'] %}class="active"{% endif %}><a href="{% if element['no_param'] %}{{url_for(element['link'])}}{%else%}{{url_for(element['link'], data=element['page'], sort_param='stored')}}{% endif %}"><span class="glyphicon {{element['glyph']}}"></span> {{_(element['text'])}}</a></li>
                 {% endif %}
               {% endfor %}
               {% if current_user.is_authenticated or g.allow_anonymous %}

--- a/cps/templates/list.html
+++ b/cps/templates/list.html
@@ -20,7 +20,7 @@
 
       {% if data == "series" %}
       <button class="update-view btn btn-primary" data-page="series" data-target="series_view" id="grid-button" data-view="grid">{{_('Grid')}}</button>
-      {% elif data == "series2" %}
+      {% elif data == g.series2_key %}
       <button class="update-view btn btn-primary" data-page="series2" data-target="series2_view" id="grid-button" data-view="grid">{{_('Grid')}}</button>
       {% endif %}
     </div>

--- a/cps/templates/list.html
+++ b/cps/templates/list.html
@@ -19,7 +19,9 @@
       </div>
 
       {% if data == "series" %}
-      <button class="update-view btn btn-primary" data-target="series_view" id="grid-button" data-view="grid">{{_('Grid')}}</button>
+      <button class="update-view btn btn-primary" data-page="series" data-target="series_view" id="grid-button" data-view="grid">{{_('Grid')}}</button>
+      {% elif data == "series2" %}
+      <button class="update-view btn btn-primary" data-page="series2" data-target="series2_view" id="grid-button" data-view="grid">{{_('Grid')}}</button>
       {% endif %}
     </div>
   <div class="container1">

--- a/cps/templates/search.html
+++ b/cps/templates/search.html
@@ -101,7 +101,7 @@
         {% endif %}
         {% if g.config_show_series2_on_book_list and entry.Books.series2.__len__() > 0 %}
         <p class="series">
-          <a href="{{url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
+          <a href="{{url_for('web.books_list', data=g.series2_key, sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
             {{entry.Books.series2[0].value}}
           </a>
           ({{entry.Books.series2[0].extra|formatfloat(2)}})

--- a/cps/templates/search.html
+++ b/cps/templates/search.html
@@ -99,6 +99,14 @@
           ({{entry.Books.series_index|formatfloat(2)}})
         </p>
         {% endif %}
+        {% if g.config_show_series2_on_book_list and entry.Books.series2.__len__() > 0 %}
+        <p class="series">
+          <a href="{{url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
+            {{entry.Books.series2[0].value}}
+          </a>
+          ({{entry.Books.series2[0].extra|formatfloat(2)}})
+        </p>
+        {% endif %}
 
         {% if entry.Books.ratings.__len__() > 0 %}
         <div class="rating">

--- a/cps/templates/search_form.html
+++ b/cps/templates/search_form.html
@@ -86,7 +86,7 @@
     {% if series2|length > 0 %}
     <div class="row">
       <div class="form-group col-sm-6">
-        <div><label for="include_serie2">{{_('Series')}}</label></div>
+        <div><label for="include_serie2">{{series2_label}}</label></div>
         <select class="selectpicker" name="include_serie2" id="include_serie2" data-live-search="true" data-style="btn-primary" data-dropup-auto="false" data-actions-box="true" multiple>
           {% for serie in series2 %}
           <option value="{{serie.id}}">{{serie.value}}</option>
@@ -94,7 +94,7 @@
         </select>
       </div>
       <div class="form-group col-sm-6">
-        <div><label for="exclude_serie2">{{_('Exclude Series')}}</label></div>
+        <div><label for="exclude_serie2">{{_('Exclude')}} {{series2_label}}</label></div>
         <select class="selectpicker" name="exclude_serie2" id="exclude_serie2" data-live-search="true" data-style="btn-danger" data-dropup-auto="false" data-actions-box="true" multiple>
           {% for serie in series2 %}
           <option value="{{serie.id}}">{{serie.value}}</option>

--- a/cps/templates/search_form.html
+++ b/cps/templates/search_form.html
@@ -83,6 +83,26 @@
         </select>
       </div>
     </div>
+    {% if series2|length > 0 %}
+    <div class="row">
+      <div class="form-group col-sm-6">
+        <div><label for="include_serie2">{{_('Series')}}</label></div>
+        <select class="selectpicker" name="include_serie2" id="include_serie2" data-live-search="true" data-style="btn-primary" data-dropup-auto="false" data-actions-box="true" multiple>
+          {% for serie in series2 %}
+          <option value="{{serie.id}}">{{serie.value}}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="form-group col-sm-6">
+        <div><label for="exclude_serie2">{{_('Exclude Series')}}</label></div>
+        <select class="selectpicker" name="exclude_serie2" id="exclude_serie2" data-live-search="true" data-style="btn-danger" data-dropup-auto="false" data-actions-box="true" multiple>
+          {% for serie in series2 %}
+          <option value="{{serie.id}}">{{serie.value}}</option>
+          {% endfor %}
+        </select>
+      </div>
+    </div>
+    {% endif %}
      <div class="row">
       <div class="form-group col-sm-6">
         <div><label for="include_shelf">{{_('Shelves')}}</label></div>

--- a/cps/templates/shelf.html
+++ b/cps/templates/shelf.html
@@ -75,7 +75,7 @@
         {% endif %}
         {% if g.config_show_series2_on_book_list and entry.Books.series2.__len__() > 0 %}
         <p class="series">
-          <a href="{{url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
+          <a href="{{url_for('web.books_list', data=g.series2_key, sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
             {{entry.Books.series2[0].value}}
           </a>
           ({{entry.Books.series2[0].extra|formatfloat(2)}})

--- a/cps/templates/shelf.html
+++ b/cps/templates/shelf.html
@@ -73,6 +73,14 @@
           ({{entry.Books.series_index|formatfloat(2)}})
         </p>
         {% endif %}
+        {% if g.config_show_series2_on_book_list and entry.Books.series2.__len__() > 0 %}
+        <p class="series">
+          <a href="{{url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
+            {{entry.Books.series2[0].value}}
+          </a>
+          ({{entry.Books.series2[0].extra|formatfloat(2)}})
+        </p>
+        {% endif %}
         {% if entry.Books.ratings.__len__() > 0 %}
         <div class="rating">
           {% for number in range((entry.Books.ratings[0].rating/2)|int(2)) %}

--- a/cps/templates/shelfdown.html
+++ b/cps/templates/shelfdown.html
@@ -48,6 +48,14 @@
           ({{entry.Books.series_index|formatfloat(2)}})
         </p>
         {% endif %}
+        {% if g.config_show_series2_on_book_list and entry.Books.series2.__len__() > 0 %}
+        <p class="series">
+          <a href="{{url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
+            {{entry.Books.series2[0].value}}
+          </a>
+          ({{entry.Books.series2[0].extra|formatfloat(2)}})
+        </p>
+        {% endif %}
       </div>
 
 	  <div class="btn-group" role="group" aria-label="Download, send to eReader, reading">

--- a/cps/templates/shelfdown.html
+++ b/cps/templates/shelfdown.html
@@ -50,7 +50,7 @@
         {% endif %}
         {% if g.config_show_series2_on_book_list and entry.Books.series2.__len__() > 0 %}
         <p class="series">
-          <a href="{{url_for('web.books_list', data='series2', sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
+          <a href="{{url_for('web.books_list', data=g.series2_key, sort_param='stored', book_id=entry.Books.series2[0].map_value )}}">
             {{entry.Books.series2[0].value}}
           </a>
           ({{entry.Books.series2[0].extra|formatfloat(2)}})

--- a/cps/web.py
+++ b/cps/web.py
@@ -60,7 +60,8 @@ from .usermanagement import user_login_required
 from .string_helper import strip_whitespaces
 
 # Computed once at startup (after create_app loads config). Used for dynamic series2 URL routing.
-_s2_key = (config.config_series2_slug or '').strip() or 'series2'
+# Falls back to label (column name) if slug not yet saved, then to 'series2'.
+_s2_key = (config.config_series2_slug or config.config_series2_label or '').strip() or 'series2'
 
 
 feature_support = {
@@ -837,8 +838,9 @@ def books_list(data, sort_param, book_id, page):
     return render_books_list(data, sort_param, book_id, page)
 
 # Limit number of routes to avoid redirects
-data =["rated", "discover", "unread", "read", "hot", "download", "author", "publisher", "series", _s2_key,
-       "ratings", "formats", "category", "language", "archived", "search", "advsearch", "newest"]
+_s2_data_keys = [_s2_key] if _s2_key == 'series2' else [_s2_key, 'series2']
+data = ["rated", "discover", "unread", "read", "hot", "download", "author", "publisher", "series"] + _s2_data_keys + [
+        "ratings", "formats", "category", "language", "archived", "search", "advsearch", "newest"]
 for d in data:
     web.add_url_rule('/{}/<sort_param>'.format(d), view_func=books_list, defaults={'page': 1, 'book_id': 1, "data": d})
     web.add_url_rule('/{}/<sort_param>/'.format(d), view_func=books_list, defaults={'page': 1, 'book_id': 1, "data": d})
@@ -1101,7 +1103,7 @@ def series2_list():
                                          charlist=[],
                                          title=label,
                                          page="series2list",
-                                         data="series2", order=order_no)
+                                         data=_s2_key, order=order_no)
         else:
             entries = (calibre_db.session.query(
                 db.Books,
@@ -1122,9 +1124,13 @@ def series2_list():
                                          charlist=[],
                                          title=label,
                                          page="series2list",
-                                         data="series2", bodyClass="grid-view", order=order_no)
+                                         data=_s2_key, bodyClass="grid-view", order=order_no)
     else:
         abort(404)
+
+
+if _s2_key != 'series2':
+    web.add_url_rule('/series2', view_func=series2_list)
 
 
 @web.route("/ratings")

--- a/cps/web.py
+++ b/cps/web.py
@@ -1704,6 +1704,8 @@ def show_book(book_id):
             if media_format.format.lower() in constants.EXTENSIONS_AUDIO:
                 entry.audio_entries.append(media_format.format.lower())
 
+        log.debug("series2: link_class=%s, cc_class=%s, entry.series2=%r",
+                  db.series2_link_class, db.series2_cc_class, entry.series2)
         return render_title_template('detail.html',
                                      entry=entry,
                                      cc=cc,

--- a/cps/web.py
+++ b/cps/web.py
@@ -392,6 +392,8 @@ def render_books_list(data, sort_param, book_id, page):
         return render_publisher_books(page, book_id, order)
     elif data == "series":
         return render_series_books(page, book_id, order)
+    elif data == "series2":
+        return render_series2_books(page, book_id, order)
     elif data == "ratings":
         return render_ratings_books(page, book_id, order)
     elif data == "formats":
@@ -584,6 +586,24 @@ def render_publisher_books(page, book_id, order):
                                  title=_("Publisher: %(name)s", name=publisher),
                                  page="publisher",
                                  order=order[1])
+
+
+def render_series2_books(page, book_id, order):
+    if db.series2_link_class is None or db.series2_cc_class is None:
+        abort(404)
+    series2_entry = calibre_db.session.query(db.series2_cc_class).filter(
+        db.series2_cc_class.id == book_id).first()
+    if series2_entry:
+        entries, random, pagination = calibre_db.fill_indexpage(
+            page, 0, db.Books,
+            db.Books.series2.any(db.series2_link_class.map_value == book_id),
+            [order[0][0]], True, config.config_read_column)
+        label = config.config_series2_label or 'World'
+        title = label + ": " + series2_entry.value
+    else:
+        abort(404)
+    return render_title_template('index.html', random=random, pagination=pagination, entries=entries,
+                                 id=book_id, title=title, page="series2", order=order[1])
 
 
 def render_series_books(page, book_id, order):
@@ -814,8 +834,8 @@ def books_list(data, sort_param, book_id, page):
     return render_books_list(data, sort_param, book_id, page)
 
 # Limit number of routes to avoid redirects
-data =["rated", "discover", "unread", "read", "hot", "download", "author", "publisher", "series", "ratings", "formats",
-       "category", "language", "archived", "search", "advsearch", "newest"]
+data =["rated", "discover", "unread", "read", "hot", "download", "author", "publisher", "series", "series2",
+       "ratings", "formats", "category", "language", "archived", "search", "advsearch", "newest"]
 for d in data:
     web.add_url_rule('/{}/<sort_param>'.format(d), view_func=books_list, defaults={'page': 1, 'book_id': 1, "data": d})
     web.add_url_rule('/{}/<sort_param>/'.format(d), view_func=books_list, defaults={'page': 1, 'book_id': 1, "data": d})
@@ -1045,6 +1065,39 @@ def series_list():
             return render_title_template('grid.html', entries=entries, folder='web.books_list', charlist=char_list,
                                          title=_("Series"), page="serieslist", data="series", bodyClass="grid-view",
                                          order=order_no)
+    else:
+        abort(404)
+
+
+@web.route("/series2")
+@login_required_if_no_ano
+def series2_list():
+    if not config.config_series2_column or db.series2_link_class is None or db.series2_cc_class is None:
+        abort(404)
+    if current_user.check_visibility(constants.SIDEBAR_SERIES2):
+        if current_user.get_view_property('series2', 'dir') == 'desc':
+            order = db.series2_cc_class.value.desc()
+            order_no = 0
+        else:
+            order = db.series2_cc_class.value.asc()
+            order_no = 1
+        entries_raw = (calibre_db.session.query(db.series2_cc_class,
+                                                func.count(db.series2_link_class.book).label('count'))
+                       .join(db.series2_link_class, db.series2_link_class.map_value == db.series2_cc_class.id)
+                       .join(db.Books, db.Books.id == db.series2_link_class.book)
+                       .filter(calibre_db.common_filters())
+                       .group_by(db.series2_link_class.map_value)
+                       .order_by(order)
+                       .all())
+        entries = [[db.Category(row[0].value, row[0].id), row[1]] for row in entries_raw]
+        label = config.config_series2_label or 'World'
+        return render_title_template('list.html',
+                                     entries=entries,
+                                     folder='web.books_list',
+                                     charlist=[],
+                                     title=label,
+                                     page="series2list",
+                                     data="series2", order=order_no)
     else:
         abort(404)
 

--- a/cps/web.py
+++ b/cps/web.py
@@ -59,6 +59,9 @@ from .tasks_status import render_task_status
 from .usermanagement import user_login_required
 from .string_helper import strip_whitespaces
 
+# Computed once at startup (after create_app loads config). Used for dynamic series2 URL routing.
+_s2_key = (config.config_series2_slug or '').strip() or 'series2'
+
 
 feature_support = {
     'ldap': bool(services.ldap),
@@ -392,7 +395,7 @@ def render_books_list(data, sort_param, book_id, page):
         return render_publisher_books(page, book_id, order)
     elif data == "series":
         return render_series_books(page, book_id, order)
-    elif data == "series2":
+    elif data in (_s2_key, "series2"):
         return render_series2_books(page, book_id, order)
     elif data == "ratings":
         return render_ratings_books(page, book_id, order)
@@ -834,7 +837,7 @@ def books_list(data, sort_param, book_id, page):
     return render_books_list(data, sort_param, book_id, page)
 
 # Limit number of routes to avoid redirects
-data =["rated", "discover", "unread", "read", "hot", "download", "author", "publisher", "series", "series2",
+data =["rated", "discover", "unread", "read", "hot", "download", "author", "publisher", "series", _s2_key,
        "ratings", "formats", "category", "language", "archived", "search", "advsearch", "newest"]
 for d in data:
     web.add_url_rule('/{}/<sort_param>'.format(d), view_func=books_list, defaults={'page': 1, 'book_id': 1, "data": d})
@@ -1069,7 +1072,7 @@ def series_list():
         abort(404)
 
 
-@web.route("/series2")
+@web.route("/{}".format(_s2_key))
 @login_required_if_no_ano
 def series2_list():
     if not config.config_series2_column or db.series2_link_class is None or db.series2_cc_class is None:
@@ -1081,23 +1084,45 @@ def series2_list():
         else:
             order = db.series2_cc_class.value.asc()
             order_no = 1
-        entries_raw = (calibre_db.session.query(db.series2_cc_class,
-                                                func.count(db.series2_link_class.book).label('count'))
-                       .join(db.series2_link_class, db.series2_link_class.map_value == db.series2_cc_class.id)
-                       .join(db.Books, db.Books.id == db.series2_link_class.book)
-                       .filter(calibre_db.common_filters())
-                       .group_by(db.series2_link_class.map_value)
-                       .order_by(order)
-                       .all())
-        entries = [[db.Category(row[0].value, row[0].id), row[1]] for row in entries_raw]
         label = config.config_series2_label or 'World'
-        return render_title_template('list.html',
-                                     entries=entries,
-                                     folder='web.books_list',
-                                     charlist=[],
-                                     title=label,
-                                     page="series2list",
-                                     data="series2", order=order_no)
+        if current_user.get_view_property('series2', 'series2_view') == 'list':
+            entries_raw = (calibre_db.session.query(db.series2_cc_class,
+                                                    func.count(db.series2_link_class.book).label('count'))
+                           .join(db.series2_link_class, db.series2_link_class.map_value == db.series2_cc_class.id)
+                           .join(db.Books, db.Books.id == db.series2_link_class.book)
+                           .filter(calibre_db.common_filters())
+                           .group_by(db.series2_link_class.map_value)
+                           .order_by(order)
+                           .all())
+            entries = [[db.Category(row[0].value, row[0].id), row[1]] for row in entries_raw]
+            return render_title_template('list.html',
+                                         entries=entries,
+                                         folder='web.books_list',
+                                         charlist=[],
+                                         title=label,
+                                         page="series2list",
+                                         data="series2", order=order_no)
+        else:
+            entries = (calibre_db.session.query(
+                db.Books,
+                func.count(db.series2_link_class.book).label('count'),
+                func.max(db.series2_link_class.extra),
+                db.series2_cc_class.id.label('s2_id'),
+                db.series2_cc_class.value.label('s2_name')
+            )
+                .join(db.series2_link_class, db.series2_link_class.book == db.Books.id)
+                .join(db.series2_cc_class, db.series2_cc_class.id == db.series2_link_class.map_value)
+                .filter(calibre_db.common_filters())
+                .group_by(db.series2_link_class.map_value)
+                .order_by(order)
+                .all())
+            return render_title_template('grid2.html',
+                                         entries=entries,
+                                         folder='web.books_list',
+                                         charlist=[],
+                                         title=label,
+                                         page="series2list",
+                                         data="series2", bodyClass="grid-view", order=order_no)
     else:
         abort(404)
 

--- a/cps/web.py
+++ b/cps/web.py
@@ -1074,7 +1074,7 @@ def series_list():
 def series2_list():
     if not config.config_series2_column or db.series2_link_class is None or db.series2_cc_class is None:
         abort(404)
-    if current_user.check_visibility(constants.SIDEBAR_SERIES2):
+    if current_user.check_visibility(constants.SIDEBAR_SERIES):
         if current_user.get_view_property('series2', 'dir') == 'desc':
             order = db.series2_cc_class.value.desc()
             order_no = 0


### PR DESCRIPTION
Configuration option for setting a second series field (for storing world, collection, etc).
Shows in sidebar, and in book details under the primary series. Uses column name as the display name.
Available to select in the advanced search in the same manner as the main series.
Configuration allows for setting the icon to use in the sidebar (defaults to the same as the main series icon)
Sidebar display has the same "Show <SecondSeries Section" config option in the user's config page as the main series
The "show second series on book list pages" checkbox causes the second series to be displayed below the primary series on all book pages

<img width="858" height="490" alt="image" src="https://github.com/user-attachments/assets/7da2bef1-c876-42f4-9209-185fa47e4922" />


Also includes some cleanup for sidebar urls, so they no longer have extra URL parameters that are not used.

If used with PR #3376, commits 1451f28 & 3285d6b allow for the second series to be sent as the subtitle when syncing with a Kobo

Issues: https://github.com/janeczku/calibre-web/issues/1501, https://github.com/janeczku/calibre-web/issues/2797