### PR TITLE
Fix Caliblur eReader toolbar dropdown clipping

### DIFF
--- a/cps/static/css/caliBlur.css
+++ b/cps/static/css/caliBlur.css
@@ -477,7 +477,7 @@ body.shelforder > div.container-fluid > div.row-fluid > div.col-sm-10:before {
     color: #fff !important
 }
 
-#have_read_form span, div[aria-label="Download, send to Kindle, reading"] > .btn-group:first-child > p:first-child, div[aria-label="Download, send to Kindle, reading"] > .btn-group:first-child > p:last-child {
+#have_read_form span, div[aria-label^="Download, send"] > .btn-group:first-child > p:first-child, div[aria-label^="Download, send"] > .btn-group:first-child > p:last-child {
     display: none
 }
 
@@ -538,7 +538,7 @@ body.shelforder > div.container-fluid > div.row-fluid > div.col-sm-10:before {
     color: #fff !important
 }
 
-#archived_form span, div[aria-label="Download, send to Kindle, reading"] > .btn-group:first-child > p:first-child, div[aria-label="Download, send to Kindle, reading"] > .btn-group:first-child > p:last-child {
+#archived_form span, div[aria-label^="Download, send"] > .btn-group:first-child > p:first-child, div[aria-label^="Download, send"] > .btn-group:first-child > p:last-child {
     display: none
 }
 
@@ -3160,14 +3160,14 @@ body.book .author {
     margin-left: 0
 }
 
-div.btn-group[role=group][aria-label="Download, send to Kindle, reading"] {
+div.btn-group[role=group][aria-label^="Download, send"] {
     white-space: nowrap;
     display: -webkit-box;
     display: -ms-flexbox;
     display: flex
 }
 
-div.btn-group[role=group][aria-label="Download, send to Kindle, reading"] > div.btn-group[role=group] > p {
+div.btn-group[role=group][aria-label^="Download, send"] > div.btn-group[role=group] > p {
     display: none
 }
 
@@ -3314,7 +3314,7 @@ ul.dropdown-menu.offscreen {
     margin: 2px -160px 0
 }
 
-div.btn-group[role=group][aria-label="Download, send to Kindle, reading"] .dropdown-menu.offscreen {
+div.btn-group[role=group][aria-label^="Download, send"] .dropdown-menu.offscreen {
     position: fixed;
     top: 120px;
     right: 5px
@@ -6927,7 +6927,7 @@ body.edituser.admin > div.container-fluid > div.row-fluid > div.col-sm-10 > div.
         width: 50px
     }
 
-    div.btn-group[role=group][aria-label="Download, send to Kindle, reading"] {
+    div.btn-group[role=group][aria-label^="Download, send"] {
         display: block
     }
 
@@ -6935,7 +6935,7 @@ body.edituser.admin > div.container-fluid > div.row-fluid > div.col-sm-10 > div.
         display: none
     }
 
-    div.btn-group[role=group][aria-label="Download, send to Kindle, reading"] > .downloadBtn {
+    div.btn-group[role=group][aria-label^="Download, send"] > .downloadBtn {
         border-left: 0
     }
 

--- a/cps/static/js/caliBlur.js
+++ b/cps/static/js/caliBlur.js
@@ -154,7 +154,7 @@ if ($("body.book").length > 0) {
     // Move dropdown lists higher in dom, replace bootstrap toggle with own toggle.
     $('ul[aria-labelledby="read-in-browser"]').insertBefore(".blur-wrapper").addClass("readinbrowser-drop");
     $('ul[aria-labelledby="listen-in-browser"]').insertBefore(".blur-wrapper").addClass("readinbrowser-drop");
-    $('ul[aria-labelledby="send-to-kereader"]').insertBefore(".blur-wrapper").addClass("sendtoereader-drop");
+    $('ul[aria-labelledby="send-to-ereader"]').insertBefore(".blur-wrapper").addClass("sendtoereader-drop");
     $(".leramslist").insertBefore(".blur-wrapper");
     $('ul[aria-labelledby="btnGroupDrop1"]').insertBefore(".blur-wrapper").addClass("leramslist");
     $("#add-to-shelves").insertBefore(".blur-wrapper");


### PR DESCRIPTION
## Problem

In the Caliblur theme, the **Send to eReader** dropdown on the book details page can be clipped by the content panel, especially at narrower viewport widths.

The dropdown is supposed to be moved higher in the DOM and positioned against the viewport. However, Caliblur looks for:

```js
ul[aria-labelledby="send-to-kereader"]
```

while the template renders:

```html
<ul aria-labelledby="send-to-ereader">
```

As a result, the menu never receives the `sendtoereader-drop` class or the viewport-aware positioning logic.

Several related Caliblur CSS selectors also still target the old accessible label `Download, send to Kindle, reading`, while the current template uses `Download, send to eReader, reading`. This prevents the intended toolbar layout rules from applying.

## Solution

- Fix the typo in the Send to eReader dropdown selector.
- Replace the stale exact Kindle toolbar label selectors with a stable `aria-label^="Download, send"` prefix selector.

This keeps the selectors compatible with the current eReader wording and avoids coupling layout behavior to the full accessible label.

## Verification

- Confirmed that the template's `send-to-ereader` identifier matches the JavaScript selector.
- Confirmed that no stale `send-to-kereader` or `Download, send to Kindle, reading` selectors remain in the affected Caliblur files.
- `node --check cps/static/js/caliBlur.js`
- `git diff --check`
