### PR TITLE
Fix crash when User-Agent header is missing in download endpoint

### DIFF
--- a/cps/web.py
+++ b/cps/web.py
@@ -1247,9 +1247,9 @@ def serve_book(book_id, book_format, anyname):
 @login_required_if_no_ano
 @download_required
 def download_link(book_id, book_format, anyname):
-    if "kindle" in request.headers.get('User-Agent').lower():
+    if "kindle" in request.headers.get('User-Agent', "").lower():
         client = "kindle"
-    elif "Kobo" in request.headers.get('User-Agent').lower():
+    elif "Kobo" in request.headers.get('User-Agent', "").lower():
         client = "kobo"
     else:
         client = ""


### PR DESCRIPTION
## Summary

The `download_link` endpoint crashes with `AttributeError` when a client omits the User-Agent header:

```
AttributeError: 'NoneType' object has no attribute 'lower'
```

Root cause: `request.headers.get('User-Agent')` returns `None` when the header is absent, and `.lower()` is called directly on the result.

## Fix

Added empty string defaults to both `.get()` calls in `download_link()`

## Regression risk

Minimal. The same safe pattern (`get('User-Agent', '')`) is already used in `render_template.py:34`. If the header is missing, the function defaults to `client = ""` (no e-reader specific handling), which is correct.