### PR TITLE
Quote library_path and tmp_dir when trying to embed metadata

### DIFF
--- a/cps/embed_helper.py
+++ b/cps/embed_helper.py
@@ -28,7 +28,7 @@ log = logger.create()
 
 def do_calibre_export(book_id, book_format):
     try:
-        quotes = [4, 6]
+        quotes = [5, 7]
         tmp_dir = get_temp_dir()
         calibredb_binarypath = get_calibre_binarypath("calibredb")
         temp_file_name = str(uuid4())


### PR DESCRIPTION
This resolves a bug introduced with #3632 in v[0.6.27](https://github.com/janeczku/calibre-web/releases/tag/0.6.27)

On Windows when a book tries to get metadata embedded it fails with: 
```
Traceback (most recent call last):
  File "runpy.py", line 203, in _run_module_as_main
  File "runpy.py", line 88, in _run_code
  File "site.py", line 83, in <module>
  File "site.py", line 78, in main
  File "site.py", line 50, in run_entry_point
  File "calibre\db\cli\main.py", line 274, in main
  File "calibre\db\cli\main.py", line 58, in run_cmd
  File "calibre\db\cli\cmd_export.py", line 133, in main
  File "calibre\db\cli\__init__.py", line 13, in integers_from_string
ValueError: invalid literal for int() with base 10: 'Calibre'
```

when using `calibredb.exe`.

This updates the quote mapping so the paths are correctly quoted after the new `'--dont-save-cover'` arg was added.

resolves #3684.