### PR TITLE
Fix database error for tags differing only by case

### DIFF
--- a/cps/editbooks.py
+++ b/cps/editbooks.py
@@ -1212,8 +1212,17 @@ def edit_book_tags(tags, book):
     if tags is not None:
         input_tags = tags.split(',')
         input_tags = list(map(lambda it: strip_whitespaces(it), input_tags))
-        # Remove duplicates
         input_tags = helper.uniq(input_tags)
+        # Tag names are unique with NOCASE collation in the database. Remove
+        # case-insensitive duplicates before creating book-tag associations.
+        unique_tags = []
+        seen_tags = set()
+        for tag in input_tags:
+            normalized_tag = tag.casefold()
+            if normalized_tag not in seen_tags:
+                seen_tags.add(normalized_tag)
+                unique_tags.append(tag)
+        input_tags = unique_tags
         return modify_database_object(input_tags, book.tags, db.Tags, calibre_db.session, 'tags')
     return False
 


### PR DESCRIPTION
## Summary

  Prevent a database integrity error when a book is saved with duplicate tags that differ only by letter case, such as `Java` and `java`.

  ## How to reproduce

  1. Edit a book.
  2. Set its tags to `Java, java`.
  3. Save the metadata.

  The save currently fails with:

  ```text
  UNIQUE constraint failed: books_tags_link.book, books_tags_link.tag
  ```

  ## Root cause

  helper.uniq() removes exact duplicates but treats Java and java as different values.

  However, tag names use NOCASE collation in the database. Both values therefore resolve to the same tag record, and Calibre-Web attempts to add the same (book, tag) association twice.

  ## Changes

  - Deduplicate tags using str.casefold() before creating book-tag associations.
  - Preserve the spelling and order of the first occurrence.
  - Keep the existing helper.uniq() call so its whitespace normalization behavior remains unchanged.

  For example:

  Java, java, JAVA, Data   Science, Data Science

  is normalized to:

  Java, Data Science

  ## Verification

  - Confirmed that case variants are reduced to a single tag.
  - Confirmed that the first tag spelling is preserved.
  - Confirmed that existing whitespace normalization is preserved.
  - Ran Python syntax compilation for cps/editbooks.py.
  - Ran git diff --check.

  The repository's Python test suite is maintained separately, so no test file is included in this change.