### PR TITLE
Fix cover detection for EPUB3 books declaring covers via properties="cover-image"

### DIFF
--- a/cps/epub.py
+++ b/cps/epub.py
@@ -155,7 +155,10 @@ def get_epub_info(tmp_file_path, original_file_name, original_file_extension, no
 
 
 def parse_epub_cover(ns, tree, epub_zip, cover_path, tmp_file_path):
-    cover_section = tree.xpath("/pkg:package/pkg:manifest/pkg:item[@id='cover-image']/@href", namespaces=ns)
+    cover_section = tree.xpath(
+        "/pkg:package/pkg:manifest/pkg:item[@id='cover-image' or "
+        "contains(concat(' ', normalize-space(@properties), ' '), ' cover-image ')]/@href",
+        namespaces=ns)
     for cs in cover_section:
         cover_file = _extract_cover(epub_zip, cs, cover_path, tmp_file_path)
         if cover_file:


### PR DESCRIPTION
**Problem.** `parse_epub_cover()` finds the manifest cover by `item[@id='cover-image']`. EPUB3 marks covers with the `properties="cover-image"` attribute — the `id` is arbitrary. Files without the EPUB2 `<meta name="cover">` compat element or a `<guide>` (e.g. every Standard Ebooks release) therefore import with the generic cover and `has_cover=0`, despite containing a valid cover:

```xml
<item href="images/cover.jpg" id="cover.jpg" media-type="image/jpeg" properties="cover-image"/>
```

**Fix.** Extend the first manifest lookup to also match the `properties` token. Token-aware `contains()` rather than equality, since `properties` is a space-separated list per spec.

**Tested** on 0.6.27: 32 Standard Ebooks epubs reproduced the failure on upload; with this change the same files import with correct covers.

**Disclosure:** the diagnosis was done on my own instance; the code change and this PR text were written by an AI coding agent (Claude) working under my direction, and I have verified the fix on my deployment.
