### PR TITLE
feat: eReader email labels + AnythingLLM integration

### DIFF
--- a/cps/admin.py
+++ b/cps/admin.py
@@ -1839,6 +1839,10 @@ def _configuration_update_helper():
             services.goodreads_support.connect(config.config_goodreads_api_key,
                                                config.config_use_goodreads)
 
+        # AnythingLLM configuration
+        _config_string(to_save, "config_anythingllm_url")
+        _config_string(to_save, "config_anythingllm_api_key")
+
         # Google Books API configuration
         reboot_required |=_config_string(to_save, "config_googlebooks_api_key")
         

--- a/cps/config_sql.py
+++ b/cps/config_sql.py
@@ -117,6 +117,8 @@ class _Settings(_Base):
 
     config_use_goodreads = Column(Boolean, default=False)
     config_goodreads_api_key = Column(String)
+    config_anythingllm_url = Column(String, default='')
+    config_anythingllm_api_key = Column(String, default='')
     config_googlebooks_api_key = Column(String, default='')
     config_register_email = Column(Boolean, default=False)
     config_login_type = Column(Integer, default=0)

--- a/cps/helper.py
+++ b/cps/helper.py
@@ -652,18 +652,30 @@ def check_username(username):
     return username
 
 
+_EMAIL_RE = re.compile(
+    r"^[\w.!#$%&'*+\\/=?^_`{|}~-]+@[\w](?:[\w-]{0,61}[\w])?(?:\.[\w](?:[\w-]{0,61}[\w])?)*$"
+)
+_NAME_EMAIL_RE = re.compile(r'^(.+?)\s*<\s*(.+?)\s*>\s*$')
+
+
+def extract_email(entry):
+    """Return the bare email address from a 'Name <email>' or plain 'email' entry."""
+    m = _NAME_EMAIL_RE.match(entry.strip())
+    return m.group(2).strip() if m else entry.strip()
+
+
 def valid_email(emails):
     valid_emails = []
-    for email in emails.split(','):
-        email = strip_whitespaces(email)
-        # if email is not deleted
-        if email:
-            # Regex according to https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email#validation
-            if not re.search(r"^[\w.!#$%&'*+\\/=?^_`{|}~-]+@[\w](?:[\w-]{0,61}[\w])?(?:\.[\w](?:[\w-]{0,61}[\w])?)*$",
-                             email):
-                log.error("Invalid Email address format for {}".format(email))
-                raise Exception(_("Invalid Email address format"))
-            valid_emails.append(email)
+    for entry in emails.split(','):
+        entry = strip_whitespaces(entry)
+        if not entry:
+            continue
+        addr = extract_email(entry)
+        # Regex according to https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email#validation
+        if not _EMAIL_RE.search(addr):
+            log.error("Invalid Email address format for {}".format(addr))
+            raise Exception(_("Invalid Email address format"))
+        valid_emails.append(entry)
     return ",".join(valid_emails)
 
 

--- a/cps/static/js/details.js
+++ b/cps/static/js/details.js
@@ -37,10 +37,15 @@ function handleResponse (data) {
     }
 }
 $(".sendbtn-form").click(function() {
+    var email = $(this).data('email');
+    var postData = {csrf_token: $("input[name='csrf_token']").val()};
+    if (email) {
+        postData.email = email;
+    }
     $.ajax({
         method: 'post',
         url: $(this).data('href'),
-        data: {csrf_token: $("input[name='csrf_token']").val()},
+        data: postData,
         success: function (data) {
             handleResponse(data)
         }

--- a/cps/static/js/details.js
+++ b/cps/static/js/details.js
@@ -52,6 +52,25 @@ $(".sendbtn-form").click(function() {
     })
 });
 
+$(".anythingllm-send").click(function() {
+    var $btn = $(this);
+    var origHtml = $btn.html();
+    $btn.html('<span class="glyphicon glyphicon-refresh glyphicon-spin"></span> Sending…').prop('disabled', true);
+    $.ajax({
+        method: 'post',
+        url: $btn.data('href'),
+        data: {csrf_token: $("input[name='csrf_token']").val()},
+        success: function (data) {
+            $btn.html(origHtml).prop('disabled', false);
+            handleResponse(data);
+        },
+        error: function () {
+            $btn.html(origHtml).prop('disabled', false);
+            handleResponse([{type: 'danger', message: 'AnythingLLM request failed, please try again.'}]);
+        }
+    });
+});
+
 $(function() {
     $("#have_read_form").ajaxForm();
 });

--- a/cps/templates/config_edit.html
+++ b/cps/templates/config_edit.html
@@ -164,6 +164,26 @@
     </div>
     {% endif %}
     <div class="form-group">
+      <input type="checkbox" id="config_anythingllm_enabled" name="config_anythingllm_enabled"
+             data-control="anythingllm-settings" {% if config.config_anythingllm_url %}checked{% endif %}>
+      <label for="config_anythingllm_enabled">{{_('Enable AnythingLLM Integration')}}</label>
+    </div>
+    <div data-related="anythingllm-settings">
+      <div class="form-group">
+        <label for="config_anythingllm_url">{{_('AnythingLLM Server URL')}}</label>
+        <input type="text" class="form-control" id="config_anythingllm_url" name="config_anythingllm_url"
+               placeholder="http://localhost:3001"
+               value="{% if config.config_anythingllm_url %}{{ config.config_anythingllm_url }}{% endif %}"
+               autocomplete="off">
+      </div>
+      <div class="form-group">
+        <label for="config_anythingllm_api_key">{{_('AnythingLLM API Key')}}</label>
+        <input type="text" class="form-control" id="config_anythingllm_api_key" name="config_anythingllm_api_key"
+               value="{% if config.config_anythingllm_api_key %}{{ config.config_anythingllm_api_key }}{% endif %}"
+               autocomplete="off">
+      </div>
+    </div>
+    <div class="form-group">
       <label for="config_googlebooks_api_key">{{_('Google Books API Key')}}</label>
       <input type="text" class="form-control" id="config_googlebooks_api_key" name="config_googlebooks_api_key" value="{% if config.config_googlebooks_api_key != '' %}{{ config.config_googlebooks_api_key }}{% endif %}" autocomplete="off">
     </div>

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -53,9 +53,12 @@
                         {% endif %}
                         {% if current_user.kindle_mail and entry.email_share_list %}
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                            {% if entry.email_share_list.__len__() == 1 %}
+                            {% set kindle_emails = current_user.kindle_mail.split(',') | map('trim') | list %}
+                            {% if entry.email_share_list.__len__() == 1 and kindle_emails | length == 1 %}
                                 <div class="btn-group" role="group">
-                                    <button id="sendbtn" class="btn btn-primary sendbtn-form" data-href="{{url_for('web.send_to_ereader', book_id=entry.id, book_format=entry.email_share_list[0]['format'], convert=entry.email_share_list[0]['convert'])}}">
+                                    <button id="sendbtn" class="btn btn-primary sendbtn-form"
+                                            data-href="{{url_for('web.send_to_ereader', book_id=entry.id, book_format=entry.email_share_list[0]['format'], convert=entry.email_share_list[0]['convert'])}}"
+                                            data-email="{{ kindle_emails[0] }}">
                                         <span class="glyphicon glyphicon-send"></span> {{entry.email_share_list[0]['text']}}
                                     </button>
                                 </div>
@@ -68,9 +71,13 @@
                                     </button>
                                     <ul class="dropdown-menu" aria-labelledby="send-to-ereader">
                                         {% for format in entry.email_share_list %}
-                                            <li>
-                                                <a class="sendbtn-form" data-href="{{url_for('web.send_to_ereader', book_id=entry.id, book_format=format['format'], convert=format['convert'])}}">{{ format['text'] }}</a>
-                                            </li>
+                                            {% for email in kindle_emails %}
+                                                <li>
+                                                    <a class="sendbtn-form"
+                                                       data-href="{{url_for('web.send_to_ereader', book_id=entry.id, book_format=format['format'], convert=format['convert'])}}"
+                                                       data-email="{{ email }}">{{ format['text'] }} → {{ email }}</a>
+                                                </li>
+                                            {% endfor %}
                                         {% endfor %}
                                     </ul>
                                 </div>

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -83,6 +83,20 @@
                                 </div>
                             {% endif %}
                         {% endif %}
+                        {% if config.config_anythingllm_url %}
+                            {% set llm_format = 'EPUB' if 'EPUB' in entry.data|map(attribute='format')|list else ('PDF' if 'PDF' in entry.data|map(attribute='format')|list else '') %}
+                            {% if llm_format %}
+                                {% if not (current_user.kindle_mail and entry.email_share_list) %}
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                {% endif %}
+                                <div class="btn-group" role="group">
+                                    <button class="btn btn-default anythingllm-send"
+                                            data-href="{{ url_for('web.send_to_anythingllm', book_id=entry.id, book_format=llm_format) }}">
+                                        <span class="glyphicon glyphicon-education"></span> {{ _('Send to AnythingLLM') }}
+                                    </button>
+                                </div>
+                            {% endif %}
+                        {% endif %}
                     {% endif %}
                     {% if entry.reader_list and current_user.role_viewer() %}
                         <div class="btn-group" role="group">

--- a/cps/templates/detail.html
+++ b/cps/templates/detail.html
@@ -55,11 +55,19 @@
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                             {% set kindle_emails = current_user.kindle_mail.split(',') | map('trim') | list %}
                             {% if entry.email_share_list.__len__() == 1 and kindle_emails | length == 1 %}
+                                {% set ns = namespace() %}
+                                {% if '<' in kindle_emails[0] and '>' in kindle_emails[0] %}
+                                    {% set ns.label = kindle_emails[0].split('<')[0] | trim %}
+                                    {% set ns.addr  = kindle_emails[0].split('<')[1].split('>')[0] | trim %}
+                                {% else %}
+                                    {% set ns.label = kindle_emails[0] %}
+                                    {% set ns.addr  = kindle_emails[0] %}
+                                {% endif %}
                                 <div class="btn-group" role="group">
                                     <button id="sendbtn" class="btn btn-primary sendbtn-form"
                                             data-href="{{url_for('web.send_to_ereader', book_id=entry.id, book_format=entry.email_share_list[0]['format'], convert=entry.email_share_list[0]['convert'])}}"
-                                            data-email="{{ kindle_emails[0] }}">
-                                        <span class="glyphicon glyphicon-send"></span> {{entry.email_share_list[0]['text']}}
+                                            data-email="{{ ns.addr }}">
+                                        <span class="glyphicon glyphicon-send"></span> {{entry.email_share_list[0]['text']}} → {{ ns.label }}
                                     </button>
                                 </div>
                             {% else %}
@@ -71,11 +79,19 @@
                                     </button>
                                     <ul class="dropdown-menu" aria-labelledby="send-to-ereader">
                                         {% for format in entry.email_share_list %}
-                                            {% for email in kindle_emails %}
+                                            {% for raw_entry in kindle_emails %}
+                                                {% set ns = namespace() %}
+                                                {% if '<' in raw_entry and '>' in raw_entry %}
+                                                    {% set ns.label = raw_entry.split('<')[0] | trim %}
+                                                    {% set ns.addr  = raw_entry.split('<')[1].split('>')[0] | trim %}
+                                                {% else %}
+                                                    {% set ns.label = raw_entry %}
+                                                    {% set ns.addr  = raw_entry %}
+                                                {% endif %}
                                                 <li>
                                                     <a class="sendbtn-form"
                                                        data-href="{{url_for('web.send_to_ereader', book_id=entry.id, book_format=format['format'], convert=format['convert'])}}"
-                                                       data-email="{{ email }}">{{ format['text'] }} → {{ email }}</a>
+                                                       data-email="{{ ns.addr }}">{{ format['text'] }} → {{ ns.label }}</a>
                                                 </li>
                                             {% endfor %}
                                         {% endfor %}

--- a/cps/templates/user_edit.html
+++ b/cps/templates/user_edit.html
@@ -25,8 +25,10 @@
         </div>
     {% endif %}
     <div class="form-group">
-      <label for="kindle_mail">{{_('Send to eReader Email Address. Use comma to separate emails for multiple eReaders')}}</label>
-      <input type="email" class="form-control" name="kindle_mail" id="kindle_mail" value="{{ content.kindle_mail if content.kindle_mail != None }}">
+      <label for="kindle_mail">{{_('Send to eReader Email Address. Use comma to separate entries. Optionally add a label: My Kindle &lt;user@kindle.com&gt;')}}</label>
+      <input type="text" class="form-control" name="kindle_mail" id="kindle_mail"
+             placeholder="My Kindle &lt;user@kindle.com&gt;, another@kindle.com"
+             value="{{ content.kindle_mail if content.kindle_mail != None }}">
     </div>
     {% if not content.role_anonymous() %}
     <div class="form-group">

--- a/cps/web.py
+++ b/cps/web.py
@@ -1263,12 +1263,18 @@ def send_to_ereader(book_id, book_format, convert):
     if not config.get_mail_server_configured():
         return make_response(jsonify(type="danger", message=_("Please configure the SMTP mail settings first...")))
     elif current_user.kindle_mail:
-        result = send_mail(book_id, book_format, convert, current_user.kindle_mail, config.get_book_path(),
+        selected_email = request.form.get('email', '').strip()
+        allowed_emails = [e.strip() for e in current_user.kindle_mail.split(',') if e.strip()]
+        if selected_email and selected_email in allowed_emails:
+            ereader_mail = selected_email
+        else:
+            ereader_mail = allowed_emails[0] if allowed_emails else current_user.kindle_mail
+        result = send_mail(book_id, book_format, convert, ereader_mail, config.get_book_path(),
                            current_user.name)
         if result is None:
             ub.update_download(book_id, int(current_user.id))
             response = [{'type': "success", 'message': _("Success! Book queued for sending to %(eReadermail)s",
-                                                       eReadermail=current_user.kindle_mail)}]
+                                                       eReadermail=ereader_mail)}]
         else:
             response = [{'type': "danger", 'message': _("Oops! There was an error sending book: %(res)s", res=result)}]
     else:

--- a/cps/web.py
+++ b/cps/web.py
@@ -1282,6 +1282,110 @@ def send_to_ereader(book_id, book_format, convert):
     return make_response(jsonify(response))
 
 
+@web.route('/send-to-anythingllm/<int:book_id>/<book_format>', methods=["POST"])
+@login_required_if_no_ano
+@download_required
+def send_to_anythingllm(book_id, book_format):
+    """Upload an epub/pdf to AnythingLLM and embed it into a per-book workspace."""
+    import re
+    import urllib.request as _urlreq
+
+    anythingllm_url = (config.config_anythingllm_url or '').rstrip('/')
+    anythingllm_key = config.config_anythingllm_api_key or ''
+    if not anythingllm_url or not anythingllm_key:
+        return make_response(jsonify([{'type': "danger",
+                                       'message': _("AnythingLLM integration is not configured.")}]))
+
+    def _api(method, path, data=None, content_type='application/json'):
+        req = _urlreq.Request(
+            anythingllm_url + path,
+            data=data,
+            headers={'Authorization': 'Bearer ' + anythingllm_key, 'Content-Type': content_type},
+            method=method,
+        )
+        with _urlreq.urlopen(req, timeout=120) as resp:
+            return json.loads(resp.read().decode('utf-8'))
+
+    book = calibre_db.get_book(book_id)
+    if not book:
+        return make_response(jsonify([{'type': "danger", 'message': _("Book not found.")}]))
+
+    file_entry = next((e for e in book.data if e.format.upper() == book_format.upper()), None)
+    if not file_entry:
+        return make_response(jsonify([{'type': "danger",
+                                       'message': _("Format %(fmt)s not found for this book.", fmt=book_format)}]))
+
+    file_path = os.path.join(config.get_book_path(), book.path,
+                             file_entry.name + '.' + book_format.lower())
+    if not os.path.isfile(file_path):
+        return make_response(jsonify([{'type': "danger",
+                                       'message': _("File not found on disk.")}]))
+
+    # Workspace name: "calibre-{sanitized title}"
+    safe_title = re.sub(r'[^\w一-鿿぀-ヿ]', '-', book.title, flags=re.UNICODE)
+    safe_title = re.sub(r'-{2,}', '-', safe_title).strip('-')[:60]
+    workspace_name = "calibre-" + safe_title
+
+    try:
+        all_workspaces = _api('GET', '/api/v1/workspaces').get('workspaces', [])
+        existing = next((w for w in all_workspaces if w['name'] == workspace_name), None)
+        workspace_slug = existing['slug'] if existing else \
+            _api('POST', '/api/v1/workspace/new',
+                 data=json.dumps({"name": workspace_name}).encode())['workspace']['slug']
+    except Exception as e:
+        return make_response(jsonify([{'type': "danger",
+                                       'message': _("Failed to get/create workspace: %(err)s", err=str(e))}]))
+
+    try:
+        mime_type = mimetypes.guess_type(file_path)[0] or 'application/octet-stream'
+        boundary = b'----CalibreWebBoundary'
+        with open(file_path, 'rb') as f:
+            file_data = f.read()
+        body = (b'--' + boundary + b'\r\n'
+                b'Content-Disposition: form-data; name="file"; filename="'
+                + os.path.basename(file_path).encode() + b'"\r\n'
+                b'Content-Type: ' + mime_type.encode() + b'\r\n\r\n'
+                + file_data + b'\r\n'
+                b'--' + boundary + b'--\r\n')
+        upload_req = _urlreq.Request(
+            anythingllm_url + "/api/v1/document/upload",
+            data=body,
+            headers={'Authorization': 'Bearer ' + anythingllm_key,
+                     'Content-Type': 'multipart/form-data; boundary=' + boundary.decode()},
+            method='POST',
+        )
+        with _urlreq.urlopen(upload_req, timeout=120) as resp:
+            upload_result = json.loads(resp.read().decode('utf-8'))
+    except Exception as e:
+        return make_response(jsonify([{'type': "danger",
+                                       'message': _("AnythingLLM upload failed: %(err)s", err=str(e))}]))
+
+    if not upload_result.get('success') or not upload_result.get('documents'):
+        return make_response(jsonify([{'type': "danger",
+                                       'message': _("AnythingLLM upload error: %(err)s",
+                                                    err=upload_result.get('error', 'unknown'))}]))
+
+    doc_location = upload_result['documents'][0]['location']
+
+    try:
+        embed_req = _urlreq.Request(
+            anythingllm_url + "/api/v1/workspace/" + workspace_slug + "/update-embeddings",
+            data=json.dumps({"adds": [doc_location], "deletes": []}).encode(),
+            headers={'Authorization': 'Bearer ' + anythingllm_key,
+                     'Content-Type': 'application/json'},
+            method='POST',
+        )
+        with _urlreq.urlopen(embed_req, timeout=300) as resp:
+            json.loads(resp.read().decode('utf-8'))
+    except Exception as e:
+        return make_response(jsonify([{'type': "danger",
+                                       'message': _("Uploaded but embedding failed: %(err)s", err=str(e))}]))
+
+    return make_response(jsonify([{'type': "success",
+                                   'message': _("\"%(title)s\" sent to AnythingLLM workspace: %(ws)s",
+                                                title=book.title, ws=workspace_name)}]))
+
+
 # ################################### Login Logout ##################################################################
 
 @web.route('/register', methods=['POST'])

--- a/cps/web.py
+++ b/cps/web.py
@@ -46,7 +46,7 @@ from .gdriveutils import getFileFromEbooksFolder, do_gdrive_download
 from .helper import check_valid_domain, check_email, check_username, \
     get_book_cover, get_series_cover_thumbnail, get_download_link, send_mail, generate_random_password, \
     send_registration_mail, check_send_to_ereader, check_read_formats, tags_filters, reset_password, valid_email, \
-    edit_book_read_status, valid_password
+    edit_book_read_status, valid_password, extract_email
 from .pagination import Pagination
 from .redirect import get_redirect_location
 from .cw_babel import get_available_locale
@@ -1264,7 +1264,8 @@ def send_to_ereader(book_id, book_format, convert):
         return make_response(jsonify(type="danger", message=_("Please configure the SMTP mail settings first...")))
     elif current_user.kindle_mail:
         selected_email = request.form.get('email', '').strip()
-        allowed_emails = [e.strip() for e in current_user.kindle_mail.split(',') if e.strip()]
+        all_entries = [e.strip() for e in current_user.kindle_mail.split(',') if e.strip()]
+        allowed_emails = [extract_email(e) for e in all_entries]
         if selected_email and selected_email in allowed_emails:
             ereader_mail = selected_email
         else:


### PR DESCRIPTION
## Summary

This PR introduces two independent UX improvements for Calibre-Web users:

### 1. eReader email label support + send to specific address

**Problem:** Users with multiple Kindle/eReader email addresses configured (comma-separated in their profile) cannot choose which device to send a book to — it always sends to all addresses simultaneously.

**Changes:**
- `cps/helper.py`: `valid_email()` now accepts `Name <email>` entries alongside plain addresses. A new `extract_email()` helper extracts the bare address from either format.
- `cps/templates/user_edit.html`: Input type changed from `email` to `text`; label updated to explain the `Name <email>` syntax.
- `cps/web.py` (`send_to_ereader`): Reads a `email` POST parameter and validates it against the current user's own address list before sending to that single address.
- `cps/templates/detail.html`: Dropdown items show `Format → Label` (using the configured label/name, falling back to the raw address). Each item passes the bare address via `data-email`.
- `cps/static/js/details.js`: AJAX POST now includes the selected `email` field.

**Backward compatibility:** Existing plain-address entries continue to work without changes. The fallback for missing/invalid `email` POST param is the first configured address.

---

### 2. AnythingLLM integration

**Problem:** There is no built-in way to push books from Calibre-Web into a local AI knowledge base.

**Changes:**
- `cps/config_sql.py`: Two new config fields — `config_anythingllm_url` and `config_anythingllm_api_key`.
- `cps/admin.py`: Persists the two new fields via `_config_string`.
- `cps/templates/config_edit.html`: Admin UI — enable checkbox + server URL + API key inputs (collapsed when disabled, styled consistently with the Goodreads section).
- `cps/web.py` (`send_to_anythingllm`): POST route that uploads the book file (EPUB or PDF) to AnythingLLM's document API, then embeds it into a per-book workspace named `calibre-{title}` (auto-created if absent).
- `cps/templates/detail.html`: "Send to AnythingLLM" button rendered only when the integration is configured, for books that have an EPUB or PDF.
- `cps/static/js/details.js`: Click handler with spinner/disabled state during the (potentially slow) embedding request.

**No external dependencies:** Uses Python's standard `urllib.request` only.

## Test plan

- [ ] Profile page: enter `My Kindle <user@kindle.com>, Backup <other@kindle.com>` — save succeeds, plain addresses also still accepted
- [ ] Book detail: single email → button shows label; multiple emails → dropdown lists `Format → Label` per entry; clicking sends only to that address
- [ ] Admin config: AnythingLLM section visible, saves URL + key, section hidden when unchecked
- [ ] Book detail with AnythingLLM configured: "Send to AnythingLLM" button appears for EPUB/PDF; absent when integration disabled
- [ ] AnythingLLM button: spinner shown during request; success/error flash message displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
