### PR TITLE
Fix UNIQUE constraint crash on transliteration-twin authors (accented / homophone names)

### DIFF
--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -809,7 +809,13 @@ def prepare_authors(authr, calibre_path, gdrive=False):
 
     for in_aut in input_authors:
         renamed_author = calibre_db.session.query(db.Authors).filter(func.lower(db.Authors.name).ilike(in_aut)).first()
-        if renamed_author and in_aut != renamed_author.name:
+        # The custom lower() SQL function transliterates via unidecode (see cps.db.lcase), so the
+        # case-insensitive lookup above also matches accent- or homophone-twins with a genuinely
+        # different name (e.g. "José Luis Corral"/"Jose Luis Corral", "姚尧"/"妖妖"). Only treat the
+        # match as a case-rename when the names are equal ignoring case; otherwise the rename below
+        # would overwrite a distinct author and hit the authors.name UNIQUE constraint (#3403, #3170).
+        if renamed_author and in_aut != renamed_author.name \
+                and in_aut.casefold() == renamed_author.name.casefold():
             old_author_name = renamed_author.name
             # rename author in Database
             create_objects_for_addition(renamed_author, in_aut,"author")


### PR DESCRIPTION
### Problem

Editing a book's metadata, or uploading a book, can crash with:
```
(sqlite3.IntegrityError) UNIQUE constraint failed: authors.name
[SQL: UPDATE authors SET name=?, sort=? WHERE authors.id = ?]
```
This happens when two authors already exist whose names are different but collapse to the same ASCII string — accented vs. plain Latin names (`José Luis Corral` / `Jose Luis Corral`, `John le Carré` / `John Le Carre`) or Chinese homophones (`姚尧` / `妖妖`).

Closes #3403. This also resolves the same crash reported in #3170 (the accented-name upload case), though I've left that reference out of the closing keywords since it's marked invalid — the patch fixes it regardless.

### Root cause

`cps/db.py` registers a custom `lower()` SQL function (`lcase`) that transliterates via `unidecode`. In `prepare_authors()` the author lookup `func.lower(db.Authors.name).ilike(in_aut)` therefore also matches accent-/homophone-twins that are genuinely different authors. The code then renames that matched author onto the entered name, overwriting a distinct existing row and violating the `authors.name` UNIQUE constraint. Both the upload and edit paths go through `prepare_authors`, so both crash here.

### Fix

Restrict the case-rename branch to matches that are equal ignoring case only (`casefold`). Distinct authors are left untouched; genuine case-only renames (e.g. `stephen king` → `Stephen King`) still work. One-line guard added in `cps/editbooks.py::prepare_authors`.

### Testing

Reproduced the exact `IntegrityError` against an in-memory SQLite DB replicating the custom `lower()` function and the NOCASE-unique `authors` table; confirmed the guard removes the crash for accented and homophone twins while preserving case-renames. (No app+DB integration test added, as the repo's test suite lives in the separate `calibre-web-test` repo.)

### Disclosure

This change was prepared with assistance from Claude (Anthropic). The diagnosis and patch were reviewed against the codebase and verified with a standalone reproduction.
