### PR TITLE
Fix pip install module directly does not work

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-graft src/calibreweb
-global-exclude __pycache__
-global-exclude *.pyc
+recursive-include cps/static *
+recursive-include cps/templates *
+recursive-include cps/translations *

--- a/cps/cps.py
+++ b/cps/cps.py
@@ -25,7 +25,7 @@ import sys
 path = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, path)
 
-from cps.main import main
+from .main import main
 
 
 def hide_console_windows():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ kobo = [
 ]
 
 [project.scripts]
-cps = "cps.main:main"
+cps = "cps.cps:main"
 
 [tool.setuptools]
 include-package-data = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,10 +120,13 @@ kobo = [
 ]
 
 [project.scripts]
-cps = "calibreweb.__main__:main"
+cps = "cps.main:main"
 
 [tool.setuptools]
 include-package-data = true
 
 [tool.setuptools.dynamic]
-version = {attr = "calibreweb.cps.constants.STABLE_VERSION"}
+version = {attr = "cps.constants.STABLE_VERSION"}
+
+[tool.setuptools.packages.find]
+exclude = ["library"]


### PR DESCRIPTION
Running "pip install ." directly on the cloned source did not work, it somehow detected two packages `["cps", "library"]`.

Added "library" to the exclude list so it doesn't think this is a Python package it should install.

Note that the manual installation instructions will need to be updated, they say just to install "requirement.txt" and copy cps.py to the target destination.

This fixes pyproject.toml so "pip install ." just works and the entrypoint script cps is automatically installed into the active environment.

```
pip install .
cps
```