### PR TITLE
Return 401 on unsuccessful login

### DIFF
--- a/cps/web.py
+++ b/cps/web.py
@@ -1438,7 +1438,7 @@ def login_post():
             else:
                 log.warning('Login failed for user "{}" IP-address: {}'.format(username, ip_address))
                 flash(_(u"Wrong Username or Password"), category="error")
-    return render_login(username, form.get("password", ""))
+    return render_login(username, form.get("password", "")), 401
 
 
 @web.route('/logout')


### PR DESCRIPTION
calibre-web should use the 401 HTTP response for a failed login.

This would greatly improve fail2ban implementations for users running calibre-web on a remote reverse proxy, where calibre-web's logs are not readily available-- but HTTP responses are.