### PR TITLE
Fix cover editing incorrectly gated on upload permission (#3658)

### DIFF
--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -668,9 +668,6 @@ def do_edit_book(book_id, upload_formats=None):
             gdriveutils.updateGdriveCalibreFromLocal()
 
         if to_save.get("cover_url",):
-            if not current_user.role_upload():
-                edit_error = True
-                flash(_("User has no rights to upload cover"), category="error")
             if to_save["cover_url"].endswith('/static/generic_cover.jpg'):
                 book.has_cover = 0
             else:

--- a/cps/templates/book_edit.html
+++ b/cps/templates/book_edit.html
@@ -128,7 +128,7 @@
       </table>
       <a id="add-identifier-line" class="btn btn-default">{{_('Add Identifier')}}</a>
     </div>
-    {% if current_user.role_upload() and g.allow_upload %}
+    {% if (current_user.role_upload() or current_user.role_edit()) and g.allow_upload %}
     <div class="form-group">
       <label for="cover_url">{{_('Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)')}}</label>
       <input type="text" class="form-control" name="cover_url" id="cover_url" value="">


### PR DESCRIPTION
## Summary

Fixes #3658 — editing an existing book's cover (via URL) should be available to users with edit permission, not only to users with upload permission.

## Changes

**Template fix** (`cps/templates/book_edit.html`): Changed the condition from `role_upload() and g.allow_upload` to `(role_upload() or role_edit()) and g.allow_upload` so users with edit permission can see the cover editing controls.

**Backend fix** (`cps/editbooks.py`): Removed the redundant `role_upload()` check inside `do_edit_book()` for the cover URL handling path. The function is only called from two routes:
- `POST /admin/book/<int:book_id>` — guarded by `@edit_required` (checks `role_edit() or role_admin()`)
- `POST /upload` — guarded by `@upload_required` (checks `role_upload()`)

Both routes already have appropriate authorization. The inner check was inconsistent — it blocked edit-only users even though the edit route allowed them.

## Security

The local file upload path (`upload_cover()` at line 1499) still requires `role_upload()` — actual file uploads remain behind upload permission, unchanged.

## Testing

- No test suite in this repository (tests live in a separate repo: OzzieIsaacs/calibre-web-test)
- Changes are purely permission-gating logic, no functional behavior change for existing permission configurations