### PR TITLE
Update Swedish translation

### DIFF
--- a/cps/translations/sv/LC_MESSAGES/messages.po
+++ b/cps/translations/sv/LC_MESSAGES/messages.po
@@ -1,22 +1,24 @@
-# German translations for Calibre-Web.
+# Swedish translations for Calibre-Web.
 # Copyright (C) 2016 Ozzie Isaacs
 # This file is distributed under the same license as the Calibre-Web
 # project.
 # FIRST AUTHOR OzzieIsaacs, 2016.
+# Jonatan Nyberg, 2021, 2026.
 msgid ""
 msgstr ""
-"Project-Id-Version:  Calibre-Web\n"
-"Report-Msgid-Bugs-To: https://github.com/janeczku/Calibre-Web\n"
+"Project-Id-Version: Calibre-Web\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2026-08-08 16:08+0200\n"
-"PO-Revision-Date: 2021-05-13 11:00+0000\n"
-"Last-Translator: Jonatan Nyberg <jonatan.nyberg.karl@gmail.com>\n"
-"Language: sv\n"
+"PO-Revision-Date: 2026-08-15 12:46+0300\n"
+"Last-Translator: Jonatan Nyberg, 2026\n"
 "Language-Team: \n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: sv\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.18.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Generated-By: Babel 2.8.0\n"
+"X-Generator: Poedit 2.4.2\n"
 
 #: cps/about.py:85
 msgid "Statistics"
@@ -24,23 +26,24 @@ msgstr "Statistik"
 
 #: cps/admin.py:154
 msgid "Server restarted, please reload page."
-msgstr ""
+msgstr "Servern har startats om. Läs in sidan igen."
 
 #: cps/admin.py:156
 msgid "Performing Server shutdown, please close window."
-msgstr ""
+msgstr "Servern stängs av. Stäng fönstret."
 
 #: cps/admin.py:164
 msgid "Success! Database Reconnected"
-msgstr ""
+msgstr "Databasen har återanslutits."
 
 #: cps/admin.py:167
 msgid "Unknown command"
 msgstr "Okänt kommando"
 
 #: cps/admin.py:178
-msgid "Success! Books queued for Metadata Backup, please check Tasks for result"
-msgstr ""
+msgid ""
+"Success! Books queued for Metadata Backup, please check Tasks for result"
+msgstr "Böckerna har lagts i kö för säkerhetskopiering av metadata. Kontrollera Uppgifter för resultatet."
 
 #: cps/admin.py:211 cps/editbooks.py:825 cps/editbooks.py:875
 #: cps/editbooks.py:1564 cps/templates/remote_login_verify.html:8
@@ -59,13 +62,13 @@ msgstr "Grundläggande konfiguration"
 
 #: cps/admin.py:294
 msgid "UI Configuration"
-msgstr "Användargränssnitt konfiguration"
+msgstr "Konfiguration av användargränssnitt"
 
 #: cps/admin.py:318 cps/admin.py:1005 cps/db.py:809 cps/search.py:150
 #: cps/web.py:752
 #, python-format
 msgid "Custom Column No.%(column)d does not exist in calibre database"
-msgstr ""
+msgstr "Den anpassade kolumnen nr %(column)d finns inte i Calibre-databasen"
 
 #: cps/admin.py:336 cps/templates/admin.html:51
 msgid "Edit Users"
@@ -96,7 +99,7 @@ msgstr "Felaktig begäran"
 
 #: cps/admin.py:480 cps/admin.py:2156
 msgid "Guest Name can't be changed"
-msgstr "Gästnamn kan inte ändras"
+msgstr "Gästnamnet kan inte ändras"
 
 #: cps/admin.py:492
 msgid "Guest can't have this role"
@@ -104,7 +107,8 @@ msgstr "Gäst kan inte ha den här rollen"
 
 #: cps/admin.py:504 cps/admin.py:2110
 msgid "No admin user remaining, can't remove admin role"
-msgstr "Ingen administratörsanvändare kvar, kan inte ta bort administratörsrollen"
+msgstr ""
+"Ingen administratörsanvändare kvar, kan inte ta bort administratörsrollen"
 
 #: cps/admin.py:508 cps/admin.py:522
 msgid "Value has to be true or false"
@@ -128,11 +132,11 @@ msgstr "Gästens språk bestäms automatiskt och kan inte ställas in"
 
 #: cps/admin.py:531
 msgid "No Valid Locale Given"
-msgstr "Inget giltigt språk anges"
+msgstr "Inget giltigt språk har angetts"
 
 #: cps/admin.py:542
 msgid "No Valid Book Language Given"
-msgstr "Inget giltigt bokspråk anges"
+msgstr "Inget giltigt bokspråk har angetts"
 
 #: cps/admin.py:544 cps/editbooks.py:260 cps/editbooks.py:445
 #: cps/editbooks.py:447
@@ -141,15 +145,15 @@ msgstr "Parameter hittades inte"
 
 #: cps/admin.py:581
 msgid "Invalid Read Column"
-msgstr ""
+msgstr "Ogiltig kolumn för lässtatus"
 
 #: cps/admin.py:587
 msgid "Invalid Restricted Column"
-msgstr ""
+msgstr "Ogiltig begränsningskolumn"
 
 #: cps/admin.py:607 cps/admin.py:1981
 msgid "Calibre-Web configuration updated"
-msgstr "Calibre-Web konfiguration uppdaterad"
+msgstr "Calibre-Web-konfigurationen har uppdaterats"
 
 #: cps/admin.py:619
 msgid "Do you really want to delete the Kobo Token?"
@@ -165,7 +169,7 @@ msgstr "Vill du verkligen ta bort den här användaren?"
 
 #: cps/admin.py:625
 msgid "Do you really want to delete this book?"
-msgstr ""
+msgstr "Vill du verkligen ta bort den här boken?"
 
 #: cps/admin.py:627
 msgid "Are you sure you want to delete this shelf?"
@@ -176,50 +180,68 @@ msgid "Are you sure you want to change locales of selected user(s)?"
 msgstr "Är du säker på att du vill ändra språk för valda användare?"
 
 #: cps/admin.py:631
-msgid "Are you sure you want to change visible book languages for selected user(s)?"
+msgid ""
+"Are you sure you want to change visible book languages for selected user(s)?"
 msgstr "Är du säker på att du vill ändra synliga bokspråk för valda användare?"
 
 #: cps/admin.py:633
-msgid "Are you sure you want to change the selected role for the selected user(s)?"
-msgstr "Är du säker på att du vill ändra den valda rollen för de valda användarna?"
+msgid ""
+"Are you sure you want to change the selected role for the selected user(s)?"
+msgstr ""
+"Är du säker på att du vill ändra den valda rollen för de valda användarna?"
 
 #: cps/admin.py:635
-msgid "Are you sure you want to change the archive status for the selected book(s)?"
-msgstr ""
+msgid ""
+"Are you sure you want to change the archive status for the selected book(s)?"
+msgstr "Vill du ändra arkivstatus för de markerade böckerna?"
 
 #: cps/admin.py:637
-msgid "Are you sure you want to change the read status for the selected book(s)?"
-msgstr ""
+msgid ""
+"Are you sure you want to change the read status for the selected book(s)?"
+msgstr "Vill du ändra lässtatus för de markerade böckerna?"
 
 #: cps/admin.py:639
-msgid "Are you sure you want to change the selected restrictions for the selected user(s)?"
-msgstr "Är du säker på att du vill ändra de valda begränsningarna för de valda användarna?"
+msgid ""
+"Are you sure you want to change the selected restrictions for the selected "
+"user(s)?"
+msgstr ""
+"Är du säker på att du vill ändra de valda begränsningarna för de valda "
+"användarna?"
 
 #: cps/admin.py:641
-msgid "Are you sure you want to change the selected visibility restrictions for the selected user(s)?"
-msgstr "Är du säker på att du vill ändra de valda synlighetsbegränsningarna för de valda användarna?"
+msgid ""
+"Are you sure you want to change the selected visibility restrictions for the "
+"selected user(s)?"
+msgstr ""
+"Är du säker på att du vill ändra de valda synlighetsbegränsningarna för de "
+"valda användarna?"
 
 #: cps/admin.py:644
-msgid "Are you sure you want to change shelf sync behavior for the selected user(s)?"
-msgstr ""
+msgid ""
+"Are you sure you want to change shelf sync behavior for the selected user(s)?"
+msgstr "Vill du ändra hyllsynkroniseringen för de markerade användarna?"
 
 #: cps/admin.py:646
 msgid "Are you sure you want to change Calibre library location?"
-msgstr ""
+msgstr "Vill du verkligen ändra platsen för Calibre-biblioteket?"
 
 #: cps/admin.py:648
-msgid "Calibre-Web will search for updated Covers and update Cover Thumbnails, this may take a while?"
-msgstr ""
+msgid ""
+"Calibre-Web will search for updated Covers and update Cover Thumbnails, this "
+"may take a while?"
+msgstr "Calibre-Web söker efter uppdaterade omslag och uppdaterar omslagsminiatyrerna. Det kan ta en stund. Vill du fortsätta?"
 
 #: cps/admin.py:651
-msgid "Are you sure you want delete Calibre-Web's sync database to force a full sync with your Kobo Reader?"
-msgstr ""
+msgid ""
+"Are you sure you want delete Calibre-Web's sync database to force a full "
+"sync with your Kobo Reader?"
+msgstr "Vill du verkligen ta bort Calibre-Webs synkroniseringsdatabas för att tvinga fram en fullständig synkronisering med din Kobo-läsare?"
 
 #: cps/admin.py:894 cps/admin.py:900 cps/admin.py:910 cps/admin.py:920
 #: cps/templates/modal_dialogs.html:29 cps/templates/user_table.html:41
 #: cps/templates/user_table.html:58
 msgid "Deny"
-msgstr "Förneka"
+msgstr "Neka"
 
 #: cps/admin.py:896 cps/admin.py:902 cps/admin.py:912 cps/admin.py:922
 #: cps/templates/modal_dialogs.html:28 cps/templates/user_table.html:44
@@ -230,7 +252,7 @@ msgstr "Tillåt"
 #: cps/admin.py:955
 #, python-brace-format
 msgid "{} sync entries deleted"
-msgstr ""
+msgstr "{} synkroniseringsposter har tagits bort"
 
 #: cps/admin.py:996
 msgid "Tag not found"
@@ -243,12 +265,12 @@ msgstr "Ogiltig åtgärd"
 #: cps/admin.py:1137
 #, python-format
 msgid "Invalid reverse proxy trusted IP/CIDR entry: %(entry)s"
-msgstr ""
+msgstr "Ogiltig betrodd IP-/CIDR-post för omvänd proxy: %(entry)s"
 
 #: cps/admin.py:1148
 #, python-format
 msgid "Invalid %(label)s: %(value)s"
-msgstr ""
+msgstr "Ogiltig %(label)s: %(value)s"
 
 #: cps/admin.py:1166
 msgid "client_secrets.json Is Not Configured For Web Application"
@@ -260,19 +282,20 @@ msgstr "Loggfilens plats är inte giltig, vänligen ange rätt sökväg"
 
 #: cps/admin.py:1217
 msgid "Access Logfile Location is not Valid, Please Enter Correct Path"
-msgstr "Åtkomstloggplatsens plats är inte giltig, vänligen ange rätt sökväg"
+msgstr "Åtkomstloggfilens plats är inte giltig. Ange rätt sökväg"
 
 #: cps/admin.py:1251
 msgid "Please Enter a LDAP Provider, Port, DN and User Object Identifier"
-msgstr "Vänligen ange en LDAP-leverantör, port, DN och användarobjektidentifierare"
+msgstr ""
+"Vänligen ange en LDAP-leverantör, port, DN och användarobjektidentifierare"
 
 #: cps/admin.py:1257
 msgid "Please Enter a LDAP Service Account and Password"
-msgstr ""
+msgstr "Ange ett LDAP-tjänstekonto och lösenord"
 
 #: cps/admin.py:1260
 msgid "Please Enter a LDAP Service Account"
-msgstr ""
+msgstr "Ange ett LDAP-tjänstekonto"
 
 #: cps/admin.py:1265
 #, python-format
@@ -281,7 +304,7 @@ msgstr "LDAP-gruppobjektfilter måste ha en \"%s\"-formatidentifierare"
 
 #: cps/admin.py:1267
 msgid "LDAP Group Object Filter Has Unmatched Parenthesis"
-msgstr "LDAP-gruppobjektfilter har omatchande parentes"
+msgstr "LDAP-gruppobjektfiltret har en omatchad parentes"
 
 #: cps/admin.py:1271
 #, python-format
@@ -290,20 +313,25 @@ msgstr "LDAP-användarobjektfilter måste ha en \"%s\"-formatidentifierare"
 
 #: cps/admin.py:1273
 msgid "LDAP User Object Filter Has Unmatched Parenthesis"
-msgstr "LDAP-användarobjektfilter har omatchad parentes"
+msgstr "LDAP-användarobjektfiltret har en omatchad parentes"
 
 #: cps/admin.py:1280
 #, python-format
 msgid "LDAP Member User Filter needs to Have One \"%s\" Format Identifier"
-msgstr "Användarfilter för LDAP-medlemmar måste ha en \"%s\"-formatidentifierare"
+msgstr ""
+"Användarfilter för LDAP-medlemmar måste ha en \"%s\"-formatidentifierare"
 
 #: cps/admin.py:1282
 msgid "LDAP Member User Filter Has Unmatched Parenthesis"
-msgstr "Användarfilter för LDAP-medlemmar har omatchad parentes"
+msgstr "LDAP-användarfiltret för medlemmar har en omatchad parentes"
 
 #: cps/admin.py:1289
-msgid "LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter Correct Path"
-msgstr "LDAP-certifikat, certifikat eller nyckelplats är inte giltigt, vänligen ange rätt sökväg"
+msgid ""
+"LDAP CACertificate, Certificate or Key Location is not Valid, Please Enter "
+"Correct Path"
+msgstr ""
+"Sökvägen till LDAP-CA-certifikatet, certifikatet eller nyckeln är inte "
+"giltig. Ange rätt sökväg"
 
 #: cps/admin.py:1320 cps/templates/admin.html:53
 msgid "Add New User"
@@ -315,7 +343,7 @@ msgstr "Ändra SMTP-inställningar"
 
 #: cps/admin.py:1348
 msgid "Success! Gmail Account Verified."
-msgstr ""
+msgstr "Gmail-kontot har verifierats."
 
 #: cps/admin.py:1368 cps/admin.py:1371 cps/admin.py:1756 cps/admin.py:1965
 #: cps/admin.py:2063 cps/admin.py:2184 cps/editbooks.py:170
@@ -328,13 +356,16 @@ msgstr "Databasfel: %(error)s."
 
 #: cps/admin.py:1378
 #, python-format
-msgid "Test e-mail queued for sending to %(email)s, please check Tasks for result"
-msgstr "Testa e-post i kö för att skicka till %(email)s, vänligen kontrollera Uppgifter för resultat"
+msgid ""
+"Test e-mail queued for sending to %(email)s, please check Tasks for result"
+msgstr ""
+"Testmeddelandet har lagts i kö för att skickas till %(email)s. Kontrollera "
+"Uppgifter för resultatet"
 
 #: cps/admin.py:1381
 #, python-format
 msgid "There was an error sending the Test e-mail: %(res)s"
-msgstr "Det gick inte att skicka Testmeddelandet: %(res)s"
+msgstr "Det gick inte att skicka testmeddelandet: %(res)s"
 
 #: cps/admin.py:1383
 msgid "Please configure your e-mail address first..."
@@ -346,19 +377,19 @@ msgstr "E-postserverinställningar uppdaterade"
 
 #: cps/admin.py:1408 cps/templates/admin.html:211
 msgid "Edit Scheduled Tasks Settings"
-msgstr ""
+msgstr "Redigera inställningar för schemalagda uppgifter"
 
 #: cps/admin.py:1420
 msgid "Invalid start time for task specified"
-msgstr ""
+msgstr "Ogiltig starttid har angetts för uppgiften"
 
 #: cps/admin.py:1425
 msgid "Invalid duration for task specified"
-msgstr ""
+msgstr "Ogiltig varaktighet har angetts för uppgiften"
 
 #: cps/admin.py:1435
 msgid "Scheduled tasks settings updated"
-msgstr ""
+msgstr "Inställningarna för schemalagda uppgifter har uppdaterats"
 
 #: cps/admin.py:1445 cps/admin.py:1494 cps/admin.py:2180 cps/web.py:1335
 msgid "Oops! An unknown error occurred. Please try again later."
@@ -366,7 +397,7 @@ msgstr "Ett okänt fel uppstod. Försök igen senare."
 
 #: cps/admin.py:1449
 msgid "Settings DB is not Writeable"
-msgstr ""
+msgstr "Inställningsdatabasen är inte skrivbar"
 
 #: cps/admin.py:1479 cps/admin.py:2172
 #, python-format
@@ -376,15 +407,15 @@ msgstr "Redigera användaren %(nick)s"
 #: cps/admin.py:1491
 #, python-format
 msgid "Success! Password for user %(user)s reset"
-msgstr ""
+msgstr "Lösenordet för användaren %(user)s har återställts"
 
 #: cps/admin.py:1497
 msgid "Oops! Please configure the SMTP mail settings."
-msgstr ""
+msgstr "Konfigurera SMTP-inställningarna för e-post."
 
 #: cps/admin.py:1508
 msgid "Logfile viewer"
-msgstr "Visaren för loggfil"
+msgstr "Loggfilvisare"
 
 #: cps/admin.py:1574
 msgid "Requesting update package"
@@ -400,7 +431,7 @@ msgstr "Packar upp uppdateringspaketet"
 
 #: cps/admin.py:1577
 msgid "Replacing files"
-msgstr "Ersätta filer"
+msgstr "Ersätter filer"
 
 #: cps/admin.py:1578
 msgid "Database connections are closed"
@@ -408,11 +439,11 @@ msgstr "Databasanslutningarna är stängda"
 
 #: cps/admin.py:1579
 msgid "Stopping server"
-msgstr "Stoppar server"
+msgstr "Stoppar servern"
 
 #: cps/admin.py:1580
 msgid "Update finished, please press okay and reload page"
-msgstr "Uppdatering klar, tryck på okej och uppdatera sidan"
+msgstr "Uppdateringen är klar. Tryck på OK och läs in sidan igen"
 
 #: cps/admin.py:1581 cps/admin.py:1582 cps/admin.py:1583 cps/admin.py:1584
 #: cps/admin.py:1585 cps/admin.py:1586
@@ -429,7 +460,7 @@ msgstr "Anslutningsfel"
 
 #: cps/admin.py:1583 cps/updater.py:395 cps/updater.py:632
 msgid "Timeout while establishing connection"
-msgstr "Tiden ute när du etablerade anslutning"
+msgstr "Tidsgränsen överskreds när anslutningen skulle upprättas"
 
 #: cps/admin.py:1584 cps/updater.py:397 cps/updater.py:634
 msgid "General error"
@@ -437,15 +468,15 @@ msgstr "Allmänt fel"
 
 #: cps/admin.py:1585
 msgid "Update file could not be saved in temp dir"
-msgstr ""
+msgstr "Uppdateringsfilen kunde inte sparas i den tillfälliga mappen"
 
 #: cps/admin.py:1586
 msgid "Files could not be replaced during update"
-msgstr ""
+msgstr "Filer kunde inte ersättas under uppdateringen"
 
 #: cps/admin.py:1610
 msgid "Failed to extract at least One LDAP User"
-msgstr ""
+msgstr "Det gick inte att hämta minst en LDAP-användare"
 
 #: cps/admin.py:1655
 msgid "Failed to Create at Least One LDAP User"
@@ -458,7 +489,7 @@ msgstr "Fel: %(ldaperror)s"
 
 #: cps/admin.py:1672
 msgid "Error: No user returned in response of LDAP server"
-msgstr "Fel: Ingen användare återges som svar på LDAP-servern"
+msgstr "Fel: LDAP-servern returnerade ingen användare"
 
 #: cps/admin.py:1708
 msgid "At Least One LDAP User Not Found in Database"
@@ -471,63 +502,66 @@ msgstr "{} användare har importerats"
 
 #: cps/admin.py:1768
 msgid "Books path not valid"
-msgstr ""
+msgstr "Sökvägen till böckerna är ogiltig"
 
 #: cps/admin.py:1774
 msgid "DB Location is not Valid, Please Enter Correct Path"
-msgstr "DB-plats är inte giltig, vänligen ange rätt sökväg"
+msgstr "Databasens plats är inte giltig. Ange rätt sökväg"
 
 #: cps/admin.py:1802
 msgid "DB is not Writeable"
-msgstr "DB är inte skrivbar"
+msgstr "Databasen är inte skrivbar"
 
 #: cps/admin.py:1816
 msgid "Keyfile Location is not Valid, Please Enter Correct Path"
-msgstr "Keyfile-platsen är inte giltig, vänligen ange rätt sökväg"
+msgstr "Nyckelfilens plats är inte giltig. Ange rätt sökväg"
 
 #: cps/admin.py:1820
 msgid "Certfile Location is not Valid, Please Enter Correct Path"
-msgstr "Certfile-platsen är inte giltig, vänligen ange rätt sökväg"
+msgstr "Certifikatfilens plats är inte giltig. Ange rätt sökväg"
 
 #: cps/admin.py:1846
 msgid "Kepubify binary not found"
-msgstr ""
+msgstr "Körfilen för Kepubify hittades inte"
 
 #: cps/admin.py:1894
 msgid "reverse proxy login header name"
-msgstr ""
+msgstr "namn på inloggningshuvud för omvänd proxy"
 
 #: cps/admin.py:1904
 msgid "reverse proxy shared secret header name"
-msgstr ""
+msgstr "namn på huvud för delad hemlighet för omvänd proxy"
 
 #: cps/admin.py:1913
-msgid "Please configure both reverse proxy shared secret header name and secret"
-msgstr ""
+msgid ""
+"Please configure both reverse proxy shared secret header name and secret"
+msgstr "Konfigurera både namnet på huvudet för den delade hemligheten och själva hemligheten för den omvända proxyn"
 
 #: cps/admin.py:1917
-msgid "Please configure reverse proxy shared secret header name and secret or disable the feature"
-msgstr ""
+msgid ""
+"Please configure reverse proxy shared secret header name and secret or "
+"disable the feature"
+msgstr "Konfigurera namn och hemlighet för den omvända proxyns huvud för delad hemlighet, eller inaktivera funktionen"
 
 #: cps/admin.py:1922
 msgid "Please configure at least one trusted reverse proxy IP or CIDR"
-msgstr ""
+msgstr "Konfigurera minst en betrodd IP-adress eller CIDR för omvänd proxy"
 
 #: cps/admin.py:1946
 msgid "Password length has to be between 1 and 40"
-msgstr ""
+msgstr "Lösenordets längd måste vara mellan 1 och 40 tecken"
 
 #: cps/admin.py:1957 cps/helper.py:1007
 msgid "Please specify a valid UnRar directory"
-msgstr ""
+msgstr "Ange en giltig katalog för UnRar"
 
 #: cps/admin.py:2004
 msgid "Database Settings updated"
-msgstr ""
+msgstr "Databasinställningarna har uppdaterats"
 
 #: cps/admin.py:2012
 msgid "Database Configuration"
-msgstr ""
+msgstr "Databaskonfiguration"
 
 #: cps/admin.py:2027 cps/web.py:1305
 msgid "Oops! Please complete all fields."
@@ -535,7 +569,7 @@ msgstr "Fyll i alla fält!"
 
 #: cps/admin.py:2036
 msgid "E-mail is not from valid domain"
-msgstr "E-posten är inte från giltig domän"
+msgstr "E-postadressen kommer inte från en giltig domän"
 
 #: cps/admin.py:2042
 msgid "Add new user"
@@ -561,11 +595,11 @@ msgstr "Det går inte att ta bort gästanvändaren"
 
 #: cps/admin.py:2095
 msgid "No admin user remaining, can't delete user"
-msgstr "Ingen adminstratörsanvändare kvar, kan inte ta bort användaren"
+msgstr "Ingen administratörsanvändare finns kvar. Användaren kan inte tas bort"
 
 #: cps/admin.py:2150 cps/web.py:1485
 msgid "Email can't be empty and has to be a valid Email"
-msgstr ""
+msgstr "E-postadressen får inte vara tom och måste vara giltig"
 
 #: cps/admin.py:2176
 #, python-format
@@ -586,7 +620,7 @@ msgstr "inte installerad"
 
 #: cps/converter.py:33
 msgid "Execution permissions missing"
-msgstr "Körningstillstånd saknas"
+msgstr "Körbehörighet saknas"
 
 #: cps/db.py:1129 cps/templates/config_edit.html:229
 #: cps/templates/config_view_edit.html:62 cps/templates/email_edit.html:41
@@ -599,7 +633,7 @@ msgstr "Ingen"
 #: cps/editbooks.py:156
 #, python-format
 msgid "File %(file)s uploaded"
-msgstr "Filen %(file)s uppladdad"
+msgstr "Filen %(file)s har laddats upp"
 
 #: cps/editbooks.py:185
 msgid "Source or destination format for conversion missing"
@@ -607,11 +641,11 @@ msgstr "Källa eller målformat för konvertering saknas"
 
 #: cps/editbooks.py:189 cps/editbooks.py:197
 msgid "Source format for conversion not supported"
-msgstr ""
+msgstr "Källformatet för konvertering stöds inte"
 
 #: cps/editbooks.py:201
 msgid "Destination format for conversion not supported"
-msgstr ""
+msgstr "Målformatet för konvertering stöds inte"
 
 #: cps/editbooks.py:209
 #, python-format
@@ -625,30 +659,35 @@ msgstr "Det gick inte att konvertera den här boken: %(res)s"
 
 #: cps/editbooks.py:314
 msgid "Changes successfully applied"
-msgstr ""
+msgstr "Ändringarna har tillämpats"
 
 #: cps/editbooks.py:334
 msgid "Value is missing on request"
-msgstr ""
+msgstr "Ett värde saknas i begäran"
 
 #: cps/editbooks.py:336 cps/editbooks.py:343 cps/editbooks.py:644
 #: cps/editbooks.py:1170 cps/web.py:534 cps/web.py:1577 cps/web.py:1623
 #: cps/web.py:1673
-msgid "Oops! Selected book is unavailable. File does not exist or is not accessible"
-msgstr "Hoppsan! Vald boktitel är inte tillgänglig. Filen finns inte eller är inte tillgänglig"
+msgid ""
+"Oops! Selected book is unavailable. File does not exist or is not accessible"
+msgstr ""
+"Hoppsan! Vald boktitel är inte tillgänglig. Filen finns inte eller är inte "
+"tillgänglig"
 
 #: cps/editbooks.py:690 cps/editbooks.py:1547
 msgid "User has no rights to upload cover"
-msgstr ""
+msgstr "Användaren har inte behörighet att ladda upp omslag"
 
 #: cps/editbooks.py:711 cps/editbooks.py:961
 msgid "Identifiers are not Case Sensitive, Overwriting Old Identifier"
-msgstr "Identifierare är inte skiftlägeskänsliga, skriver över gammal identifierare"
+msgstr ""
+"Identifierare är inte skiftlägeskänsliga. Den gamla identifieraren skrivs "
+"över"
 
 #: cps/editbooks.py:726 cps/editbooks.py:935 cps/editbooks.py:1306
 #, python-format
 msgid "'%(langname)s' is not a valid language"
-msgstr ""
+msgstr "'%(langname)s' är inte ett giltigt språk"
 
 #: cps/editbooks.py:754
 msgid "Metadata successfully updated"
@@ -657,15 +696,19 @@ msgstr "Metadata uppdaterades"
 #: cps/editbooks.py:777
 #, python-brace-format
 msgid "Error editing book: {}"
-msgstr ""
+msgstr "Fel vid redigering av boken: {}"
 
 #: cps/editbooks.py:879
-msgid "Uploaded book probably exists in the library, consider to change before upload new: "
-msgstr "Uppladdad bok finns förmodligen i biblioteket, överväg att ändra innan du laddar upp nya: "
+msgid ""
+"Uploaded book probably exists in the library, consider to change before "
+"upload new: "
+msgstr ""
+"Den uppladdade boken finns förmodligen redan i biblioteket. Överväg att "
+"ändra den innan du laddar upp en ny: "
 
 #: cps/editbooks.py:973 cps/editbooks.py:1464
 msgid "File type isn't allowed to be uploaded to this server"
-msgstr ""
+msgstr "Den här filtypen får inte laddas upp till servern"
 
 #: cps/editbooks.py:979 cps/editbooks.py:1475
 #, python-format
@@ -679,7 +722,7 @@ msgstr "Filen som ska laddas upp måste ha en ändelse"
 #: cps/editbooks.py:992
 #, python-format
 msgid "File %(filename)s could not saved to temp dir"
-msgstr "Filen %(filename)s kunde inte sparas i temp dir"
+msgstr "Filen %(filename)s kunde inte sparas i den tillfälliga mappen"
 
 #: cps/editbooks.py:1012
 #, python-format
@@ -696,12 +739,12 @@ msgstr "Boken har tagits bort"
 
 #: cps/editbooks.py:1089
 msgid "You are missing permissions to delete books"
-msgstr ""
+msgstr "Du saknar behörighet att ta bort böcker"
 
 #: cps/editbooks.py:1163
 #, python-brace-format
 msgid "Book with id \"{}\" could not be deleted: not found"
-msgstr ""
+msgstr "Boken med id \"{}\" kunde inte tas bort: den hittades inte"
 
 #: cps/editbooks.py:1205
 msgid "edit metadata"
@@ -710,11 +753,11 @@ msgstr "redigera metadata"
 #: cps/editbooks.py:1267
 #, python-format
 msgid "Seriesindex: %(seriesindex)s is not a valid number, skipping"
-msgstr ""
+msgstr "Serieindexet %(seriesindex)s är inte ett giltigt tal och hoppas över"
 
 #: cps/editbooks.py:1469
 msgid "User has no rights to upload additional file formats"
-msgstr ""
+msgstr "Användaren har inte behörighet att ladda upp ytterligare filformat"
 
 #: cps/editbooks.py:1493
 #, python-format
@@ -733,7 +776,7 @@ msgstr "Filformatet %(ext)s lades till %(book)s"
 
 #: cps/error_handler.py:107
 msgid "Please wait one minute to register next user"
-msgstr ""
+msgstr "Vänta en minut innan nästa användare registreras"
 
 #: cps/error_handler.py:108 cps/templates/layout.html:69
 #: cps/templates/layout.html:104 cps/templates/login.html:27
@@ -745,20 +788,28 @@ msgstr "Registrera"
 
 #: cps/error_handler.py:112
 msgid "Please wait one minute before next login"
-msgstr ""
+msgstr "Vänta en minut före nästa inloggning"
 
 #: cps/gdrive.py:58
-msgid "Google Drive setup not completed, try to deactivate and activate Google Drive again"
-msgstr "Installationen av Google Drive är inte klar, försök att inaktivera och aktivera Google Drive igen"
+msgid ""
+"Google Drive setup not completed, try to deactivate and activate Google "
+"Drive again"
+msgstr ""
+"Installationen av Google Drive är inte klar, försök att inaktivera och "
+"aktivera Google Drive igen"
 
 #: cps/gdrive.py:96
-msgid "Callback domain is not verified, please follow steps to verify domain in google developer console"
-msgstr "Återuppringningsdomänen är inte verifierad, följ stegen för att verifiera domänen i Google utvecklarkonsol"
+msgid ""
+"Callback domain is not verified, please follow steps to verify domain in "
+"google developer console"
+msgstr ""
+"Återanropsdomänen är inte verifierad. Följ stegen för att verifiera domänen "
+"i Google Developer Console"
 
 #: cps/helper.py:88
 #, python-format
 msgid "%(format)s format not found for book id: %(book)d"
-msgstr "%(format)s formatet hittades inte för bok-id: %(book)d"
+msgstr "Formatet %(format)s hittades inte för bok-id %(book)d"
 
 #: cps/helper.py:94 cps/tasks/convert.py:92
 #, python-format
@@ -772,50 +823,50 @@ msgstr "%(format)s hittades inte: %(fn)s"
 
 #: cps/helper.py:105 cps/helper.py:236 cps/templates/detail.html:66
 msgid "Send to eReader"
-msgstr ""
+msgstr "Skicka till e-läsare"
 
 #: cps/helper.py:106 cps/helper.py:126 cps/helper.py:238
 msgid "This Email has been sent via Calibre-Web."
-msgstr ""
+msgstr "Det här e-postmeddelandet har skickats via Calibre-Web."
 
 #: cps/helper.py:124
 msgid "Calibre-Web Test Email"
-msgstr ""
+msgstr "Testmeddelande från Calibre-Web"
 
 #: cps/helper.py:125
 msgid "Test Email"
-msgstr ""
+msgstr "Testmeddelande"
 
 #: cps/helper.py:133
 #, python-format
 msgid "Hi %(name)s!"
-msgstr ""
+msgstr "Hej %(name)s!"
 
 #: cps/helper.py:135
 msgid "Your account at Calibre-Web has been created."
-msgstr ""
+msgstr "Ditt konto i Calibre-Web har skapats."
 
 #: cps/helper.py:136
 msgid "Please log in using the following information:"
-msgstr ""
+msgstr "Logga in med följande uppgifter:"
 
 #: cps/helper.py:137
 #, python-format
 msgid "Username: %(name)s"
-msgstr ""
+msgstr "Användarnamn: %(name)s"
 
 #: cps/helper.py:138
 #, python-format
 msgid "Password: %(password)s"
-msgstr ""
+msgstr "Lösenord: %(password)s"
 
 #: cps/helper.py:139
 msgid "Don't forget to change your password after your first login."
-msgstr ""
+msgstr "Glöm inte att ändra lösenordet efter din första inloggning."
 
 #: cps/helper.py:140
 msgid "Regards,"
-msgstr ""
+msgstr "Med vänlig hälsning,"
 
 #: cps/helper.py:142
 msgid "Get Started with Calibre-Web"
@@ -824,22 +875,22 @@ msgstr "Kom igång med Calibre-Web"
 #: cps/helper.py:149
 #, python-format
 msgid "Registration Email for user: %(name)s"
-msgstr ""
+msgstr "Registreringsmeddelande för användaren: %(name)s"
 
 #: cps/helper.py:160 cps/helper.py:166
 #, python-format
 msgid "Convert %(orig)s to %(format)s and send to eReader"
-msgstr ""
+msgstr "Konvertera %(orig)s till %(format)s och skicka till e-läsare"
 
 #: cps/helper.py:185 cps/helper.py:189 cps/helper.py:193
 #, python-format
 msgid "Send %(format)s to eReader"
-msgstr ""
+msgstr "Skicka %(format)s till e-läsare"
 
 #: cps/helper.py:233
 #, python-format
 msgid "%(book)s send to eReader"
-msgstr ""
+msgstr "%(book)s skickad till e-läsare"
 
 #: cps/helper.py:240
 msgid "The requested file could not be read. Maybe wrong permissions?"
@@ -848,12 +899,15 @@ msgstr "Den begärda filen kunde inte läsas. Kanske fel behörigheter?"
 #: cps/helper.py:353
 #, python-brace-format
 msgid "Read status could not set: {}"
-msgstr ""
+msgstr "Lässtatus kunde inte ställas in: {}"
 
 #: cps/helper.py:376
 #, python-format
-msgid "Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
-msgstr "Borttagning av bokmapp för boken %(id)s misslyckades, sökvägen har undermappar: %(path)s"
+msgid ""
+"Deleting bookfolder for book %(id)s failed, path has subfolders: %(path)s"
+msgstr ""
+"Borttagning av bokmapp för boken %(id)s misslyckades, sökvägen har "
+"undermappar: %(path)s"
 
 #: cps/helper.py:382
 #, python-format
@@ -862,18 +916,23 @@ msgstr "Borttagning av boken %(id)s misslyckades: %(message)s"
 
 #: cps/helper.py:393
 #, python-format
-msgid "Deleting book %(id)s from database only, book path in database not valid: %(path)s"
-msgstr ""
+msgid ""
+"Deleting book %(id)s from database only, book path in database not valid: "
+"%(path)s"
+msgstr "Tar endast bort boken %(id)s från databasen eftersom bokens sökväg är ogiltig: %(path)s"
 
 #: cps/helper.py:407
 #, python-format
-msgid "Moving book path of Book %(book_id)s to: '%(src)s' failed with error: %(error)s"
-msgstr ""
+msgid ""
+"Moving book path of Book %(book_id)s to: '%(src)s' failed with error: "
+"%(error)s"
+msgstr "Det gick inte att flytta sökvägen för boken %(book_id)s till '%(src)s': %(error)s"
 
 #: cps/helper.py:446
 #, python-format
-msgid "Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
-msgstr ""
+msgid ""
+"Rename author from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
+msgstr "Det gick inte att byta namn på författaren från '%(src)s' till '%(dest)s': %(error)s"
 
 #: cps/helper.py:516 cps/helper.py:525
 #, python-format
@@ -883,7 +942,9 @@ msgstr "Filen %(file)s hittades inte på Google Drive"
 #: cps/helper.py:567
 #, python-format
 msgid "Rename title from: '%(src)s' to '%(dest)s' failed with error: %(error)s"
-msgstr "Byt namn på titel från: \"%(src)s\" till \"%(dest)s\" misslyckades med fel: %(error)s"
+msgstr ""
+"Det gick inte att byta namn på titeln från '%(src)s' till '%(dest)s': "
+"%(error)s"
 
 #: cps/helper.py:586
 #, python-format
@@ -892,7 +953,7 @@ msgstr "Boksökvägen %(path)s hittades inte på Google Drive"
 
 #: cps/helper.py:646
 msgid "Found an existing account for this Email address"
-msgstr ""
+msgstr "Det finns redan ett konto för den här e-postadressen"
 
 #: cps/helper.py:654
 msgid "This username is already taken"
@@ -900,15 +961,16 @@ msgstr "Detta användarnamn är redan taget"
 
 #: cps/helper.py:668
 msgid "Invalid Email address format"
-msgstr ""
+msgstr "Ogiltigt format på e-postadressen"
 
 #: cps/helper.py:690
 msgid "Password doesn't comply with password validation rules"
-msgstr ""
+msgstr "Lösenordet uppfyller inte reglerna för lösenordsvalidering"
 
 #: cps/helper.py:836
-msgid "Python module 'advocate' is not installed but is needed for cover uploads"
-msgstr ""
+msgid ""
+"Python module 'advocate' is not installed but is needed for cover uploads"
+msgstr "Python-modulen 'advocate' är inte installerad men krävs för uppladdning av omslag"
 
 #: cps/helper.py:846
 msgid "Error Downloading Cover"
@@ -919,8 +981,10 @@ msgid "Cover Format Error"
 msgstr "Fel på omslagsformat"
 
 #: cps/helper.py:852
-msgid "You are not allowed to access localhost or the local network for cover uploads"
-msgstr ""
+msgid ""
+"You are not allowed to access localhost or the local network for cover "
+"uploads"
+msgstr "Du får inte använda localhost eller det lokala nätverket för uppladdning av omslag"
 
 #: cps/helper.py:862
 msgid "Failed to create path for cover"
@@ -936,7 +1000,7 @@ msgstr "Endast jpg/jpeg/png/webp/bmp-filer stöds som omslagsfil"
 
 #: cps/helper.py:901
 msgid "Invalid cover file content"
-msgstr ""
+msgstr "Ogiltigt innehåll i omslagsfilen"
 
 #: cps/helper.py:905
 msgid "Only jpg/jpeg files are supported as coverfile"
@@ -944,49 +1008,51 @@ msgstr "Endast jpg/jpeg-filer stöds som omslagsfil"
 
 #: cps/helper.py:989 cps/helper.py:1152
 msgid "Cover"
-msgstr ""
+msgstr "Omslag"
 
 #: cps/helper.py:1017
 msgid "Error executing UnRar"
-msgstr ""
+msgstr "Fel vid körning av UnRar"
 
 #: cps/helper.py:1025
 msgid "Could not find the specified directory"
-msgstr ""
+msgstr "Den angivna katalogen hittades inte"
 
 #: cps/helper.py:1028
 msgid "Please specify a directory, not a file"
-msgstr ""
+msgstr "Ange en katalog, inte en fil"
 
 #: cps/helper.py:1042
 msgid "Calibre binaries not viable"
-msgstr ""
+msgstr "Calibre-körfilerna kan inte användas"
 
 #: cps/helper.py:1051
 #, python-format
 msgid "Missing calibre binaries: %(missing)s"
-msgstr ""
+msgstr "Calibre-körfiler saknas: %(missing)s"
 
 #: cps/helper.py:1053
 #, python-format
 msgid "Missing executable permissions: %(missing)s"
-msgstr ""
+msgstr "Körbehörighet saknas: %(missing)s"
 
 #: cps/helper.py:1058
 msgid "Error executing Calibre"
-msgstr ""
+msgstr "Fel vid körning av Calibre"
 
 #: cps/helper.py:1154 cps/templates/admin.html:232
 msgid "Queue all books for metadata backup"
-msgstr ""
+msgstr "Lägg alla böcker i kö för säkerhetskopiering av metadata"
 
 #: cps/kobo_auth.py:93
-msgid "Please access Calibre-Web from non localhost to get valid api_endpoint for kobo device"
-msgstr ""
+msgid ""
+"Please access Calibre-Web from non localhost to get valid api_endpoint for "
+"kobo device"
+msgstr "Öppna Calibre-Web från en annan adress än localhost för att få en giltig API-slutpunkt för Kobo-enheten"
 
 #: cps/kobo_auth.py:119
 msgid "Kobo Setup"
-msgstr "Kobo-installation"
+msgstr "Kobo-konfiguration"
 
 #: cps/oauth_bb.py:78
 #, python-format
@@ -996,7 +1062,7 @@ msgstr "Registrera dig med %(provider)s"
 #: cps/oauth_bb.py:140
 #, python-format
 msgid "This %(oauth)s account is already linked to a different user"
-msgstr ""
+msgstr "Det här %(oauth)s-kontot är redan länkat till en annan användare"
 
 #: cps/oauth_bb.py:147 cps/remotelogin.py:150
 #, python-format
@@ -1006,7 +1072,7 @@ msgstr "du är nu inloggad som: \"%(nickname)s\""
 #: cps/oauth_bb.py:157
 #, python-format
 msgid "Link to %(oauth)s Succeeded"
-msgstr "Länk till %(oauth)s lyckades"
+msgstr "Länkningen till %(oauth)s lyckades"
 
 #: cps/oauth_bb.py:164
 msgid "Login failed, No User Linked With OAuth Account"
@@ -1015,17 +1081,17 @@ msgstr "Inloggningen misslyckades, ingen användare kopplad till OAuth-konto"
 #: cps/oauth_bb.py:206
 #, python-format
 msgid "Unlink to %(oauth)s Succeeded"
-msgstr "Sluta länka till %(oauth)s lyckades"
+msgstr "Bortkopplingen från %(oauth)s lyckades"
 
 #: cps/oauth_bb.py:211
 #, python-format
 msgid "Unlink to %(oauth)s Failed"
-msgstr "Sluta länka till %(oauth)s misslyckades"
+msgstr "Bortkopplingen från %(oauth)s misslyckades"
 
 #: cps/oauth_bb.py:214
 #, python-format
 msgid "Not Linked to %(oauth)s"
-msgstr "Inte länkad till %(oauth)s"
+msgstr "Inte kopplad till %(oauth)s"
 
 #: cps/oauth_bb.py:271
 msgid "Failed to log in with GitHub."
@@ -1082,11 +1148,11 @@ msgstr "Logga in"
 
 #: cps/remotelogin.py:100
 msgid "Token already approved"
-msgstr ""
+msgstr "Token har redan godkänts"
 
 #: cps/remotelogin.py:108
 msgid "Success! Please return to your device"
-msgstr "Lyckades! Vänligen återvänd till din enhet"
+msgstr "Klart! Återgå till din enhet"
 
 #: cps/render_template.py:41 cps/web.py:423
 msgid "Books"
@@ -1128,7 +1194,7 @@ msgstr "Lästa böcker"
 
 #: cps/render_template.py:63
 msgid "Show Read and Unread"
-msgstr ""
+msgstr "Visa lästa och olästa"
 
 #: cps/render_template.py:65 cps/templates/index.xml:70
 #: cps/templates/index.xml:74 cps/web.py:774
@@ -1155,7 +1221,7 @@ msgstr "Kategorier"
 
 #: cps/render_template.py:73 cps/templates/user_table.html:158
 msgid "Show Category Section"
-msgstr ""
+msgstr "Visa kategorisektionen"
 
 #: cps/render_template.py:74 cps/templates/book_edit.html:86
 #: cps/templates/book_table.html:94 cps/templates/index.xml:106
@@ -1165,7 +1231,7 @@ msgstr "Serier"
 
 #: cps/render_template.py:76 cps/templates/user_table.html:157
 msgid "Show Series Section"
-msgstr ""
+msgstr "Visa seriesektionen"
 
 #: cps/render_template.py:77 cps/templates/book_table.html:92
 #: cps/templates/index.xml:79
@@ -1174,7 +1240,7 @@ msgstr "Författare"
 
 #: cps/render_template.py:79 cps/templates/user_table.html:160
 msgid "Show Author Section"
-msgstr ""
+msgstr "Visa författarsektionen"
 
 #: cps/render_template.py:81 cps/templates/book_table.html:98
 #: cps/templates/index.xml:88 cps/web.py:1004
@@ -1183,7 +1249,7 @@ msgstr "Förlag"
 
 #: cps/render_template.py:83 cps/templates/user_table.html:163
 msgid "Show Publisher Section"
-msgstr ""
+msgstr "Visa utgivarsektionen"
 
 #: cps/render_template.py:84 cps/templates/book_table.html:96
 #: cps/templates/index.xml:115 cps/templates/search_form.html:108
@@ -1193,7 +1259,7 @@ msgstr "Språk"
 
 #: cps/render_template.py:87 cps/templates/user_table.html:155
 msgid "Show Language Section"
-msgstr ""
+msgstr "Visa språksektionen"
 
 #: cps/render_template.py:88 cps/templates/index.xml:124
 msgid "Ratings"
@@ -1201,7 +1267,7 @@ msgstr "Betyg"
 
 #: cps/render_template.py:90 cps/templates/user_table.html:164
 msgid "Show Ratings Section"
-msgstr ""
+msgstr "Visa betygssektionen"
 
 #: cps/render_template.py:91 cps/templates/index.xml:133
 msgid "File formats"
@@ -1209,7 +1275,7 @@ msgstr "Filformat"
 
 #: cps/render_template.py:93 cps/templates/user_table.html:165
 msgid "Show File Formats Section"
-msgstr ""
+msgstr "Visa filformatssektionen"
 
 #: cps/render_template.py:95 cps/web.py:797
 msgid "Archived Books"
@@ -1217,7 +1283,7 @@ msgstr "Arkiverade böcker"
 
 #: cps/render_template.py:97 cps/templates/user_table.html:166
 msgid "Show Archived Books"
-msgstr ""
+msgstr "Visa arkiverade böcker"
 
 #: cps/render_template.py:100 cps/web.py:833
 msgid "Books List"
@@ -1248,11 +1314,11 @@ msgstr "Betyg >= %(rating)s"
 #: cps/search.py:247
 #, python-format
 msgid "Read Status = '%(status)s'"
-msgstr ""
+msgstr "Lässtatus = '%(status)s'"
 
 #: cps/search.py:365
 msgid "Error on search for custom columns, please restart Calibre-Web"
-msgstr ""
+msgstr "Fel vid sökning efter anpassade kolumner. Starta om Calibre-Web"
 
 #: cps/search.py:384 cps/search.py:416 cps/templates/layout.html:57
 msgid "Advanced Search"
@@ -1264,7 +1330,7 @@ msgstr "Ogiltig hylla specificerad"
 
 #: cps/shelf.py:55
 msgid "Sorry you are not allowed to add a book to that shelf"
-msgstr ""
+msgstr "Du har inte behörighet att lägga till en bok på den hyllan"
 
 #: cps/shelf.py:64
 #, python-format
@@ -1274,7 +1340,7 @@ msgstr "Boken är redan en del av hyllan: %(shelfname)s"
 #: cps/shelf.py:77
 #, python-format
 msgid "%(book_id)s is a invalid Book Id. Could not be added to Shelf"
-msgstr ""
+msgstr "%(book_id)s är ett ogiltigt bok-id och kunde inte läggas till på hyllan"
 
 #: cps/shelf.py:97
 #, python-format
@@ -1283,26 +1349,26 @@ msgstr "Boken har lagts till i hyllan: %(sname)s"
 
 #: cps/shelf.py:116
 msgid "You are not allowed to remove a book from the shelf"
-msgstr ""
+msgstr "Du har inte behörighet att ta bort en bok från hyllan"
 
 #: cps/shelf.py:129
 #, python-format
 msgid "No Books are part of the shelf: %(name)s"
-msgstr ""
+msgstr "Det finns inga böcker på hyllan: %(name)s"
 
 #: cps/shelf.py:140
 #, python-format
 msgid "Books have been removed from shelf: %(sname)s"
-msgstr ""
+msgstr "Böckerna har tagits bort från hyllan: %(sname)s"
 
 #: cps/shelf.py:147
 #, python-format
 msgid "Could not remove books from shelf: %(sname)s"
-msgstr ""
+msgstr "Böckerna kunde inte tas bort från hyllan: %(sname)s"
 
 #: cps/shelf.py:162
 msgid "You are not allowed to add a book to the shelf"
-msgstr ""
+msgstr "Du har inte behörighet att lägga till en bok på hyllan"
 
 #: cps/shelf.py:178
 #, python-format
@@ -1326,7 +1392,7 @@ msgstr "Boken har tagits bort från hyllan: %(sname)s"
 
 #: cps/shelf.py:252
 msgid "Sorry you are not allowed to remove a book from this shelf"
-msgstr ""
+msgstr "Du har inte behörighet att ta bort en bok från den här hyllan"
 
 #: cps/shelf.py:262 cps/templates/layout.html:159
 msgid "Create a Shelf"
@@ -1334,7 +1400,7 @@ msgstr "Skapa en hylla"
 
 #: cps/shelf.py:270 cps/shelf.py:312
 msgid "Sorry you are not allowed to edit this shelf"
-msgstr ""
+msgstr "Du har inte behörighet att redigera den här hyllan"
 
 #: cps/shelf.py:272
 msgid "Edit a shelf"
@@ -1342,11 +1408,11 @@ msgstr "Redigera en hylla"
 
 #: cps/shelf.py:281
 msgid "Error deleting Shelf"
-msgstr ""
+msgstr "Fel när hyllan skulle tas bort"
 
 #: cps/shelf.py:283
 msgid "Shelf successfully deleted"
-msgstr ""
+msgstr "Hyllan har tagits bort"
 
 #: cps/shelf.py:336
 #, python-format
@@ -1355,7 +1421,7 @@ msgstr "Ändra ordning på hyllan: '%(name)s'"
 
 #: cps/shelf.py:371
 msgid "Sorry you are not allowed to create a public shelf"
-msgstr ""
+msgstr "Du har inte behörighet att skapa en offentlig hylla"
 
 #: cps/shelf.py:388
 #, python-format
@@ -1413,11 +1479,11 @@ msgstr "Klar"
 
 #: cps/tasks_status.py:71
 msgid "Ended"
-msgstr ""
+msgstr "Avslutad"
 
 #: cps/tasks_status.py:73
 msgid "Cancelled"
-msgstr ""
+msgstr "Avbruten"
 
 #: cps/tasks_status.py:75
 msgid "Unknown Status"
@@ -1429,11 +1495,16 @@ msgstr "Oväntade data vid läsning av uppdateringsinformation"
 
 #: cps/updater.py:440 cps/updater.py:552
 msgid "No update available. You already have the latest version installed"
-msgstr "Ingen uppdatering tillgänglig. Du har redan den senaste versionen installerad"
+msgstr ""
+"Ingen uppdatering tillgänglig. Du har redan den senaste versionen installerad"
 
 #: cps/updater.py:459
-msgid "A new update is available. Click on the button below to update to the latest version."
-msgstr "En ny uppdatering är tillgänglig. Klicka på knappen nedan för att uppdatera till den senaste versionen."
+msgid ""
+"A new update is available. Click on the button below to update to the latest "
+"version."
+msgstr ""
+"En ny uppdatering är tillgänglig. Klicka på knappen nedan för att uppdatera "
+"till den senaste versionen."
 
 #: cps/updater.py:476
 msgid "Could not fetch update information"
@@ -1441,12 +1512,17 @@ msgstr "Kunde inte hämta uppdateringsinformation"
 
 #: cps/updater.py:487
 msgid "Click on the button below to update to the latest stable version."
-msgstr "Klicka på knappen nedan för att uppdatera till den senaste stabila versionen."
+msgstr ""
+"Klicka på knappen nedan för att uppdatera till den senaste stabila versionen."
 
 #: cps/updater.py:495 cps/updater.py:509 cps/updater.py:520
 #, python-format
-msgid "A new update is available. Click on the button below to update to version: %(version)s"
-msgstr "En ny uppdatering är tillgänglig. Klicka på knappen nedan för att uppdatera till version: %(version)s"
+msgid ""
+"A new update is available. Click on the button below to update to version: "
+"%(version)s"
+msgstr ""
+"En ny uppdatering är tillgänglig. Klicka på knappen nedan för att uppdatera "
+"till version: %(version)s"
 
 #: cps/updater.py:538
 msgid "No release information available"
@@ -1482,7 +1558,7 @@ msgstr "Serier: %(serie)s"
 
 #: cps/web.py:628
 msgid "Rating: None"
-msgstr ""
+msgstr "Betyg: inget"
 
 #: cps/web.py:637
 #, python-format
@@ -1518,11 +1594,11 @@ msgstr "Lista över filformat"
 
 #: cps/web.py:1272
 msgid "Book format not supported"
-msgstr ""
+msgstr "Bokformatet stöds inte"
 
 #: cps/web.py:1274
 msgid "Please configure the SMTP mail settings first..."
-msgstr ""
+msgstr "Konfigurera SMTP-postinställningarna först..."
 
 #: cps/web.py:1280
 #, python-format
@@ -1536,10 +1612,11 @@ msgstr "Det gick inte att skicka den här boken: %(res)s"
 
 #: cps/web.py:1285
 msgid "Oops! Please update your profile with a valid eReader Email."
-msgstr ""
+msgstr "Uppdatera din profil med en giltig e-postadress för e-läsaren."
 
 #: cps/web.py:1301 cps/web.py:1352
-msgid "Oops! Email server is not configured, please contact your administrator."
+msgid ""
+"Oops! Email server is not configured, please contact your administrator."
 msgstr "E-postservern är inte konfigurerad, kontakta din administratör!"
 
 #: cps/web.py:1338
@@ -1552,43 +1629,47 @@ msgstr "Bekräftelsemail skickades till ditt e-postkonto."
 
 #: cps/web.py:1386 cps/web.py:1400
 msgid "Cannot activate LDAP authentication"
-msgstr ""
+msgstr "Det går inte att aktivera LDAP-autentisering"
 
 #: cps/web.py:1409
 #, python-format
 msgid "you are now logged in as: '%(nickname)s'"
-msgstr ""
+msgstr "Du är nu inloggad som '%(nickname)s'"
 
 #: cps/web.py:1416
 #, python-format
-msgid "Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not known"
+msgid ""
+"Fallback Login as: '%(nickname)s', LDAP Server not reachable, or user not "
+"known"
 msgstr ""
+"Reservinloggning som '%(nickname)s': LDAP-servern kan inte nås eller "
+"användaren är okänd"
 
 #: cps/web.py:1421
 #, python-format
 msgid "Could not login: %(message)s"
-msgstr ""
+msgstr "Det gick inte att logga in: %(message)s"
 
 #: cps/web.py:1425 cps/web.py:1450
 msgid "Wrong Username or Password"
-msgstr ""
+msgstr "Fel användarnamn eller lösenord"
 
 #: cps/web.py:1432
 msgid "New Password was sent to your email address"
-msgstr ""
+msgstr "Ett nytt lösenord har skickats till din e-postadress"
 
 #: cps/web.py:1436
 msgid "An unknown error occurred. Please try again later."
-msgstr ""
+msgstr "Ett okänt fel uppstod. Försök igen senare."
 
 #: cps/web.py:1438
 msgid "Please enter valid username to reset password"
-msgstr ""
+msgstr "Ange giltigt användarnamn för att återställa lösenordet"
 
 #: cps/web.py:1446
 #, python-format
 msgid "You are now logged in as: '%(nickname)s'"
-msgstr ""
+msgstr "Du är nu inloggad som: \"%(nickname)s\""
 
 #: cps/web.py:1511 cps/web.py:1561
 #, python-format
@@ -1597,7 +1678,7 @@ msgstr "%(name)ss profil"
 
 #: cps/web.py:1527
 msgid "Success! Profile Updated"
-msgstr ""
+msgstr "Profilen har uppdaterats"
 
 #: cps/web.py:1531
 msgid "Oops! An account already exists for this Email."
@@ -1609,12 +1690,12 @@ msgstr "Hittade ingen giltig gmail.json-fil med OAuth-information"
 
 #: cps/tasks/clean.py:29
 msgid "Delete temp folder contents"
-msgstr ""
+msgstr "Ta bort innehållet i den tillfälliga mappen"
 
 #: cps/tasks/convert.py:113
 #, python-format
 msgid "%(book)s send to E-Reader"
-msgstr ""
+msgstr "%(book)s skickad till e-läsare"
 
 #: cps/tasks/convert.py:180
 #, python-format
@@ -1652,38 +1733,38 @@ msgstr "E-bokkonverteraren misslyckades: %(error)s"
 
 #: cps/tasks/convert.py:350
 msgid "Convert"
-msgstr ""
+msgstr "Konvertera"
 
 #: cps/tasks/database.py:26
 msgid "Reconnecting Calibre database"
-msgstr ""
+msgstr "Återansluter Calibre-databasen"
 
 #: cps/tasks/mail.py:283
 msgid "E-mail"
-msgstr ""
+msgstr "E-post"
 
 #: cps/tasks/metadata_backup.py:34
 msgid "Backing up Metadata"
-msgstr ""
+msgstr "Säkerhetskopierar metadata"
 
 #: cps/tasks/thumbnail.py:97
 #, python-format
 msgid "Generated %(count)s cover thumbnails"
-msgstr ""
+msgstr "%(count)s omslagsminiatyrer har skapats"
 
 #: cps/tasks/thumbnail.py:233 cps/tasks/thumbnail.py:448
 #: cps/tasks/thumbnail.py:518
 msgid "Cover Thumbnails"
-msgstr ""
+msgstr "Omslagsminiatyrer"
 
 #: cps/tasks/thumbnail.py:294
 #, python-brace-format
 msgid "Generated {0} series thumbnails"
-msgstr ""
+msgstr "{0} serieminiatyrer har skapats"
 
 #: cps/tasks/thumbnail.py:459
 msgid "Clearing cover thumbnail cache"
-msgstr ""
+msgstr "Tömmer cacheminnet för omslagsminiatyrer"
 
 #: cps/tasks/upload.py:39 cps/templates/admin.html:20
 #: cps/templates/layout.html:82 cps/templates/user_table.html:145
@@ -1707,7 +1788,7 @@ msgstr "E-post"
 
 #: cps/templates/admin.html:15
 msgid "Send to eReader Email"
-msgstr ""
+msgstr "Skicka till e-läsarens e-postadress"
 
 #: cps/templates/admin.html:17 cps/templates/layout.html:93
 #: cps/templates/user_table.html:143
@@ -1776,7 +1857,7 @@ msgstr "Från meddelande"
 
 #: cps/templates/admin.html:90
 msgid "Email Service"
-msgstr ""
+msgstr "E-posttjänst"
 
 #: cps/templates/admin.html:91
 msgid "Gmail via Oauth2"
@@ -1828,27 +1909,27 @@ msgstr "Omvänd proxy inloggning"
 
 #: cps/templates/admin.html:154 cps/templates/config_edit.html:180
 msgid "Reverse Proxy Header Name"
-msgstr "Omvänt proxy rubriknamn"
+msgstr "Rubriknamn för omvänd proxy"
 
 #: cps/templates/admin.html:158
 msgid "Reverse Proxy Trusted IPs/CIDRs"
-msgstr ""
+msgstr "Betrodda IP-adresser/CIDR för omvänd proxy"
 
 #: cps/templates/admin.html:162 cps/templates/config_edit.html:193
 msgid "Reverse Proxy Shared Secret Header Name"
-msgstr ""
+msgstr "Namn på huvud för delad hemlighet för omvänd proxy"
 
 #: cps/templates/admin.html:166
 msgid "Reverse Proxy Shared Secret Header"
-msgstr ""
+msgstr "Huvud för delad hemlighet för omvänd proxy"
 
 #: cps/templates/admin.html:170
 msgid "Reverse Proxy Shared Secret Configured"
-msgstr ""
+msgstr "Delad hemlighet för omvänd proxy har konfigurerats"
 
 #: cps/templates/admin.html:175
 msgid "Edit Calibre Database Configuration"
-msgstr ""
+msgstr "Redigera Calibre-databaskonfiguration"
 
 #: cps/templates/admin.html:176
 msgid "Edit Basic Configuration"
@@ -1860,37 +1941,37 @@ msgstr "Redigera UI-konfiguration"
 
 #: cps/templates/admin.html:183
 msgid "Scheduled Tasks"
-msgstr ""
+msgstr "Schemalagda uppgifter"
 
 #: cps/templates/admin.html:186 cps/templates/schedule_edit.html:12
 #: cps/templates/tasks.html:18
 msgid "Start Time"
-msgstr ""
+msgstr "Starttid"
 
 #: cps/templates/admin.html:190 cps/templates/schedule_edit.html:20
 msgid "Maximum Duration"
-msgstr ""
+msgstr "Maximal varaktighet"
 
 #: cps/templates/admin.html:194 cps/templates/schedule_edit.html:29
 msgid "Generate Thumbnails"
-msgstr ""
+msgstr "Skapa miniatyrer"
 
 #: cps/templates/admin.html:198
 msgid "Generate series cover thumbnails"
-msgstr ""
+msgstr "Skapa omslagsminiatyrer för serier"
 
 #: cps/templates/admin.html:202 cps/templates/admin.html:224
 #: cps/templates/schedule_edit.html:37
 msgid "Reconnect Calibre Database"
-msgstr ""
+msgstr "Anslut till Calibre DB igen"
 
 #: cps/templates/admin.html:206 cps/templates/schedule_edit.html:41
 msgid "Generate Metadata Backup Files"
-msgstr ""
+msgstr "Skapa säkerhetskopior av metadata"
 
 #: cps/templates/admin.html:213
 msgid "Refresh Thumbnail Cache"
-msgstr ""
+msgstr "Uppdatera miniatyrcache"
 
 #: cps/templates/admin.html:219
 msgid "Administration"
@@ -1914,7 +1995,7 @@ msgstr "Stoppa Calibre-Web"
 
 #: cps/templates/admin.html:237
 msgid "Version Information"
-msgstr ""
+msgstr "Versionsinformation"
 
 #: cps/templates/admin.html:241
 msgid "Version"
@@ -2020,7 +2101,7 @@ msgstr "Mer av"
 #: cps/templates/listenmp3.html:62
 #, python-format
 msgid "Book %(index)s of %(range)s"
-msgstr ""
+msgstr "Bok %(index)s av %(range)s"
 
 #: cps/templates/basic_detail.html:41 cps/templates/book_edit.html:106
 #: cps/templates/detail.html:165 cps/templates/listenmp3.html:69
@@ -2074,7 +2155,7 @@ msgstr "Logga ut"
 
 #: cps/templates/basic_layout.html:35
 msgid "Normal Theme"
-msgstr ""
+msgstr "Normalt tema"
 
 #: cps/templates/book_edit.html:11
 msgid "Delete Book"
@@ -2121,7 +2202,7 @@ msgstr "Fel"
 
 #: cps/templates/book_edit.html:53 cps/templates/layout.html:79
 msgid "Upload done, processing, please wait..."
-msgstr "Uppladdning klar, bearbetning, vänligen vänta ..."
+msgstr "Uppladdningen är klar. Bearbetar, vänta..."
 
 #: cps/templates/book_edit.html:58
 msgid "Upload Format"
@@ -2179,8 +2260,11 @@ msgid "Add Identifier"
 msgstr "Lägg till identifierare"
 
 #: cps/templates/book_edit.html:133
-msgid "Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
-msgstr "Omslagswebbadress (jpg, omslag hämtas och lagras i databasen, fältet är efteråt tomt igen)"
+msgid ""
+"Fetch Cover from URL (JPEG - Image will be downloaded and stored in database)"
+msgstr ""
+"Omslagswebbadress (jpg, omslag hämtas och lagras i databasen, fältet är "
+"efteråt tomt igen)"
 
 #: cps/templates/book_edit.html:137
 msgid "Upload Cover from Local Disk"
@@ -2218,7 +2302,7 @@ msgstr "Sökord"
 
 #: cps/templates/book_edit.html:240
 msgid "Search keyword"
-msgstr ""
+msgstr "Sökord"
 
 #: cps/templates/book_edit.html:246
 msgid "Click the cover to load metadata to the form"
@@ -2248,19 +2332,19 @@ msgstr "Detta fält är obligatoriskt"
 
 #: cps/templates/book_table.html:25
 msgid "Archive selected books"
-msgstr ""
+msgstr "Arkivera markerade böcker"
 
 #: cps/templates/book_table.html:28
 msgid "Unarchive selected books"
-msgstr ""
+msgstr "Avarkivera markerade böcker"
 
 #: cps/templates/book_table.html:34
 msgid "Mark selected books as read"
-msgstr ""
+msgstr "Markera markerade böcker som lästa"
 
 #: cps/templates/book_table.html:37
 msgid "Mark selected books as unread"
-msgstr ""
+msgstr "Markera markerade böcker som olästa"
 
 #: cps/templates/book_table.html:57
 msgid "Merge selected books"
@@ -2268,15 +2352,15 @@ msgstr "Slå ihop utvalda böcker"
 
 #: cps/templates/book_table.html:60 cps/templates/user_table.html:124
 msgid "Clear selections"
-msgstr ""
+msgstr "Rensa markeringar"
 
 #: cps/templates/book_table.html:63
 msgid "Edit selected books"
-msgstr ""
+msgstr "Redigera markerade böcker"
 
 #: cps/templates/book_table.html:67
 msgid "Exchange author and title"
-msgstr ""
+msgstr "Byt plats på författare och titel"
 
 #: cps/templates/book_table.html:73
 msgid "Update Title Sort automatically"
@@ -2341,15 +2425,15 @@ msgstr "Ange utgivare"
 
 #: cps/templates/book_table.html:99
 msgid "Enter comments"
-msgstr ""
+msgstr "Ange kommentarer"
 
 #: cps/templates/book_table.html:99
 msgid "Comments"
-msgstr ""
+msgstr "Kommentarer"
 
 #: cps/templates/book_table.html:101
 msgid "Archive Status"
-msgstr ""
+msgstr "Arkivstatus"
 
 #: cps/templates/book_table.html:103 cps/templates/search_form.html:42
 msgid "Read Status"
@@ -2360,11 +2444,11 @@ msgstr "Lässtatus"
 #: cps/templates/book_table.html:116 cps/templates/book_table.html:118
 #: cps/templates/book_table.html:122
 msgid "Enter "
-msgstr ""
+msgstr "Ange "
 
 #: cps/templates/book_table.html:128
 msgid "Delete selected books"
-msgstr ""
+msgstr "Ta bort markerade böcker"
 
 #: cps/templates/book_table.html:148 cps/templates/book_table.html:172
 #: cps/templates/book_table.html:192 cps/templates/book_table.html:212
@@ -2387,39 +2471,39 @@ msgstr "Slå samman"
 
 #: cps/templates/book_table.html:176
 msgid "The following books will be deleted:"
-msgstr ""
+msgstr "Följande böcker kommer att tas bort:"
 
 #: cps/templates/book_table.html:196
 msgid "The following books will be archived:"
-msgstr ""
+msgstr "Följande böcker kommer att arkiveras:"
 
 #: cps/templates/book_table.html:200 cps/templates/detail.html:275
 msgid "Archive"
-msgstr ""
+msgstr "Arkivera"
 
 #: cps/templates/book_table.html:216
 msgid "The following books will be unarchived:"
-msgstr ""
+msgstr "Följande böcker kommer att avarkiveras:"
 
 #: cps/templates/book_table.html:220
 msgid "Unarchive"
-msgstr ""
+msgstr "Avarkivera"
 
 #: cps/templates/book_table.html:236
 msgid "The following books will be marked read:"
-msgstr ""
+msgstr "Följande böcker kommer att markeras som lästa:"
 
 #: cps/templates/book_table.html:240
 msgid "Mark as read"
-msgstr ""
+msgstr "Markera som läst"
 
 #: cps/templates/book_table.html:256
 msgid "The following books will be marked unread:"
-msgstr ""
+msgstr "Följande böcker kommer att markeras som olästa:"
 
 #: cps/templates/book_table.html:260
 msgid "Mark as unread"
-msgstr ""
+msgstr "Markera som oläst"
 
 #: cps/templates/book_table.html:272 cps/templates/detail.html:348
 msgid "Edit Metadata"
@@ -2427,7 +2511,7 @@ msgstr "Redigera metadata"
 
 #: cps/templates/book_table.html:275
 msgid "Edit the fields you want changed. Blank fields will be ignored:"
-msgstr ""
+msgstr "Redigera de fält som du vill ändra. Tomma fält ignoreras:"
 
 #: cps/templates/config_db.html:12
 msgid "Location of Calibre Database"
@@ -2435,7 +2519,7 @@ msgstr "Plats för Calibre-databasen"
 
 #: cps/templates/config_db.html:21
 msgid "Separate Book Files from Library"
-msgstr ""
+msgstr "Separera bokfiler från biblioteket"
 
 #: cps/templates/config_db.html:34
 msgid "Use Google Drive?"
@@ -2451,7 +2535,7 @@ msgstr "Google Drive Calibre-mapp"
 
 #: cps/templates/config_db.html:52
 msgid "Metadata Watch Channel ID"
-msgstr "Metadata Titta på kanal ID"
+msgstr "Kanal-ID för metadataövervakning"
 
 #: cps/templates/config_db.html:55
 msgid "Revoke"
@@ -2459,7 +2543,7 @@ msgstr "Återkalla"
 
 #: cps/templates/config_db.html:80
 msgid "New db location is invalid, please enter valid path"
-msgstr ""
+msgstr "Den nya databasplatsen är ogiltig. Ange en giltig sökväg"
 
 #: cps/templates/config_edit.html:18
 msgid "Server Configuration"
@@ -2471,11 +2555,11 @@ msgstr "Serverport"
 
 #: cps/templates/config_edit.html:28
 msgid "SSL certfile location (leave it empty for non-SSL Servers)"
-msgstr "SSL certfile plats (lämna den tom för icke-SSL-servrar)"
+msgstr "Sökväg till SSL-certifikatfil (lämna tomt för servrar utan SSL)"
 
 #: cps/templates/config_edit.html:35
 msgid "SSL Keyfile location (leave it empty for non-SSL Servers)"
-msgstr "SSL Keyfile plats (lämna den tom för icke-SSL-servrar)"
+msgstr "Sökväg till SSL-nyckelfil (lämna tomt för servrar utan SSL)"
 
 #: cps/templates/config_edit.html:43
 msgid "Update Channel"
@@ -2487,15 +2571,15 @@ msgstr "Stabil"
 
 #: cps/templates/config_edit.html:46
 msgid "Nightly"
-msgstr "Ostabil"
+msgstr "Nattlig"
 
 #: cps/templates/config_edit.html:50
 msgid "Trusted Hosts (Comma Separated)"
-msgstr ""
+msgstr "Betrodda värdar (kommaseparerade)"
 
 #: cps/templates/config_edit.html:61
 msgid "Logfile Configuration"
-msgstr "Loggfil konfiguration"
+msgstr "Loggfilskonfiguration"
 
 #: cps/templates/config_edit.html:77
 msgid "Location and name of logfile (calibre-web.log for no entry)"
@@ -2511,15 +2595,17 @@ msgstr "Plats och namn på åtkomstloggfil (access.log för ingen post)"
 
 #: cps/templates/config_edit.html:96
 msgid "Feature Configuration"
-msgstr "Funktion konfiguration"
+msgstr "Funktionskonfiguration"
 
 #: cps/templates/config_edit.html:104
 msgid "Convert non-English characters in title and author while saving to disk"
-msgstr ""
+msgstr "Konvertera icke-engelska tecken i titel och författare när filer sparas på disk"
 
 #: cps/templates/config_edit.html:108
-msgid "Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/Kepubify binaries)"
-msgstr ""
+msgid ""
+"Embed Metadata to Ebook File on Download/Conversion/e-mail (needs Calibre/"
+"Kepubify binaries)"
+msgstr "Bädda in metadata i e-boksfilen vid hämtning, konvertering eller e-post (kräver Calibre-/Kepubify-körfiler)"
 
 #: cps/templates/config_edit.html:112
 msgid "Enable Uploads"
@@ -2527,7 +2613,7 @@ msgstr "Aktivera uppladdning"
 
 #: cps/templates/config_edit.html:112
 msgid "(Please ensure that users also have upload permissions)"
-msgstr ""
+msgstr "(Se till att användarna även har uppladdningsbehörighet)"
 
 #: cps/templates/config_edit.html:116
 msgid "Allowed Upload Fileformats"
@@ -2551,15 +2637,15 @@ msgstr "Aktivera fjärrinloggning (\"magisk länk\")"
 
 #: cps/templates/config_edit.html:141
 msgid "Enable Kobo sync"
-msgstr "Aktivera Kobo sync"
+msgstr "Aktivera Kobo-synkronisering"
 
 #: cps/templates/config_edit.html:146
 msgid "Proxy unknown requests to Kobo Store"
-msgstr "Proxy okänd begäran till Kobo Store"
+msgstr "Vidarebefordra okända begäranden till Kobo Store via proxy"
 
 #: cps/templates/config_edit.html:149
 msgid "Server External Port (for port forwarded API calls)"
-msgstr "Extern port för server (för port vidarebefordrade API-anrop)"
+msgstr "Serverns externa port (för portvidarebefordrade API-anrop)"
 
 #: cps/templates/config_edit.html:157
 msgid "Use Goodreads"
@@ -2571,7 +2657,7 @@ msgstr "Goodreads API-nyckel"
 
 #: cps/templates/config_edit.html:167
 msgid "Google Books API Key"
-msgstr ""
+msgstr "API-nyckel för Google Books"
 
 #: cps/templates/config_edit.html:172
 msgid "Allow Reverse Proxy Authentication"
@@ -2579,23 +2665,26 @@ msgstr "Tillåt omvänd proxyautentisering"
 
 #: cps/templates/config_edit.html:176
 msgid "Security Warning"
-msgstr ""
+msgstr "Säkerhetsvarning"
 
 #: cps/templates/config_edit.html:177
-msgid "Only enable this when Calibre-Web is reachable exclusively through a trusted reverse proxy. Never expose Calibre-Web directly to untrusted networks while reverse proxy authentication is enabled."
-msgstr ""
+msgid ""
+"Only enable this when Calibre-Web is reachable exclusively through a trusted "
+"reverse proxy. Never expose Calibre-Web directly to untrusted networks while "
+"reverse proxy authentication is enabled."
+msgstr "Aktivera detta endast när Calibre-Web enbart kan nås via en betrodd omvänd proxy. Exponera aldrig Calibre-Web direkt mot opålitliga nätverk när autentisering via omvänd proxy är aktiverad."
 
 #: cps/templates/config_edit.html:184
 msgid "Reverse Proxy Trusted IPs/CIDRs (Comma Separated)"
-msgstr ""
+msgstr "Betrodda IP-adresser/CIDR för omvänd proxy (kommaseparerade)"
 
 #: cps/templates/config_edit.html:189
 msgid "Enable Reverse Proxy Shared Secret Header"
-msgstr ""
+msgstr "Aktivera huvud för delad hemlighet för omvänd proxy"
 
 #: cps/templates/config_edit.html:197
 msgid "Reverse Proxy Shared Secret"
-msgstr ""
+msgstr "Delad hemlighet för omvänd proxy"
 
 #: cps/templates/config_edit.html:205
 msgid "Login type"
@@ -2634,16 +2723,22 @@ msgid "SSL"
 msgstr "SSL"
 
 #: cps/templates/config_edit.html:235
-msgid "LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
-msgstr "LDAP CACertificate-sökväg (behövs endast för autentisering av klientcertifikat)"
+msgid ""
+"LDAP CACertificate Path (Only needed for Client Certificate Authentication)"
+msgstr ""
+"Sökväg till LDAP-CA-certifikat (behövs endast för "
+"klientcertifikatautentisering)"
 
 #: cps/templates/config_edit.html:242
-msgid "LDAP Certificate Path (Only needed for Client Certificate Authentication)"
-msgstr "LDAP-certifikatsökväg (behövs endast för autentisering av klientcertifikat)"
+msgid ""
+"LDAP Certificate Path (Only needed for Client Certificate Authentication)"
+msgstr ""
+"LDAP-certifikatsökväg (behövs endast för autentisering av klientcertifikat)"
 
 #: cps/templates/config_edit.html:249
 msgid "LDAP Keyfile Path (Only needed for Client Certificate Authentication)"
-msgstr "LDAP-nyckelfilsökväg (behövs endast för autentisering av klientcertifikat)"
+msgstr ""
+"LDAP-nyckelfilsökväg (behövs endast för autentisering av klientcertifikat)"
 
 #: cps/templates/config_edit.html:258
 msgid "LDAP Authentication"
@@ -2663,15 +2758,15 @@ msgstr "Enkel"
 
 #: cps/templates/config_edit.html:267
 msgid "LDAP Administrator Username"
-msgstr "LDAP-adminstratörsanvändarnamn"
+msgstr "Användarnamn för LDAP-administratör"
 
 #: cps/templates/config_edit.html:273
 msgid "LDAP Administrator Password"
-msgstr "LDAP-adminstratörslösenord"
+msgstr "Lösenord för LDAP-administratör"
 
 #: cps/templates/config_edit.html:278
 msgid "LDAP Distinguished Name (DN)"
-msgstr "LDAP Distinguished Name (DN)"
+msgstr "LDAP-distinguished name (DN)"
 
 #: cps/templates/config_edit.html:282
 msgid "LDAP User Object Filter"
@@ -2716,7 +2811,7 @@ msgstr "LDAP-användarfilter för medlemmar"
 #: cps/templates/config_edit.html:322
 #, python-format
 msgid "Obtain %(provider)s OAuth Credential"
-msgstr "Skaffa %(provider)s OAuth-certifikat"
+msgstr "Hämta OAuth-autentiseringsuppgifter för %(provider)s"
 
 #: cps/templates/config_edit.html:325
 #, python-format
@@ -2726,7 +2821,7 @@ msgstr "%(provider)s OAuth-klient-id"
 #: cps/templates/config_edit.html:329
 #, python-format
 msgid "%(provider)s OAuth Client Secret"
-msgstr "%(provider)s OAuth-klient-hemlighet"
+msgstr "OAuth-klienthemlighet för %(provider)s"
 
 #: cps/templates/config_edit.html:345
 msgid "External binaries"
@@ -2734,79 +2829,79 @@ msgstr "Externa binärer"
 
 #: cps/templates/config_edit.html:351
 msgid "Path to Calibre Binaries"
-msgstr ""
+msgstr "Sökväg till Calibre-körfiler"
 
 #: cps/templates/config_edit.html:359
 msgid "Calibre E-Book Converter Settings"
-msgstr "Inställningar för calibre e-bokkonverterare"
+msgstr "Inställningar för Calibres e-bokskonverterare"
 
 #: cps/templates/config_edit.html:362
 msgid "Path to Kepubify E-Book Converter"
-msgstr "Sökväg till Kepubify calibre e-bokkonverterare"
+msgstr "Sökväg till Kepubify e-bokskonverterare"
 
 #: cps/templates/config_edit.html:370
 msgid "Location of Unrar binary"
-msgstr ""
+msgstr "Plats för den körbara Unrar-filen"
 
 #: cps/templates/config_edit.html:386
 msgid "Security Settings"
-msgstr ""
+msgstr "Säkerhetsinställningar"
 
 #: cps/templates/config_edit.html:394
 msgid "Limit failed login attempts"
-msgstr ""
+msgstr "Begränsa misslyckade inloggningsförsök"
 
 #: cps/templates/config_edit.html:398
 msgid "Configure Backend for Limiter"
-msgstr ""
+msgstr "Konfigurera bakände för begränsning"
 
 #: cps/templates/config_edit.html:402
 msgid "Options for Limiter Backend"
-msgstr ""
+msgstr "Alternativ för begränsningsbakände"
 
 #: cps/templates/config_edit.html:408
 msgid "Check if file extensions matches file content on upload"
-msgstr ""
+msgstr "Kontrollera att filändelsen motsvarar filinnehållet vid uppladdning"
 
 #: cps/templates/config_edit.html:411
 msgid "Session protection"
-msgstr ""
+msgstr "Sessionsskydd"
 
 #: cps/templates/config_edit.html:413
 msgid "Basic"
-msgstr ""
+msgstr "Grundläggande"
 
 #: cps/templates/config_edit.html:414
 msgid "Strong"
-msgstr ""
+msgstr "Starkt"
 
 #: cps/templates/config_edit.html:419
 msgid "User Password policy"
-msgstr ""
+msgstr "Lösenordspolicy för användare"
 
 #: cps/templates/config_edit.html:423
 msgid "Minimum password length"
-msgstr ""
+msgstr "Minsta lösenordslängd"
 
 #: cps/templates/config_edit.html:428
 msgid "Enforce number"
-msgstr ""
+msgstr "Kräv siffra"
 
 #: cps/templates/config_edit.html:432
 msgid "Enforce lowercase characters"
-msgstr ""
+msgstr "Kräv gemener"
 
 #: cps/templates/config_edit.html:436
 msgid "Enforce uppercase characters"
-msgstr ""
+msgstr "Kräv versaler"
 
 #: cps/templates/config_edit.html:440
 msgid "Enforce characters (needed For Chinese/Japanese/Korean Characters)"
-msgstr ""
+msgstr "Kräv tecken (behövs för kinesiska, japanska och koreanska tecken)"
 
 #: cps/templates/config_edit.html:444
 msgid "Enforce special characters"
-msgstr ""
+msgstr "Kräv specialtecken"
 
 #: cps/templates/config_view_edit.html:17
 msgid "View Configuration"
@@ -2818,7 +2913,7 @@ msgstr "Antal slumpmässiga böcker att visa"
 
 #: cps/templates/config_view_edit.html:36
 msgid "No. of Authors to Display Before Hiding (0=Disable Hiding)"
-msgstr "Antal författare att visa innan de döljs (0 = inaktivera dölja)"
+msgstr "Antal författare att visa innan resten döljs (0 = inaktivera döljning)"
 
 #: cps/templates/config_view_edit.html:40 cps/templates/readcbr.html:101
 msgid "Theme"
@@ -2826,7 +2921,7 @@ msgstr "Tema"
 
 #: cps/templates/config_view_edit.html:42
 msgid "Standard Theme"
-msgstr "Standard tema"
+msgstr "Standardtema"
 
 #: cps/templates/config_view_edit.html:43
 msgid "caliBlur! Dark Theme"
@@ -2854,11 +2949,11 @@ msgstr "Standardinställningar för nya användare"
 
 #: cps/templates/config_view_edit.html:88 cps/templates/user_edit.html:96
 msgid "Admin User"
-msgstr "Adminstratör användare"
+msgstr "Administratörsanvändare"
 
 #: cps/templates/config_view_edit.html:92 cps/templates/user_edit.html:101
 msgid "Allow Downloads"
-msgstr "Tillåt Hämtningar"
+msgstr "Tillåt hämtningar"
 
 #: cps/templates/config_view_edit.html:96 cps/templates/user_edit.html:105
 msgid "Allow eBook Viewer"
@@ -2866,11 +2961,11 @@ msgstr "Tillåt bokvisare"
 
 #: cps/templates/config_view_edit.html:101 cps/templates/user_edit.html:110
 msgid "Allow Uploads"
-msgstr "Tillåt Uppladdningar"
+msgstr "Tillåt uppladdningar"
 
 #: cps/templates/config_view_edit.html:106 cps/templates/user_edit.html:115
 msgid "Allow Edit"
-msgstr "Tillåt Redigera"
+msgstr "Tillåt redigering"
 
 #: cps/templates/config_view_edit.html:111 cps/templates/user_edit.html:120
 msgid "Allow Delete Books"
@@ -2878,23 +2973,23 @@ msgstr "Tillåt borttagning av böcker"
 
 #: cps/templates/config_view_edit.html:116 cps/templates/user_edit.html:126
 msgid "Allow Changing Password"
-msgstr "Tillåt Ändra lösenord"
+msgstr "Tillåt ändring av lösenord"
 
 #: cps/templates/config_view_edit.html:120 cps/templates/user_edit.html:130
 msgid "Allow Editing Public Shelves"
-msgstr "Tillåt Redigering av offentliga hyllor"
+msgstr "Tillåt redigering av offentliga hyllor"
 
 #: cps/templates/config_view_edit.html:123
 msgid "Default Language"
-msgstr ""
+msgstr "Standardspråk"
 
 #: cps/templates/config_view_edit.html:131
 msgid "Default Visible Language of Books"
-msgstr ""
+msgstr "Förvalt synligt språk för böcker"
 
 #: cps/templates/config_view_edit.html:147
 msgid "Default Visibilities for New Users"
-msgstr "Standardvisibiliteter för nya användare"
+msgstr "Standardvisning för nya användare"
 
 #: cps/templates/config_view_edit.html:163 cps/templates/user_edit.html:84
 #: cps/templates/user_table.html:154
@@ -2927,7 +3022,7 @@ msgstr "Markera som läst"
 
 #: cps/templates/detail.html:262
 msgid "Mark Book as Read or Unread"
-msgstr ""
+msgstr "Markera bok som läst eller oläst"
 
 #: cps/templates/detail.html:262 cps/templates/listenmp3.html:159
 msgid "Read"
@@ -2942,8 +3037,10 @@ msgid "Add to archive"
 msgstr "Lägg till i arkivet"
 
 #: cps/templates/detail.html:275
-msgid "Mark Book as archived or not, to hide it in Calibre-Web and delete it from Kobo Reader"
-msgstr ""
+msgid ""
+"Mark Book as archived or not, to hide it in Calibre-Web and delete it from "
+"Kobo Reader"
+msgstr "Markera boken som arkiverad eller inte för att dölja den i Calibre-Web och ta bort den från Kobo-läsaren"
 
 #: cps/templates/detail.html:301 cps/templates/listenmp3.html:190
 #: cps/templates/search.html:16
@@ -2955,7 +3052,7 @@ msgstr "Lägg till hyllan"
 #: cps/templates/listenmp3.html:201 cps/templates/listenmp3.html:218
 #: cps/templates/search.html:22 cps/templates/search.html:35
 msgid "(Public)"
-msgstr "(Publik)"
+msgstr "(Offentlig)"
 
 #: cps/templates/email_edit.html:13
 msgid "Email Account Type"
@@ -2963,15 +3060,15 @@ msgstr "Välj servertyp"
 
 #: cps/templates/email_edit.html:15
 msgid "Standard Email Account"
-msgstr ""
+msgstr "Standardkonto för e-post"
 
 #: cps/templates/email_edit.html:16
 msgid "Gmail Account"
-msgstr ""
+msgstr "Gmail-konto"
 
 #: cps/templates/email_edit.html:22
 msgid "Setup Gmail Account"
-msgstr ""
+msgstr "Konfigurera Gmail-konto"
 
 #: cps/templates/email_edit.html:24
 msgid "Revoke Gmail Access"
@@ -2995,7 +3092,7 @@ msgstr "Gräns för bilagestorlek"
 
 #: cps/templates/email_edit.html:66
 msgid "Save and Send Test Email"
-msgstr ""
+msgstr "Spara och skicka testmeddelande"
 
 #: cps/templates/email_edit.html:70 cps/templates/layout.html:26
 #: cps/templates/shelf_order.html:42 cps/templates/user_table.html:174
@@ -3024,20 +3121,24 @@ msgid "Denied Domains (Blacklist)"
 msgstr "Avvisade domäner för registrering"
 
 #: cps/templates/generate_kobo_auth_url.html:6
-msgid "Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or edit):"
-msgstr "Öppna filen .kobo/Kobo/Kobo eReader.conf i en textredigerare och lägg till (eller redigera):"
+msgid ""
+"Open the .kobo/Kobo/Kobo eReader.conf file in a text editor and add (or "
+"edit):"
+msgstr ""
+"Öppna filen .kobo/Kobo/Kobo eReader.conf i en textredigerare och lägg till "
+"(eller redigera):"
 
 #: cps/templates/generate_kobo_auth_url.html:11
 msgid "Kobo Token:"
-msgstr ""
+msgstr "Kobo-token:"
 
 #: cps/templates/grid.html:21
 msgid "List"
-msgstr ""
+msgstr "Lista"
 
 #: cps/templates/http_error.html:34
 msgid "Calibre-Web Instance is unconfigured, please contact your administrator"
-msgstr ""
+msgstr "Calibre-Web-instansen är inte konfigurerad. Kontakta administratören"
 
 #: cps/templates/http_error.html:44
 msgid "Create Issue"
@@ -3045,7 +3146,7 @@ msgstr "Skapa ärende"
 
 #: cps/templates/http_error.html:52
 msgid "Return to Database config"
-msgstr ""
+msgstr "Återgå till databaskonfigurationen"
 
 #: cps/templates/http_error.html:54
 msgid "Return to Home"
@@ -3053,15 +3154,15 @@ msgstr "Tillbaka till hemmet"
 
 #: cps/templates/http_error.html:57
 msgid "Logout User"
-msgstr ""
+msgstr "Logga ut användare"
 
 #: cps/templates/index.html:71
 msgid "Sort ascending according to download count"
-msgstr ""
+msgstr "Sortera stigande efter antal hämtningar"
 
 #: cps/templates/index.html:72
 msgid "Sort descending according to download count"
-msgstr ""
+msgstr "Sortera fallande efter antal hämtningar"
 
 #: cps/templates/index.html:78 cps/templates/search.html:49
 #: cps/templates/shelf.html:24
@@ -3095,11 +3196,12 @@ msgstr "Böcker sorterade alfabetiskt"
 
 #: cps/templates/index.xml:31
 msgid "Popular publications from this catalog based on Downloads."
-msgstr "Populära publikationer från den här katalogen baserad på hämtningar."
+msgstr ""
+"Populära publikationer från den här katalogen baserat på antal hämtningar."
 
 #: cps/templates/index.xml:40
 msgid "Popular publications from this catalog based on Rating."
-msgstr "Populära publikationer från den här katalogen baserad på betyg."
+msgstr "Populära publikationer från den här katalogen baserat på betyg."
 
 #: cps/templates/index.xml:45
 msgid "Recently added Books"
@@ -3135,11 +3237,11 @@ msgstr "Böcker ordnade efter språk"
 
 #: cps/templates/index.xml:128
 msgid "Books ordered by Rating"
-msgstr "Böcker sorterade efter Betyg"
+msgstr "Böcker ordnade efter betyg"
 
 #: cps/templates/index.xml:137
 msgid "Books ordered by file formats"
-msgstr "Böcker ordnade av filformat"
+msgstr "Böcker ordnade efter filformat"
 
 #: cps/templates/index.xml:142 cps/templates/layout.html:154
 #: cps/templates/search_form.html:88
@@ -3156,7 +3258,7 @@ msgstr "Växla navigering"
 
 #: cps/templates/layout.html:58
 msgid "Simple Theme"
-msgstr ""
+msgstr "Enkelt tema"
 
 #: cps/templates/layout.html:66 cps/templates/layout.html:96
 msgid "Account"
@@ -3169,7 +3271,7 @@ msgstr "Inställningar"
 
 #: cps/templates/layout.html:137
 msgid "Please do not refresh the page"
-msgstr "Vänligen uppdatera inte sidan"
+msgstr "Läs inte in sidan igen"
 
 #: cps/templates/layout.html:147
 msgid "Browse"
@@ -3181,11 +3283,11 @@ msgstr "Om"
 
 #: cps/templates/layout.html:199
 msgid "Book Details"
-msgstr "Bokdetaljer"
+msgstr "Bokinformation"
 
 #: cps/templates/list.html:22
 msgid "Grid"
-msgstr ""
+msgstr "Rutnät"
 
 #: cps/templates/listenmp3.html:167
 msgid "Archived"
@@ -3209,7 +3311,7 @@ msgstr "Visa Calibre-Web-logg: "
 
 #: cps/templates/logviewer.html:8
 msgid "Calibre-Web Log: "
-msgstr "Visa åtkomstlogg: "
+msgstr "Calibre-Web-logg: "
 
 #: cps/templates/logviewer.html:8
 msgid "Stream output, can't be displayed"
@@ -3221,7 +3323,7 @@ msgstr "Visa åtkomstlogg: "
 
 #: cps/templates/logviewer.html:18
 msgid "Download Calibre-Web Log"
-msgstr "Hämta logg för calibre-web"
+msgstr "Hämta Calibre-Web-logg"
 
 #: cps/templates/logviewer.html:21
 msgid "Download Access Log"
@@ -3237,7 +3339,7 @@ msgstr "Välj tillåtna/avvisade anpassade kolumnvärden"
 
 #: cps/templates/modal_dialogs.html:8
 msgid "Select Allowed/Denied Tags of User"
-msgstr "Välj tillåtna/avvisade användarens taggar"
+msgstr "Välj användarens tillåtna/nekade taggar"
 
 #: cps/templates/modal_dialogs.html:9
 msgid "Select Allowed/Denied Custom Column Values of User"
@@ -3257,15 +3359,22 @@ msgstr "Detta bokformat tas bort permanent från databasen"
 
 #: cps/templates/modal_dialogs.html:51
 msgid "This book will be permanently erased from database and hard disk"
-msgstr ""
+msgstr "Den här boken kommer att tas bort permanent från databasen och hårddisken"
 
 #: cps/templates/modal_dialogs.html:55
-msgid "Important Kobo Note: deleted books will remain on any paired Kobo device."
-msgstr "Viktigt Kobo-notering: borttagna böcker kommer att finnas kvar på alla kopplade Kobo-enheter."
+msgid ""
+"Important Kobo Note: deleted books will remain on any paired Kobo device."
+msgstr ""
+"Viktigt om Kobo: borttagna böcker finns kvar på alla parkopplade Kobo-"
+"enheter."
 
 #: cps/templates/modal_dialogs.html:56
-msgid "Books must first be archived and the device synced before a book can safely be deleted."
-msgstr "Böcker måste först arkiveras och enheten synkroniseras innan en bok säkert kan tas bort."
+msgid ""
+"Books must first be archived and the device synced before a book can safely "
+"be deleted."
+msgstr ""
+"Böcker måste först arkiveras och enheten synkroniseras innan en bok säkert "
+"kan tas bort."
 
 #: cps/templates/modal_dialogs.html:75
 msgid "Choose File Location"
@@ -3285,7 +3394,7 @@ msgstr "storlek"
 
 #: cps/templates/modal_dialogs.html:90
 msgid "Parent Directory"
-msgstr "Föräldramapp"
+msgstr "Överordnad mapp"
 
 #: cps/templates/modal_dialogs.html:99
 msgid "Select"
@@ -3293,7 +3402,7 @@ msgstr "Välj"
 
 #: cps/templates/modal_dialogs.html:135 cps/templates/tasks.html:46
 msgid "Ok"
-msgstr "Ok"
+msgstr "OK"
 
 #: cps/templates/osd.xml:5
 msgid "Calibre-Web eBook Catalog"
@@ -3301,11 +3410,11 @@ msgstr "Calibre-Web e-bokkatalog"
 
 #: cps/templates/read.html:7
 msgid "epub Reader"
-msgstr ""
+msgstr "EPUB-läsare"
 
 #: cps/templates/read.html:85
 msgid "Choose a theme below:"
-msgstr ""
+msgstr "Välj ett tema nedan:"
 
 #: cps/templates/read.html:89 cps/templates/readcbr.html:104
 msgid "Light"
@@ -3317,67 +3426,67 @@ msgstr "Mörkt"
 
 #: cps/templates/read.html:93
 msgid "Sepia"
-msgstr ""
+msgstr "Sepia"
 
 #: cps/templates/read.html:95
 msgid "Amber"
-msgstr ""
+msgstr "Bärnsten"
 
 #: cps/templates/read.html:97
 msgid "Black"
-msgstr ""
+msgstr "Svart"
 
 #: cps/templates/read.html:109
 msgid "Reflow text when sidebars are open."
-msgstr "Fyll i texten igen när sidofält är öppna."
+msgstr "Flöda om texten när sidofälten är öppna."
 
 #: cps/templates/read.html:114
 msgid "Show pages count"
-msgstr ""
+msgstr "Visa sidantal"
 
 #: cps/templates/read.html:118
 msgid "Font Size"
-msgstr ""
+msgstr "Teckenstorlek"
 
 #: cps/templates/read.html:126
 msgid "Font"
-msgstr ""
+msgstr "Teckensnitt"
 
 #: cps/templates/read.html:127
 msgid "Default"
-msgstr ""
+msgstr "Standard"
 
 #: cps/templates/read.html:128
 msgid "Yahei"
-msgstr ""
+msgstr "Yahei"
 
 #: cps/templates/read.html:129
 msgid "SimSun"
-msgstr ""
+msgstr "SimSun"
 
 #: cps/templates/read.html:130
 msgid "KaiTi"
-msgstr ""
+msgstr "KaiTi"
 
 #: cps/templates/read.html:131
 msgid "Arial"
-msgstr ""
+msgstr "Arial"
 
 #: cps/templates/read.html:134
 msgid "Spread"
-msgstr ""
+msgstr "Uppslag"
 
 #: cps/templates/read.html:135
 msgid "Two columns"
-msgstr ""
+msgstr "Två kolumner"
 
 #: cps/templates/read.html:136
 msgid "One column"
-msgstr ""
+msgstr "En kolumn"
 
 #: cps/templates/readcbr.html:8
 msgid "Comic Reader"
-msgstr ""
+msgstr "Serieläsare"
 
 #: cps/templates/readcbr.html:75
 msgid "Keyboard Shortcuts"
@@ -3393,15 +3502,15 @@ msgstr "Nästa sida"
 
 #: cps/templates/readcbr.html:80
 msgid "Single Page Display"
-msgstr ""
+msgstr "Ensidig visning"
 
 #: cps/templates/readcbr.html:81
 msgid "Long Strip Display"
-msgstr ""
+msgstr "Lång remsa"
 
 #: cps/templates/readcbr.html:82
 msgid "Scale to Best"
-msgstr "Skala till bäst"
+msgstr "Anpassa optimalt"
 
 #: cps/templates/readcbr.html:83
 msgid "Scale to Width"
@@ -3413,7 +3522,7 @@ msgstr "Skala till höjd"
 
 #: cps/templates/readcbr.html:85
 msgid "Scale to Native"
-msgstr "Skala till ursprunglig"
+msgstr "Visa i ursprunglig storlek"
 
 #: cps/templates/readcbr.html:86
 msgid "Rotate Right"
@@ -3429,15 +3538,15 @@ msgstr "Vänd bilden"
 
 #: cps/templates/readcbr.html:110
 msgid "Display"
-msgstr ""
+msgstr "Visning"
 
 #: cps/templates/readcbr.html:113
 msgid "Single Page"
-msgstr ""
+msgstr "En sida"
 
 #: cps/templates/readcbr.html:114
 msgid "Long Strip"
-msgstr ""
+msgstr "Lång remsa"
 
 #: cps/templates/readcbr.html:119
 msgid "Scale"
@@ -3457,7 +3566,7 @@ msgstr "Höjd"
 
 #: cps/templates/readcbr.html:125
 msgid "Native"
-msgstr "Ursprunglig"
+msgstr "Ursprunglig storlek"
 
 #: cps/templates/readcbr.html:130
 msgid "Rotate"
@@ -3489,35 +3598,35 @@ msgstr "Höger till vänster"
 
 #: cps/templates/readcbr.html:162
 msgid "Reset to Top"
-msgstr ""
+msgstr "Återgå till början"
 
 #: cps/templates/readcbr.html:163
 msgid "Remember Position"
-msgstr ""
+msgstr "Kom ihåg position"
 
 #: cps/templates/readcbr.html:168
 msgid "Scrollbar"
-msgstr ""
+msgstr "Rullningslist"
 
 #: cps/templates/readcbr.html:171
 msgid "Show"
-msgstr ""
+msgstr "Visa"
 
 #: cps/templates/readcbr.html:172
 msgid "Hide"
-msgstr ""
+msgstr "Dölj"
 
 #: cps/templates/readdjvu.html:5
 msgid "DJVU Reader"
-msgstr ""
+msgstr "DjVu-läsare"
 
 #: cps/templates/readpdf.html:31
 msgid "PDF Reader"
-msgstr ""
+msgstr "PDF-läsare"
 
 #: cps/templates/readtxt.html:6
 msgid "txt Reader"
-msgstr ""
+msgstr "TXT-läsare"
 
 #: cps/templates/register.html:4
 msgid "Register New Account"
@@ -3533,15 +3642,15 @@ msgstr "Din e-postadress"
 
 #: cps/templates/remote_login.html:5
 msgid "Magic Link - Authorise New Device"
-msgstr "Magic Link - Auktorisera ny enhet"
+msgstr "Magisk länk – auktorisera ny enhet"
 
 #: cps/templates/remote_login.html:7
 msgid "On another device, login and visit:"
-msgstr "På en annan enhet, logga in och besök:"
+msgstr "Logga in på en annan enhet och besök:"
 
 #: cps/templates/remote_login.html:11
 msgid "Once verified, you will automatically be logged in on this device."
-msgstr "När du gör det kommer du automatiskt att logga in på den här enheten."
+msgstr "När verifieringen är klar loggas du automatiskt in på den här enheten."
 
 #: cps/templates/remote_login.html:14
 msgid "This verification link will expire in 10 minutes."
@@ -3549,32 +3658,34 @@ msgstr "Länken går ut efter 10 minuter."
 
 #: cps/templates/remote_login_verify.html:4
 msgid "Approve Magic Link Login"
-msgstr ""
+msgstr "Godkänn inloggning med magisk länk"
 
 #: cps/templates/remote_login_verify.html:5
 msgid "Review the device that requested access before approving this login."
-msgstr ""
+msgstr "Kontrollera enheten som begärde åtkomst innan du godkänner inloggningen."
 
 #: cps/templates/remote_login_verify.html:7
 msgid "IP address"
-msgstr ""
+msgstr "IP-adress"
 
 #: cps/templates/remote_login_verify.html:9
 msgid "Browser"
-msgstr ""
+msgstr "Webbläsare"
 
 #: cps/templates/remote_login_verify.html:12
 #, python-format
-msgid "If you approve this request, the device that started it will be logged in as %(username)s."
-msgstr ""
+msgid ""
+"If you approve this request, the device that started it will be logged in as "
+"%(username)s."
+msgstr "Om du godkänner begäran loggas enheten som initierade den in som %(username)s."
 
 #: cps/templates/remote_login_verify.html:15
 msgid "Approve Login"
-msgstr ""
+msgstr "Godkänn inloggning"
 
 #: cps/templates/schedule_edit.html:33
 msgid "Generate Series Cover Thumbnails"
-msgstr ""
+msgstr "Skapa omslagsminiatyrer för serier"
 
 #: cps/templates/search.html:7
 msgid "Search Term:"
@@ -3586,7 +3697,7 @@ msgstr "Resultat för:"
 
 #: cps/templates/search.html:29
 msgid "Remove from shelf"
-msgstr ""
+msgstr "Ta bort från hyllan"
 
 #: cps/templates/search_form.html:21
 msgid "Published Date From"
@@ -3598,11 +3709,11 @@ msgstr "Publiceringsdatum till"
 
 #: cps/templates/search_form.html:44 cps/templates/search_form.html:165
 msgid "Any"
-msgstr ""
+msgstr "Valfri"
 
 #: cps/templates/search_form.html:45 cps/templates/search_form.html:166
 msgid "Empty"
-msgstr ""
+msgstr "Tom"
 
 #: cps/templates/search_form.html:60
 msgid "Exclude Tags"
@@ -3630,21 +3741,21 @@ msgstr "Uteslut tillägg"
 
 #: cps/templates/search_form.html:145
 msgid "Rating Above"
-msgstr "Betyg större än"
+msgstr "Betyg över"
 
 #: cps/templates/search_form.html:149
 msgid "Rating Below"
-msgstr "Betyg mindre än"
+msgstr "Betyg under"
 
 #: cps/templates/search_form.html:175 cps/templates/search_form.html:187
 #: cps/templates/search_form.html:201
 msgid "From:"
-msgstr ""
+msgstr "Från:"
 
 #: cps/templates/search_form.html:179 cps/templates/search_form.html:191
 #: cps/templates/search_form.html:211
 msgid "To:"
-msgstr ""
+msgstr "Till:"
 
 #: cps/templates/shelf.html:13
 msgid "Delete this Shelf"
@@ -3668,11 +3779,11 @@ msgstr "Aktivera ändring av ordning"
 
 #: cps/templates/shelf.html:28
 msgid "Sort according to book added to shelf, newest first"
-msgstr ""
+msgstr "Sortera efter när boken lades till på hyllan, nyaste först"
 
 #: cps/templates/shelf.html:29
 msgid "Sort according to book added to shelf, oldest first"
-msgstr ""
+msgstr "Sortera efter när boken lades till på hyllan, äldsta först"
 
 #: cps/templates/shelf_edit.html:14
 msgid "Share with Everyone"
@@ -3680,11 +3791,11 @@ msgstr "Dela med alla"
 
 #: cps/templates/shelf_edit.html:21
 msgid "Sync this shelf with Kobo device"
-msgstr ""
+msgstr "Synkronisera den här hyllan med Kobo-enheten"
 
 #: cps/templates/shelf_order.html:5
 msgid "Drag to Rearrange Order"
-msgstr "Drag och släpp för att ändra ordning"
+msgstr "Dra för att ändra ordning"
 
 #: cps/templates/shelf_order.html:33
 msgid "Hidden Book"
@@ -3708,7 +3819,7 @@ msgstr "Kategorier i det här biblioteket"
 
 #: cps/templates/stats.html:24
 msgid "Series in this Library"
-msgstr "Serier i detta bibliotek"
+msgstr "Serier i det här biblioteket"
 
 #: cps/templates/stats.html:29
 msgid "System Statistics"
@@ -3716,7 +3827,7 @@ msgstr "Systemstatistik"
 
 #: cps/templates/stats.html:33
 msgid "Program"
-msgstr ""
+msgstr "Program"
 
 #: cps/templates/stats.html:34
 msgid "Installed Version"
@@ -3740,35 +3851,40 @@ msgstr "Förlopp"
 
 #: cps/templates/tasks.html:17
 msgid "Run Time"
-msgstr "Drifttid"
+msgstr "Körtid"
 
 #: cps/templates/tasks.html:19
 msgid "Message"
-msgstr ""
+msgstr "Meddelande"
 
 #: cps/templates/tasks.html:21
 msgid "Actions"
-msgstr ""
+msgstr "Åtgärder"
 
 #: cps/templates/tasks.html:41
-msgid "This task will be cancelled. Any progress made by this task will be saved."
-msgstr ""
+msgid ""
+"This task will be cancelled. Any progress made by this task will be saved."
+msgstr "Den här uppgiften avbryts. Alla framsteg som uppgiften har gjort sparas."
 
 #: cps/templates/tasks.html:42
-msgid "If this is a scheduled task, it will be re-ran during the next scheduled time."
-msgstr ""
+msgid ""
+"If this is a scheduled task, it will be re-ran during the next scheduled "
+"time."
+msgstr "Om det här är en schemalagd uppgift körs den igen vid nästa schemalagda tidpunkt."
 
 #: cps/templates/user_edit.html:20
 msgid "Reset user Password"
-msgstr "Återställ användarlösenordet"
+msgstr "Återställ användarens lösenord"
 
 #: cps/templates/user_edit.html:28
-msgid "Send to eReader Email Address. Use comma to separate emails for multiple eReaders"
-msgstr ""
+msgid ""
+"Send to eReader Email Address. Use comma to separate emails for multiple "
+"eReaders"
+msgstr "Skicka till e-läsarens e-postadress. Använd kommatecken för att separera adresser för flera e-läsare"
 
 #: cps/templates/user_edit.html:43
 msgid "Language of Books"
-msgstr "Visa böcker med språk"
+msgstr "Böckernas språk"
 
 #: cps/templates/user_edit.html:54
 msgid "OAuth Settings"
@@ -3784,7 +3900,7 @@ msgstr "Koppla bort"
 
 #: cps/templates/user_edit.html:64
 msgid "Kobo Sync Token"
-msgstr "Kobo Sync Token"
+msgstr "Kobo-synkroniseringstoken"
 
 #: cps/templates/user_edit.html:66
 msgid "Create/View"
@@ -3792,7 +3908,7 @@ msgstr "Skapa/Visa"
 
 #: cps/templates/user_edit.html:70
 msgid "Force full kobo sync"
-msgstr ""
+msgstr "Tvinga fullständig Kobo-synkronisering"
 
 #: cps/templates/user_edit.html:88
 msgid "Add allowed/Denied Custom Column Values"
@@ -3800,7 +3916,7 @@ msgstr "Lägg till tillåtna/avvisade anpassade kolumnvärden"
 
 #: cps/templates/user_edit.html:137
 msgid "Sync only books in selected shelves with Kobo"
-msgstr ""
+msgstr "Synkronisera endast böcker på markerade hyllor med Kobo"
 
 #: cps/templates/user_edit.html:147 cps/templates/user_table.html:169
 msgid "Delete User"
@@ -3808,7 +3924,7 @@ msgstr "Ta bort den här användaren"
 
 #: cps/templates/user_edit.html:159
 msgid "Generate Kobo Auth URL"
-msgstr "Skapa Kobo Auth URL"
+msgstr "Skapa URL för Kobo-autentisering"
 
 #: cps/templates/user_table.html:80 cps/templates/user_table.html:103
 msgid "Select..."
@@ -3824,15 +3940,15 @@ msgstr "Ange användarnamn"
 
 #: cps/templates/user_table.html:135
 msgid "Enter Email"
-msgstr ""
+msgstr "Ange e-postadress"
 
 #: cps/templates/user_table.html:136
 msgid "Enter eReader Email"
-msgstr ""
+msgstr "Ange e-läsarens e-postadress"
 
 #: cps/templates/user_table.html:136
 msgid "eReader Email"
-msgstr ""
+msgstr "E-läsarens e-postadress"
 
 #: cps/templates/user_table.html:137
 msgid "Locale"
@@ -3872,7 +3988,7 @@ msgstr "Redigera avvisade kolumnvärden"
 
 #: cps/templates/user_table.html:142
 msgid "Denied Column Values"
-msgstr ""
+msgstr "Nekade kolumnvärden"
 
 #: cps/templates/user_table.html:144
 msgid "Change Password"
@@ -3884,13 +4000,369 @@ msgstr "Visa"
 
 #: cps/templates/user_table.html:150
 msgid "Edit Public Shelves"
-msgstr ""
+msgstr "Redigera offentliga hyllor"
 
 #: cps/templates/user_table.html:152
 msgid "Sync selected Shelves with Kobo"
-msgstr ""
+msgstr "Synkronisera markerade hyllor med Kobo"
 
 #: cps/templates/user_table.html:156
 msgid "Show Read/Unread Section"
-msgstr ""
+msgstr "Visa sektionen Lästa/olästa"
 
+#~ msgid "installed"
+#~ msgstr "installerad"
+
+#~ msgid "Server restarted, please reload page"
+#~ msgstr "Servern har startats om. Läs in sidan igen"
+
+#~ msgid "Performing shutdown of server, please close window"
+#~ msgstr "Stänger servern, vänligen stäng fönstret"
+
+#~ msgid "Reconnect successful"
+#~ msgstr "Återanslutning lyckades"
+
+#~ msgid "all"
+#~ msgstr "alla"
+
+#~ msgid "Please fill out all fields!"
+#~ msgstr "Fyll i alla fält!"
+
+#~ msgid "Found an existing account for this e-mail address or name."
+#~ msgstr ""
+#~ "Hittade ett befintligt konto för den här e-postadressen eller namnet."
+
+#~ msgid "An unknown error occurred."
+#~ msgstr "Ett okänt fel uppstod."
+
+#~ msgid "Edit E-mail Server Settings"
+#~ msgstr "Ändra SMTP-inställningar"
+
+#~ msgid "G-Mail Account Verification Successful"
+#~ msgstr "Verifieringen av Gmail-kontot lyckades"
+
+#~ msgid "E-mail server settings updated"
+#~ msgstr "E-postserverinställningar uppdaterade"
+
+#, python-format
+#~ msgid "Password for user %(user)s reset"
+#~ msgstr "Lösenordet för användaren %(user)s har återställts"
+
+#~ msgid "Update File Could Not be Saved in Temp Dir"
+#~ msgstr "Uppdateringsfilen kunde inte sparas i den tillfälliga mappen"
+
+#~ msgid "not configured"
+#~ msgstr "inte konfigurerad"
+
+#~ msgid "Error opening eBook. File does not exist or file is not accessible"
+#~ msgstr ""
+#~ "Det gick inte att öppna e-boken. Filen finns inte eller filen är inte "
+#~ "tillgänglig"
+
+#, python-format
+#~ msgid "%(langname)s is not a valid language"
+#~ msgstr "%(langname)s är inte ett giltigt språk"
+
+#, python-format
+#~ msgid "Database error: %(error)s."
+#~ msgstr "Databasfel: %(error)s."
+
+#~ msgid "Error editing book, please check logfile for details"
+#~ msgstr ""
+#~ "Det gick inte att redigera boken, kontrollera loggfilen för mer "
+#~ "information"
+
+#~ msgid "Send to Kindle"
+#~ msgstr "Skicka till Kindle"
+
+#~ msgid "This e-mail has been sent via Calibre-Web."
+#~ msgstr "Detta e-postmeddelande har skickats via Calibre-Web."
+
+#~ msgid "Calibre-Web test e-mail"
+#~ msgstr "Testmeddelande från Calibre-Web"
+
+#~ msgid "Test e-mail"
+#~ msgstr "Testmeddelande"
+
+#, python-format
+#~ msgid "Registration e-mail for user: %(name)s"
+#~ msgstr "Registreringsmeddelande för användaren %(name)s"
+
+#, python-format
+#~ msgid "Convert %(orig)s to %(format)s and send to Kindle"
+#~ msgstr "Konvertera %(orig)s till %(format)s och skicka till Kindle"
+
+#, python-format
+#~ msgid "Send %(format)s to Kindle"
+#~ msgstr "Skicka %(format)s till Kindle"
+
+#, python-format
+#~ msgid "E-mail: %(book)s"
+#~ msgstr "E-post: %(book)s"
+
+#, python-format
+#~ msgid "Deleting book %(id)s, book path not valid: %(path)s"
+#~ msgstr "Borttagning av boken %(id)s, boksökväg inte giltig: %(path)s"
+
+#, python-format
+#~ msgid ""
+#~ "Rename file in path '%(src)s' to '%(dest)s' failed with error: %(error)s"
+#~ msgstr ""
+#~ "Det gick inte att byta namn på filen i sökvägen '%(src)s' till "
+#~ "'%(dest)s': %(error)s"
+
+#~ msgid "Found an existing account for this e-mail address"
+#~ msgstr "Hittade ett befintligt konto för den här e-postadressen"
+
+#~ msgid "Invalid e-mail address format"
+#~ msgstr "Ogiltigt e-postadressformat"
+
+#~ msgid "Unrar binary file not found"
+#~ msgstr "Den körbara Unrar-filen hittades inte"
+
+#~ msgid "Error excecuting UnRar"
+#~ msgstr "Fel vid körning av Unrar"
+
+#~ msgid ""
+#~ "PLease access calibre-web from non localhost to get valid api_endpoint "
+#~ "for kobo device"
+#~ msgstr ""
+#~ "Öppna Calibre-Web från en annan värd än localhost för att få en giltig "
+#~ "API-slutpunkt för Kobo-enheten"
+
+#~ msgid "login"
+#~ msgstr "logga in"
+
+#~ msgid "Show read and unread"
+#~ msgstr "Visa lästa och olästa"
+
+#~ msgid "Show random books"
+#~ msgstr "Visa slumpmässiga böcker"
+
+#~ msgid "Show category selection"
+#~ msgstr "Visa kategorival"
+
+#~ msgid "Show series selection"
+#~ msgstr "Visa serieval"
+
+#~ msgid "Show author selection"
+#~ msgstr "Visa författarval"
+
+#~ msgid "Show publisher selection"
+#~ msgstr "Visa urval av förlag"
+
+#~ msgid "Show language selection"
+#~ msgstr "Visa språkval"
+
+#~ msgid "Show ratings selection"
+#~ msgstr "Visa val av betyg"
+
+#~ msgid "Show file formats selection"
+#~ msgstr "Visa val av filformat"
+
+#~ msgid "Show archived books"
+#~ msgstr "Visa arkiverade böcker"
+
+#, python-format
+#~ msgid ""
+#~ "Sorry you are not allowed to add a book to the the shelf: %(shelfname)s"
+#~ msgstr "Tyvärr får du inte lägga till en bok på hyllan: %(shelfname)s"
+
+#, python-format
+#~ msgid "You are not allowed to add a book to the the shelf: %(name)s"
+#~ msgstr "Du får inte lägga till en bok i hyllan: %(name)s"
+
+#, python-format
+#~ msgid ""
+#~ "Sorry you are not allowed to remove a book from this shelf: %(sname)s"
+#~ msgstr ""
+#~ "Tyvärr har du inte rätt att ta bort en bok från den här hyllan: %(sname)s"
+
+#~ msgid ""
+#~ "Oops! Selected book title is unavailable. File does not exist or is not "
+#~ "accessible"
+#~ msgstr ""
+#~ "Hoppsan! Vald boktitel är inte tillgänglig. Filen finns inte eller är "
+#~ "inte tillgänglig"
+
+#, python-format
+#~ msgid "Custom Column No.%(column)d is not existing in calibre database"
+#~ msgstr "Anpassad kolumn n.%(column)d finns inte i calibre-databasen"
+
+#, python-format
+#~ msgid "Read Status = %(status)s"
+#~ msgstr "Lässtatus = %(status)s"
+
+#, python-format
+#~ msgid "Book successfully queued for sending to %(kindlemail)s"
+#~ msgstr "Boken är i kö för att skicka till %(kindlemail)s"
+
+#, python-format
+#~ msgid "Oops! There was an error sending this book: %(res)s"
+#~ msgstr "Det gick inte att skicka den här boken: %(res)s"
+
+#~ msgid ""
+#~ "Please update your profile with a valid Send to Kindle E-mail Address."
+#~ msgstr "Konfigurera din kindle-e-postadress först..."
+
+#~ msgid "E-Mail server is not configured, please contact your administrator!"
+#~ msgstr "E-postservern är inte konfigurerad, kontakta din administratör!"
+
+#~ msgid "register"
+#~ msgstr "registrera"
+
+#~ msgid "Your e-mail is not allowed to register"
+#~ msgstr "Din e-post är inte tillåten att registrera"
+
+#~ msgid "Confirmation e-mail was send to your e-mail account."
+#~ msgstr "Bekräftelsemail skickades till ditt e-postkonto."
+
+#~ msgid "New Password was send to your email address"
+#~ msgstr "Nytt lösenord skickades till din e-postadress"
+
+#, python-format
+#~ msgid "%(name)s's profile"
+#~ msgstr "%(name)ss profil"
+
+#~ msgid "Profile updated"
+#~ msgstr "Profilen uppdaterad"
+
+#~ msgid "Found an existing account for this e-mail address."
+#~ msgstr "Hittade ett befintligt konto för den här e-postadressen."
+
+#~ msgid "Read a Book"
+#~ msgstr "Läs en bok"
+
+#~ msgid "E-mail Address"
+#~ msgstr "E-post"
+
+#~ msgid "Send to Kindle E-mail Address"
+#~ msgstr "Kindle"
+
+#~ msgid "E-mail Server Settings"
+#~ msgstr "Inställningar för SMTP-e-postserver"
+
+#~ msgid "From E-mail"
+#~ msgstr "Från meddelande"
+
+#~ msgid "E-Mail Service"
+#~ msgstr "E-posttjänst"
+
+#~ msgid "Reverse proxy header name"
+#~ msgstr "Omvänt proxy rubriknamn"
+
+#~ msgid "Update"
+#~ msgstr "Uppdatera"
+
+#~ msgid "Current version"
+#~ msgstr "Aktuell version"
+
+#~ msgid " Search keyword "
+#~ msgstr " Sök sökord "
+
+#~ msgid "Remove Selections"
+#~ msgstr "Ta bort markeringar"
+
+#~ msgid "Enter title"
+#~ msgstr "Ange titel"
+
+#~ msgid "Library Configuration"
+#~ msgstr "Bibliotekets konfiguration"
+
+#~ msgid "To activate serverside filepicker start Calibre-Web with -f option"
+#~ msgstr ""
+#~ "Starta Calibre-Web med alternativet -f för att aktivera filväljaren på "
+#~ "serversidan"
+
+#~ msgid "Google Drive config problem"
+#~ msgstr "Google Drive-konfigurationsproblem"
+
+#~ msgid "Please hit save to continue with setup"
+#~ msgstr "Klicka på Spara för att fortsätta med konfigurationen"
+
+#~ msgid "Please finish Google Drive setup after login"
+#~ msgstr "Slutför Google Drive-konfigurationen efter inloggning"
+
+#~ msgid "Use E-Mail as Username"
+#~ msgstr "Använd e-post som användarnamn"
+
+#~ msgid "Create an API Key"
+#~ msgstr "Skapa en API-nyckel"
+
+#~ msgid "Goodreads API Secret"
+#~ msgstr "Goodreads API-hemlighet"
+
+#~ msgid "Path to Calibre E-Book Converter"
+#~ msgstr "Sökväg till Calibres e-bokskonverterare"
+
+#~ msgid "Book"
+#~ msgstr "Bok"
+
+#~ msgid "of"
+#~ msgstr "av"
+
+#~ msgid "Choose Server Type"
+#~ msgstr "Välj servertyp"
+
+#~ msgid "Use Standard E-Mail Account"
+#~ msgstr "Använd vanligt e-postkonto"
+
+#~ msgid "Gmail Account with OAuth2 Verfification"
+#~ msgstr "Gmail-konto med OAuth2-verifiering"
+
+#~ msgid "Setup Gmail Account as E-Mail Server"
+#~ msgstr "Ställ in Gmail-kontot som e-postserver"
+
+#~ msgid "Save and Send Test E-mail"
+#~ msgstr "Spara och skicka testmeddelande"
+
+#~ msgid ""
+#~ "Open the .kobo/Kobo eReader.conf file in a text editor and add (or edit):"
+#~ msgstr ""
+#~ "Öppna filen .kobo/Kobo eReader.conf i en textredigerare och lägg till "
+#~ "(eller redigera):"
+
+#~ msgid "This book will be permanently erased from database"
+#~ msgstr "Boken kommer att tas bort från Calibre-databasen"
+
+#~ msgid "and hard disk"
+#~ msgstr "och från hårddisken"
+
+#~ msgid "PDF reader"
+#~ msgstr "PDF-läsare"
+
+#~ msgid "Basic txt Reader"
+#~ msgstr "Enkel TXT-läsare"
+
+#~ msgid "Your email address"
+#~ msgstr "Din e-postadress"
+
+#~ msgid "Shelf will be deleted for all users"
+#~ msgstr "Hyllan tas bort för alla användare"
+
+#~ msgid "Program Library"
+#~ msgstr "Programbibliotek"
+
+#~ msgid "Delete finished tasks"
+#~ msgstr "Ta bort färdiga uppgifter"
+
+#~ msgid "Hide all tasks"
+#~ msgstr "Dölj alla uppgifter"
+
+#~ msgid "Enter E-mail Address"
+#~ msgstr "Ange e-postadress"
+
+#~ msgid "Enter Kindle E-mail Address"
+#~ msgstr "Ange Kindle-e-postadress"
+
+#~ msgid "Kindle E-mail"
+#~ msgstr "Kindle-e-postadress"
+
+#~ msgid "Denied Columns Values"
+#~ msgstr "Avvisade kolumnvärden"
+
+#~ msgid "Edit Public Shelfs"
+#~ msgstr "Redigera offentliga hyllor"
+
+#~ msgid "Show read/unread selection"
+#~ msgstr "Visa val för läst/oläst"


### PR DESCRIPTION
This PR updates and improves the Swedish translation for Calibre-Web.

Changes include:

* updating the Swedish translation against the current `master`
* completing all previously untranslated strings
* improving grammar, wording, and terminology
* correcting typos and awkward translations
* improving consistency across the interface
* preserving placeholders, plural forms, and formatting
* updating the translator information

Validation:

* 910 translated messages
* 0 untranslated messages
* 0 fuzzy entries
* `msgfmt --check` passes successfully

The Swedish translation is now complete for the current translation catalog.