### PR TITLE
Fix infinite scroll not triggering on mobile browsers (#3664)

### DIFF
--- a/cps/static/js/main.js
+++ b/cps/static/js/main.js
@@ -414,7 +414,7 @@ $(function() {
         $(".col-sm-10").bind("scroll", function () {
             if (
                 $(this).scrollTop() + $(this).innerHeight() >=
-                $(this)[0].scrollHeight
+                $(this)[0].scrollHeight - 5
             ) {
                 $loadMore.infiniteScroll("loadNextPage");
                 window.history.replaceState({}, null, $loadMore.infiniteScroll("getAbsolutePath"));


### PR DESCRIPTION
## Summary

Fixes #3664 — infinite scrolling on mobile browsers fails to trigger because the scroll detection comparison is too strict. Mobile browsers render subpixel scroll positions that never exactly equal `scrollHeight`.

## Changes

**`cps/static/js/main.js`**: Added 5px tolerance to the scroll bottom detection (`scrollHeight - 5`).

Root cause identified by @jvanderzande in the issue comments.

## Testing

- No test suite in this repository
- Change is purely client-side: scroll threshold tolerance, no functional impact on desktop where pixel values are exact integers