### PR TITLE
Add generic hierarchical custom column browsing support

### DIFF
--- a/cps/db.py
+++ b/cps/db.py
@@ -20,6 +20,7 @@
 import os
 import re
 import json
+import time
 from datetime import datetime, timezone
 from urllib.parse import quote
 import unidecode
@@ -48,6 +49,7 @@ from flask_babel import get_locale
 from flask import flash, g, Flask
 
 from . import logger, ub, isoLanguages
+from . import hierarchy
 from .pagination import Pagination
 from .string_helper import strip_whitespaces
 
@@ -1072,6 +1074,77 @@ class CalibreDB:
 
         return cc
 
+    def hierarchical_cc_filter(self, col_id, path):
+        """SQLAlchemy filter matching a hierarchy node and all of its descendants.
+
+        Matches:      Computers            (exact leaf)
+                      Computers.DB         (descendant)
+                      Computers.DB.Oracle  (deeper descendant)
+        Does NOT match: ComputersX         (prefix collision guard via trailing '.')
+        """
+        cc = cc_classes[col_id]
+        return or_(
+            cc.value == path,
+            cc.value.like(hierarchy.like_pattern(path), escape=hierarchy.ESCAPE_CHAR)
+        )
+
+    def get_hierarchical_column_ids(self, ttl=300):
+        """Return the set of custom column ids that behave as hierarchies.
+
+        A column qualifies only when at least one stored value is a proper
+        prefix (value + separator) of another stored value, e.g. 'Computers'
+        and 'Computers.DB'. This avoids false positives on columns whose
+        values merely contain dots (Dewey '778.3', LCC 'QA76.76.C68', ...).
+        Result is cached process-wide for `ttl` seconds.
+        """
+        now = time.monotonic()
+        cached = getattr(self.__class__, '_hier_cache', None)
+        if cached is not None and now - cached[0] < ttl:
+            return cached[1]
+        ids = set()
+        for cid, cc in cc_classes.items():
+            try:
+                values = [r[0] for r in self.session.query(cc.value).distinct()]
+            except OperationalError:
+                continue
+            if hierarchy.is_hierarchical_value_set(values):
+                ids.add(cid)
+        self.__class__._hier_cache = (now, ids)
+        return ids
+
+    def hierarchical_cc_search_filter(self, col_id, term):
+        """Calibre-style search semantics for hierarchical columns: a term
+        matches the exact value or any of its descendants ('Computers'
+        matches 'Computers' and 'Computers.DB'), case-insensitively.
+        Non-hierarchical columns keep the fuzzy substring behaviour."""
+        cc = cc_classes[col_id]
+        pattern = func.lower(hierarchy.like_pattern(term))
+        return or_(
+            func.lower(cc.value) == func.lower(term),
+            func.lower(cc.value).like(pattern, escape=hierarchy.ESCAPE_CHAR)
+        )
+
+    def get_hierarchical_tree(self, col_id, apply_common_filters=True):
+        """Return the nested tree (list of root nodes) for custom column `col_id`,
+        honouring user visibility filters. See cps/hierarchy.py for the node shape.
+        """
+        cc = cc_classes.get(col_id)
+        if cc is None:
+            return []
+        rel = getattr(Books, 'custom_column_' + str(col_id))
+        q = (self.session.query(Books.id, cc.value)
+            .select_from(Books)
+            .join(rel)
+            .distinct())
+        if apply_common_filters:
+            q = q.filter(self.common_filters())
+        try:
+            rows = q.all()
+        except OperationalError:
+            log.error("Failed to read custom column %s for hierarchy tree", col_id)
+            return []
+        return hierarchy.parse_tag_hierarchy([r[1] for r in rows])
+
     # read search results from calibre-database and return it (function is used for feed and simple search
     def get_search_results(self, term, config, offset=None, order=None, limit=None, *join):
         order = order[0] if order else [Books.sort]
@@ -1196,9 +1269,14 @@ class Category:
     count = None
     rating = None
 
-    def __init__(self, name, cat_id, rating=None):
+    def __init__(self, name, cat_id, rating=None, path=None, children=None):
         self.name = name
         self.sort = name
         self.id = cat_id
         self.rating = rating
         self.count = 1
+        # Hierarchical custom column support: full dotted path and nested
+        # child nodes (list of Category instances). Flat categories keep
+        # the previous behaviour (path == name, no children).
+        self.path = path or name
+        self.children = children or []

--- a/cps/hierarchy.py
+++ b/cps/hierarchy.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+
+#  This file is part of the Calibre-Web (https://github.com/janeczku/calibre-web)
+#    Copyright (C) 2024 Calibre-Web contributors
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Helpers for Calibre-style hierarchical custom columns ("dot notation").
+
+Values such as ``Computers.DB.Oracle`` stored in tag-like custom columns are
+converted into nested tree dictionaries so they can be rendered as collapsible
+trees and filtered with prefix matching (a parent node matches itself plus all
+of its descendants).
+
+This module intentionally has no Flask/SQLAlchemy dependencies so it stays
+unit-testable in isolation.
+"""
+
+SEPARATOR = '.'
+ESCAPE_CHAR = '\\'
+
+
+def split_path(path):
+    """Split a dotted path into its non-empty, stripped components."""
+    return [p.strip() for p in (path or '').split(SEPARATOR) if p.strip()]
+
+
+def join_path(parts):
+    """Join path components back into a canonical dotted path."""
+    return SEPARATOR.join(split_path(SEPARATOR.join(parts)))
+
+
+def parse_tag_hierarchy(values):
+    """Convert an iterable of dot-notation strings into a sorted list of
+    top-level tree nodes.
+
+    Each node looks like::
+
+        {'name': 'DB', 'path': 'Computers.DB', 'count': 1,
+         'total_count': 2, 'children': [...]}
+
+    ``count`` counts direct hits on the exact value, ``total_count``
+    aggregates the counts of the whole subtree (including the node itself).
+    """
+    roots = {}
+    for value in values:
+        if not value:
+            continue
+        parts = split_path(value)
+        node_map = roots
+        path = ''
+        for i, part in enumerate(parts):
+            path = part if i == 0 else path + SEPARATOR + part
+            node = node_map.setdefault(part, {'name': part, 'path': path,
+                                              'id': None, 'count': 0,
+                                              'children': {}})
+            if i == len(parts) - 1:
+                node['count'] += 1          # direct hits only
+            node_map = node['children']
+    return _finalize(list(roots.values()))
+
+
+def _finalize(nodes):
+    """Recursively convert children dicts to sorted lists; aggregate counts."""
+    nodes.sort(key=lambda n: n['name'].lower())
+    for node in nodes:
+        node['children'] = _finalize(list(node['children'].values()))
+        node['total_count'] = node['count'] + sum(c['total_count']
+                                                  for c in node['children'])
+    return nodes
+
+
+def get_node_by_path(tree, path):
+    """Locate a node by its full dotted path, e.g. ``'Computers.DB'``.
+
+    Returns ``None`` when any component of the path does not exist.
+    """
+    node_map = {n['name']: n for n in tree}
+    node = None
+    for part in split_path(path):
+        node = node_map.get(part)
+        if node is None:
+            return None
+        node_map = {n['name']: n for n in node['children']}
+    return node
+
+
+def breadcrumb_trail(path):
+    """Return ``[(name, full_path), ...]`` ancestors including the node itself.
+
+    >>> breadcrumb_trail('Computers.DB')
+    [('Computers', 'Computers'), ('DB', 'Computers.DB')]
+    """
+    trail, acc = [], []
+    for part in split_path(path):
+        acc.append(part)
+        trail.append((part, SEPARATOR.join(acc)))
+    return trail
+
+
+def escape_like(text):
+    """Escape SQL LIKE wildcards so user-supplied paths match literally."""
+    return (text.replace(ESCAPE_CHAR, ESCAPE_CHAR * 2)
+                .replace('%', ESCAPE_CHAR + '%')
+                .replace('_', ESCAPE_CHAR + '_'))
+
+
+def like_pattern(path):
+    """Build the escaped LIKE pattern matching a node and all descendants."""
+    return escape_like(join_path(split_path(path))) + '.' + '%'
+
+
+def has_hierarchy_separator(value):
+    """True when a single stored value looks hierarchical (contains a dot)."""
+    return bool(value) and SEPARATOR in value
+
+
+def is_hierarchical_value_set(values):
+    """True when a column's value set behaves as a hierarchy.
+
+    Requires at least one value to be a proper prefix (value + separator) of
+    another value, e.g. {'Computers', 'Computers.DB'}. Avoids false positives
+    on dot-containing but flat value sets (Dewey '778.3', LCC 'QA76.76.C68').
+    """
+    vset = {v.strip() for v in values if v}
+    return any(any(other.startswith(v + SEPARATOR) for other in vset)
+               for v in vset)

--- a/cps/opds.py
+++ b/cps/opds.py
@@ -31,7 +31,7 @@ from flask_babel import gettext as _
 from sqlalchemy.sql.expression import func, text, or_, and_, true
 from sqlalchemy.exc import InvalidRequestError, OperationalError
 
-from . import logger, config, db, calibre_db, ub, isoLanguages, constants
+from . import logger, config, db, calibre_db, ub, isoLanguages, constants, hierarchy
 from .usermanagement import requires_basic_auth_if_no_ano, auth
 from .helper import get_download_link, get_book_cover
 from .pagination import Pagination
@@ -243,6 +243,63 @@ def feed_letter_category(book_id):
 @requires_basic_auth_if_no_ano
 def feed_category(book_id):
     return render_xml_dataset(db.Tags, book_id)
+
+
+@opds.route("/opds/custom_column/<int:column_id>", defaults={'category_path': ''})
+@opds.route("/opds/custom_column/<int:column_id>/<path:category_path>")
+@requires_basic_auth_if_no_ano
+def feed_cc_category(column_id, category_path):
+    """OPDS navigation/acquisition feed for one hierarchical custom column.
+
+    /opds/custom_column/1                    -> top-level nodes
+    /opds/custom_column/1/Computers          -> child nodes (navigation)
+    /opds/custom_column/1/Computers.DB       -> books under the leaf (acquisition)
+    Nodes with children take precedence over directly attached books;
+    those remain reachable through the OPDS search.
+    """
+    if column_id not in db.cc_classes:
+        abort(404)
+    col = calibre_db.session.query(db.CustomColumns).filter(
+        db.CustomColumns.id == column_id).first()
+    if not col or col.datatype not in ('text', 'enumeration'):
+        abort(404)
+
+    # Flask's <path:...> converter captures slashes; our separator is '.'
+    path = (category_path or '').replace('/', hierarchy.SEPARATOR)
+    path = hierarchy.join_path([path])
+    off = int(request.args.get("offset") or 0)
+    cc = calibre_db.get_cc_columns(config, filter_config_custom_read=True)
+
+    if path:
+        node = hierarchy.get_node_by_path(
+            calibre_db.get_hierarchical_tree(column_id), path)
+        if node is None:
+            abort(404)
+        if node['children']:
+            elements = [{'column_id': column_id, 'path': child['path'],
+                         'name': child['name']} for child in node['children']]
+            pagination = Pagination(1, config.config_books_per_page,
+                                    max(len(elements), 1))
+            return render_xml_template('feed.xml', hierarchyelements=elements,
+                                       pagination=pagination, cc=cc)
+
+    if path:
+        entries, __, pagination = calibre_db.fill_indexpage(
+            (int(off) / (int(config.config_books_per_page)) + 1), 0,
+            db.Books,
+            getattr(db.Books, 'custom_column_' + str(column_id)).any(
+                calibre_db.hierarchical_cc_filter(column_id, path)),
+            [db.Books.timestamp.desc()],
+            True, config.config_read_column)
+        return render_xml_template('feed.xml', entries=entries,
+                                   pagination=pagination, cc=cc)
+
+    elements = [{'column_id': column_id, 'path': n['path'], 'name': n['name']}
+                for n in calibre_db.get_hierarchical_tree(column_id)]
+    pagination = Pagination(1, config.config_books_per_page,
+                            max(len(elements), 1))
+    return render_xml_template('feed.xml', hierarchyelements=elements,
+                               pagination=pagination, cc=cc)
 
 
 @opds.route("/opds/series")

--- a/cps/render_template.py
+++ b/cps/render_template.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-from flask import g, abort, request, render_template
+from flask import g, abort, request, render_template, url_for
 from flask_themes2 import render_theme_template
 from jinja2 import TemplateNotFound
 from flask_babel import gettext as _
@@ -119,10 +119,74 @@ def get_sidebar_config(kwargs=None):
             {"glyph": "glyphicon-th-list", "text": _('Books List'), "link": 'web.books_table', "id": "list",
              "visibility": constants.SIDEBAR_LIST, 'public': (not current_user.is_anonymous),
              "show_text": _('Show Books List'), "config_show": content, "no_param":True})
+    sidebar.extend(get_custom_column_sidebar_entries())
     g.shelves_access = ub.session.query(ub.Shelf).filter(
         or_(ub.Shelf.is_public == 1, ub.Shelf.user_id == current_user.id)).order_by(ub.Shelf.name).all()
 
     return sidebar, simple
+
+
+def get_custom_column_sidebar_entries():
+    """Sidebar entries for all browsable tag-like custom columns
+    (datatype text/enumeration). Hierarchical columns render as a tree,
+    flat ones as a plain list - both through web.cc_category_list.
+
+    Per-user visibility is stored independently of the built-in section
+    flags in User.view_settings ('cc_sidebar' page, key 'show_cc_<id>'),
+    managed via named checkboxes on the profile page (/me). Entries are
+    omitted entirely when the user disabled them.
+    Failures (e.g. DB not ready) silently skip the extra entries."""
+    entries = []
+    try:
+        from . import calibre_db, db
+        if not db.cc_classes:
+            return entries
+        for col in calibre_db.get_cc_columns(config):
+            if col.datatype not in ('text', 'enumeration'):
+                continue
+            prop = 'show_cc_%d' % col.id
+            if current_user.get_view_property('cc_sidebar', prop) is False:
+                continue
+            entries.append({
+                "glyph": "glyphicon-tags",
+                "text": col.name,
+                "link": 'web.cc_category_list',
+                "href": url_for('web.cc_category_list', column_id=col.id),
+                "id": "cc_%d" % col.id,
+                "visibility": constants.SIDEBAR_CATEGORY,
+                'public': True,
+                "page": "cclist",
+                # Visibility is managed by the dedicated named-checkbox group
+                # on the profile page (see get_custom_column_visibility_options),
+                # not by the generic config_show loop.
+                "config_show": False,
+            })
+    except Exception:
+        log.debug("Could not build custom column sidebar entries", exc_info=True)
+    return entries
+
+
+def get_custom_column_visibility_options():
+    """All browsable custom columns with their per-user sidebar visibility
+    state, for the named checkbox group on the profile page (/me).
+    Disabled columns are included so they can be re-enabled."""
+    options = []
+    try:
+        from . import calibre_db, db
+        if not db.cc_classes:
+            return options
+        for col in calibre_db.get_cc_columns(config):
+            if col.datatype not in ('text', 'enumeration'):
+                continue
+            options.append({
+                'id': col.id,
+                'name': col.name,
+                'visible': current_user.get_view_property(
+                    'cc_sidebar', 'show_cc_%d' % col.id) is not False,
+            })
+    except Exception:
+        log.debug("Could not build custom column visibility options", exc_info=True)
+    return options
 
 
 # Returns the template for rendering and includes the instance name

--- a/cps/search.py
+++ b/cps/search.py
@@ -105,6 +105,12 @@ def adv_search_custom_columns(cc, term, q):
                 if c.datatype == 'rating':
                     q = q.filter(getattr(db.Books, 'custom_column_' + str(c.id)).any(
                         db.cc_classes[c.id].value == int(float(custom_query) * 2)))
+                elif c.datatype in ('text', 'enumeration') and \
+                        c.id in calibre_db.get_hierarchical_column_ids():
+                    # Hierarchical column: match the node itself plus all
+                    # descendants ('Computers' -> 'Computers.DB', ...)
+                    q = q.filter(getattr(db.Books, 'custom_column_' + str(c.id)).any(
+                        calibre_db.hierarchical_cc_search_filter(c.id, custom_query)))
                 else:
                     q = q.filter(getattr(db.Books, 'custom_column_' + str(c.id)).any(
                         func.lower(db.cc_classes[c.id].value).ilike("%" + custom_query + "%")))

--- a/cps/static/css/style.css
+++ b/cps/static/css/style.css
@@ -511,3 +511,65 @@ body > div.container-fluid  {
 .input-group .toggle-password {
   height: 40px;
 }
+
+/* ---- Hierarchical custom columns -------------------------------------- */
+.hierarchy-tree ul.hierarchy-children {
+  padding-left: 1.4em;
+}
+
+.hierarchy-node > a .hierarchy-toggle {
+  display: inline-block;
+  margin-right: .4em;
+  transition: transform .15s ease;
+}
+
+.hierarchy-node.expanded > a .hierarchy-toggle {
+  transform: rotate(90deg);
+}
+
+.hierarchy-node.collapsed > ul.hierarchy-children {
+  display: none;
+}
+
+.hierarchy-details {
+  padding-left: 1.2em;
+}
+
+.hierarchy-details > summary {
+  cursor: pointer;
+}
+
+.hierarchy-details > summary .badge,
+.hierarchy-node .badge {
+  font-size: .7em;
+  margin-left: .4em;
+}
+
+.hierarchy-breadcrumb {
+  padding: .4em 0;
+}
+
+.hierarchy-breadcrumb .sep {
+  margin: 0 .3em;
+  opacity: .6;
+}
+
+.hierarchy-hint {
+  opacity: .75;
+}
+
+.hierarchy-subcategories h3 {
+  margin-top: .4em;
+}
+
+.hierarchy-sublist {
+  margin: .3em 0;
+}
+
+.hierarchy-sublist li {
+  padding: .15em 0;
+}
+
+.hierarchy-sublist li a {
+  display: inline-block;
+}

--- a/cps/static/js/hierarchy.js
+++ b/cps/static/js/hierarchy.js
@@ -1,0 +1,64 @@
+/**
+ * Hierarchical custom columns: collapse/expand state persistence.
+ *
+ * The open/closed state of every <details class="hierarchy-details"> node is
+ * stored in sessionStorage (per column, keyed by the node's dotted path), so
+ * the user's expansion survives page navigations within the session.
+ * The active branch is additionally expanded server-side (URL-driven), which
+ * takes precedence for the current path.
+ *
+ * Also wires the "Expand all" / "Collapse all" buttons on the tree page.
+ */
+(function ($) {
+    'use strict';
+
+    $(function () {
+        var $tree = $('.hierarchy-tree');
+        if (!$tree.length) {
+            return;
+        }
+        var colId = $tree.data('col-id');
+        var storageKey = 'cw-hierarchy-' + colId;
+        var state = {};
+
+        function loadState() {
+            try {
+                state = JSON.parse(sessionStorage.getItem(storageKey) || '{}') || {};
+            } catch (e) {
+                state = {};
+            }
+        }
+
+        function saveState() {
+            try {
+                sessionStorage.setItem(storageKey, JSON.stringify(state));
+            } catch (e) { /* storage unavailable (private mode etc.) */ }
+        }
+
+        loadState();
+
+        // Restore previously toggled nodes (server-rendered "open" state for
+        // the active path is only applied when no user preference exists).
+        $tree.find('details.hierarchy-details[data-path]').each(function () {
+            var path = $(this).data('path');
+            if (Object.prototype.hasOwnProperty.call(state, path)) {
+                this.open = !!state[path];
+            }
+        });
+
+        $tree.on('toggle', 'details.hierarchy-details', function () {
+            state[$(this).data('path')] = this.open;
+            saveState();
+        });
+
+        $('#hierarchy-expand-all').on('click', function (e) {
+            e.preventDefault();
+            $tree.find('details.hierarchy-details').prop('open', true);
+        });
+
+        $('#hierarchy-collapse-all').on('click', function (e) {
+            e.preventDefault();
+            $tree.find('details.hierarchy-details').prop('open', false);
+        });
+    });
+}(jQuery));

--- a/cps/templates/feed.xml
+++ b/cps/templates/feed.xml
@@ -143,4 +143,11 @@
     <link rel="subsection" type="application/atom+xml;profile=opds-catalog" href="{{url_for(folder, book_id=entry['id'])}}"/>
   </entry>
   {% endfor %}
+  {% for entry in hierarchyelements %}
+  <entry>
+    <title>{{entry['name']}}</title>
+    <id>{{ url_for('opds.feed_cc_category', column_id=entry['column_id'], category_path=entry['path']) }}</id>
+    <link rel="subsection" type="application/atom+xml;profile=opds-catalog" href="{{url_for('opds.feed_cc_category', column_id=entry['column_id'], category_path=entry['path'])}}"/>
+  </entry>
+  {% endfor %}
 </feed>

--- a/cps/themes/caliblur/templates/cc_list.html
+++ b/cps/themes/caliblur/templates/cc_list.html
@@ -1,0 +1,21 @@
+{% extends theme("layout.html") %}
+{% from theme('macros/hierarchy.html') import render_details_tree %}
+{% block body %}
+<div class="discover">
+  {% if page == 'cclist' %}
+    <span class="catlist-icon glyphicon glyphicon-tags" aria-hidden="true"></span>
+  {% endif %}
+  <h2 class="{{ page }}">{{ _(title)|replace(':', ' —')|replace("'", "") }}</h2>
+  <p class="hierarchy-hint">{{_('Select a category to see the books assigned to it and all of its sub-categories.')}}</p>
+  <div class="btn-group hierarchy-actions" role="group">
+    <button id="hierarchy-expand-all" class="btn btn-primary btn-sm">{{_('Expand all')}}</button>
+    <button id="hierarchy-collapse-all" class="btn btn-primary btn-sm">{{_('Collapse all')}}</button>
+  </div>
+  <div class="hierarchy-tree" data-col-id="{{ col_id }}">
+    {{ render_details_tree(entries, col_id) }}
+  </div>
+</div>
+{% endblock %}
+{% block js %}
+<script src="{{ url_for('static', filename='js/hierarchy.js') }}"></script>
+{% endblock %}

--- a/cps/themes/caliblur/templates/detail.html
+++ b/cps/themes/caliblur/templates/detail.html
@@ -306,7 +306,14 @@
                                         {% elif c.datatype == 'series' %}
                                             {{ '%s [%s]' % (column.value, column.extra|formatfloat(2)) }}
                                         {% elif c.datatype == 'text' %}
-                                            {{ column.value.strip() }}{% if not loop.last %}, {% endif %}
+                                            {% if '.' in column.value %}
+                                                {% set parts = column.value.strip().split('.') %}
+                                                {% for part in parts %}
+                                                    <a class="hierarchy-crumb" href="{{ url_for('web.cc_category_list', column_id=c.id, category_path=parts[:loop.index]|join('.')) }}">{{ part }}</a>{% if not loop.last %}. {% endif %}
+                                                {% endfor %}
+                                            {% else %}
+                                                {{ column.value.strip() }}
+                                            {% endif %}{% if not loop.last %}, {% endif %}
                                         {% else %}
                                             {{ column.value }}
                                         {% endif %}

--- a/cps/themes/caliblur/templates/index.html
+++ b/cps/themes/caliblur/templates/index.html
@@ -1,6 +1,22 @@
 {% import 'image.html' as image %}
 {% extends theme("layout.html") %}
 {% block body %}
+{% if breadcrumbs %}
+  {% from theme('macros/hierarchy.html') import hierarchy_breadcrumbs %}
+  <div class="discover">
+  {{ hierarchy_breadcrumbs(breadcrumbs, col_id) }}
+  </div>
+{% endif %}
+{% if subcategories %}
+  <div class="discover hierarchy-subcategories">
+    <h3>{{_('Subcategories')}}</h3>
+    <ul class="hierarchy-sublist list-unstyled">
+    {% for sub in subcategories %}
+      <li><a href="{{ url_for('web.cc_category_list', column_id=col_id, category_path=sub.path) }}">{{ sub.name }} <span class="badge badge-sm">{{ sub.total_count }}</span></a></li>
+    {% endfor %}
+    </ul>
+  </div>
+{% endif %}
 {% if current_user.show_detail_random() and page != "discover" %}
 <div class="discover random-books caliblur-index">
   <h2 class="random-books">{{_('Discover (Random Books)')}}</h2>

--- a/cps/themes/caliblur/templates/layout.html
+++ b/cps/themes/caliblur/templates/layout.html
@@ -133,8 +133,8 @@
               <li class="nav-head hidden-xs">{{_('Browse')}}</li>
               <li><a href="{{url_for('search.advanced_search')}}" id="advanced_search"><span class="glyphicon glyphicon-search"></span><span class="hidden-sm"> {{_('Advanced Search')}}</span></a></li>
               {% for element in sidebar %}
-                {% if current_user.check_visibility(element['visibility']) and element['public'] %}
-                    <li id="nav_{{element['id']}}" {% if page == element['page'] %}class="active"{% endif %}><a href="{% if element['no_param'] %}{{url_for(element['link'], data=element['page'])}}{%else%}{{url_for(element['link'], data=element['page'], sort_param='stored')}}{% endif %}"><span class="glyphicon {{element['glyph']}}"></span> <span class="nav-text">{{_(element['text'])|trim}}</span></a></li>
+                {% if element['cc_id'] is defined or (current_user.check_visibility(element['visibility']) and element['public']) %}
+                    <li id="nav_{{element['id']}}" {% if page == element['page'] %}class="active"{% endif %}><a href="{% if element['href'] %}{{ element['href'] }}{% elif element['no_param'] %}{{url_for(element['link'], data=element['page'])}}{%else%}{{url_for(element['link'], data=element['page'], sort_param='stored')}}{% endif %}"><span class="glyphicon {{element['glyph']}}"></span> <span class="nav-text">{{_(element['text'])|trim}}</span></a></li>
                 {% endif %}
               {% endfor %}
               {% if current_user.is_authenticated or g.allow_anonymous %}

--- a/cps/themes/caliblur/templates/macros/hierarchy.html
+++ b/cps/themes/caliblur/templates/macros/hierarchy.html
@@ -1,0 +1,52 @@
+{# Recursive rendering helpers for hierarchical custom columns.
+   Shared by the standard and caliblur themes via theme(). #}
+
+{% macro hierarchy_breadcrumbs(trails, col_id) %}
+  {# `trails` is a list of trails; each trail is a list of (name, path) pairs.
+     A bare (name, path) pair passed directly degrades gracefully instead of
+     raising, so a wrong call shape can never produce a server error. #}
+  {% for trail in trails %}
+    <nav class="hierarchy-breadcrumb">
+      {% if trail and trail[0] is string %}
+        <a href="{{ url_for('web.cc_category_list', column_id=col_id, category_path=trail[1]) }}">{{ trail[0] }}</a>
+      {% else %}
+        {% for name, path in trail %}
+          <a href="{{ url_for('web.cc_category_list', column_id=col_id, category_path=path) }}">{{ name }}</a>
+          {%- if not loop.last %}<span class="sep">&rsaquo;</span>{% endif %}
+        {% endfor %}
+      {% endif %}
+    </nav>
+  {% endfor %}
+{% endmacro %}
+
+{% macro render_tree_nodes(nodes, col_id, current_path='', depth=0) %}
+  {% for node in nodes %}
+    <li class="hierarchy-node depth-{{ depth }}{% if current_path.startswith(node.path) %} expanded{% else %} collapsed{% endif %}" data-path="{{ node.path }}">
+      <a href="{{ url_for('web.cc_category_list', column_id=col_id, category_path=node.path) }}">
+        <span class="hierarchy-toggle glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
+        {{ node.name }} <span class="badge badge-sm">{{ node.total_count }}</span>
+      </a>
+      {% if node.children %}
+        <ul class="hierarchy-children list-unstyled">
+          {{ render_tree_nodes(node.children, col_id, current_path, depth + 1) }}
+        </ul>
+      {% endif %}
+    </li>
+  {% endfor %}
+{% endmacro %}
+
+{% macro render_details_tree(nodes, col_id, current_path='') %}
+  {% for node in nodes %}
+    <details class="hierarchy-details" data-path="{{ node.path }}"
+             {% if current_path.startswith(node.path) %}open{% endif %}>
+      <summary>
+        <a href="{{ url_for('web.cc_category_list', column_id=col_id, category_path=node.path) }}">
+          {{ node.name }} <span class="badge badge-sm">{{ node.total_count }}</span>
+        </a>
+      </summary>
+      {% if node.children %}
+        {{ render_details_tree(node.children, col_id, current_path) }}
+      {% endif %}
+    </details>
+  {% endfor %}
+{% endmacro %}

--- a/cps/themes/caliblur/templates/user_edit.html
+++ b/cps/themes/caliblur/templates/user_edit.html
@@ -80,6 +80,14 @@
         </div>
       {% endif %}
     {% endfor %}
+    {% if cc_visibility %}
+      {% for option in cc_visibility %}
+        <div class="form-group">
+          <input type="checkbox" name="show_cc_{{option.id}}" id="show_cc_{{option.id}}" {% if option.visible %}checked{% endif %}>
+          <label for="show_cc_{{option.id}}">{{_('Show %(name)s Section', name=option.name)}}</label>
+        </div>
+      {% endfor %}
+    {% endif %}
       <div class="form-group">
           <input type="checkbox" name="Show_detail_random" id="Show_detail_random" {% if content.show_detail_random() %}checked{% endif %}>
           <label for="Show_detail_random">{{_('Show Random Books in Detail View')}}</label>

--- a/cps/themes/standard/templates/cc_list.html
+++ b/cps/themes/standard/templates/cc_list.html
@@ -1,0 +1,19 @@
+{% extends theme("layout.html") %}
+{% from theme('macros/hierarchy.html') import render_details_tree %}
+{% block body %}
+<h1 class="{{page}}">{{_(title)}}</h1>
+
+<div class="discover">
+  <p class="hierarchy-hint">{{_('Select a category to see the books assigned to it and all of its sub-categories.')}}</p>
+  <div class="btn-group hierarchy-actions" role="group">
+    <button id="hierarchy-expand-all" class="btn btn-default btn-sm">{{_('Expand all')}}</button>
+    <button id="hierarchy-collapse-all" class="btn btn-default btn-sm">{{_('Collapse all')}}</button>
+  </div>
+  <div class="hierarchy-tree" data-col-id="{{ col_id }}">
+    {{ render_details_tree(entries, col_id) }}
+  </div>
+</div>
+{% endblock %}
+{% block js %}
+<script src="{{ url_for('static', filename='js/hierarchy.js') }}"></script>
+{% endblock %}

--- a/cps/themes/standard/templates/detail.html
+++ b/cps/themes/standard/templates/detail.html
@@ -241,7 +241,14 @@
                                         {% elif c.datatype == 'series' %}
                                             {{ '%s [%s]' % (column.value, column.extra|formatfloat(2)) }}
                                         {% elif c.datatype == 'text' %}
-                                            {{ column.value.strip() }}{% if not loop.last %}, {% endif %}
+                                            {% if '.' in column.value %}
+                                                {% set parts = column.value.strip().split('.') %}
+                                                {% for part in parts %}
+                                                    <a class="hierarchy-crumb" href="{{ url_for('web.cc_category_list', column_id=c.id, category_path=parts[:loop.index]|join('.')) }}">{{ part }}</a>{% if not loop.last %}. {% endif %}
+                                                {% endfor %}
+                                            {% else %}
+                                                {{ column.value.strip() }}
+                                            {% endif %}{% if not loop.last %}, {% endif %}
                                         {% else %}
                                             {{ column.value }}
                                         {% endif %}

--- a/cps/themes/standard/templates/index.html
+++ b/cps/themes/standard/templates/index.html
@@ -1,6 +1,22 @@
 {% import 'image.html' as image %}
 {% extends theme("layout.html") %}
 {% block body %}
+{% if breadcrumbs %}
+  {% from theme('macros/hierarchy.html') import hierarchy_breadcrumbs %}
+  <div class="discover">
+  {{ hierarchy_breadcrumbs(breadcrumbs, col_id) }}
+  </div>
+{% endif %}
+{% if subcategories %}
+  <div class="discover hierarchy-subcategories">
+    <h3>{{_('Subcategories')}}</h3>
+    <ul class="hierarchy-sublist list-unstyled">
+    {% for sub in subcategories %}
+      <li><a href="{{ url_for('web.cc_category_list', column_id=col_id, category_path=sub.path) }}">{{ sub.name }} <span class="badge badge-sm">{{ sub.total_count }}</span></a></li>
+    {% endfor %}
+    </ul>
+  </div>
+{% endif %}
 {% if current_user.show_detail_random() and page != "discover" %}
 <div class="discover random-books">
   <h2 class="random-books">{{_('Discover (Random Books)')}}</h2>

--- a/cps/themes/standard/templates/layout.html
+++ b/cps/themes/standard/templates/layout.html
@@ -114,8 +114,8 @@
             <ul class="list-unstyled" id="scnd-nav" intent in-standard-append="nav.navigation" in-mobile-after="#main-nav" in-mobile-class="nav navbar-nav">
               <li class="nav-head hidden-xs">{{_('Browse')}}</li>
               {% for element in sidebar %}
-                {% if current_user.check_visibility(element['visibility']) and element['public'] %}
-                    <li id="nav_{{element['id']}}" {% if page == element['page'] %}class="active"{% endif %}><a href="{% if element['no_param'] %}{{url_for(element['link'], data=element['page'])}}{%else%}{{url_for(element['link'], data=element['page'], sort_param='stored')}}{% endif %}"><span class="glyphicon {{element['glyph']}}"></span> {{_(element['text'])}}</a></li>
+                {% if element['cc_id'] is defined or (current_user.check_visibility(element['visibility']) and element['public']) %}
+                    <li id="nav_{{element['id']}}" {% if page == element['page'] %}class="active"{% endif %}><a href="{% if element['href'] %}{{ element['href'] }}{% elif element['no_param'] %}{{url_for(element['link'], data=element['page'])}}{%else%}{{url_for(element['link'], data=element['page'], sort_param='stored')}}{% endif %}"><span class="glyphicon {{element['glyph']}}"></span> {{_(element['text'])}}</a></li>
                 {% endif %}
               {% endfor %}
               {% if current_user.is_authenticated or g.allow_anonymous %}

--- a/cps/themes/standard/templates/macros/hierarchy.html
+++ b/cps/themes/standard/templates/macros/hierarchy.html
@@ -1,0 +1,52 @@
+{# Recursive rendering helpers for hierarchical custom columns.
+   Shared by the standard and caliblur themes via theme(). #}
+
+{% macro hierarchy_breadcrumbs(trails, col_id) %}
+  {# `trails` is a list of trails; each trail is a list of (name, path) pairs.
+     A bare (name, path) pair passed directly degrades gracefully instead of
+     raising, so a wrong call shape can never produce a server error. #}
+  {% for trail in trails %}
+    <nav class="hierarchy-breadcrumb">
+      {% if trail and trail[0] is string %}
+        <a href="{{ url_for('web.cc_category_list', column_id=col_id, category_path=trail[1]) }}">{{ trail[0] }}</a>
+      {% else %}
+        {% for name, path in trail %}
+          <a href="{{ url_for('web.cc_category_list', column_id=col_id, category_path=path) }}">{{ name }}</a>
+          {%- if not loop.last %}<span class="sep">&rsaquo;</span>{% endif %}
+        {% endfor %}
+      {% endif %}
+    </nav>
+  {% endfor %}
+{% endmacro %}
+
+{% macro render_tree_nodes(nodes, col_id, current_path='', depth=0) %}
+  {% for node in nodes %}
+    <li class="hierarchy-node depth-{{ depth }}{% if current_path.startswith(node.path) %} expanded{% else %} collapsed{% endif %}" data-path="{{ node.path }}">
+      <a href="{{ url_for('web.cc_category_list', column_id=col_id, category_path=node.path) }}">
+        <span class="hierarchy-toggle glyphicon glyphicon-triangle-right" aria-hidden="true"></span>
+        {{ node.name }} <span class="badge badge-sm">{{ node.total_count }}</span>
+      </a>
+      {% if node.children %}
+        <ul class="hierarchy-children list-unstyled">
+          {{ render_tree_nodes(node.children, col_id, current_path, depth + 1) }}
+        </ul>
+      {% endif %}
+    </li>
+  {% endfor %}
+{% endmacro %}
+
+{% macro render_details_tree(nodes, col_id, current_path='') %}
+  {% for node in nodes %}
+    <details class="hierarchy-details" data-path="{{ node.path }}"
+             {% if current_path.startswith(node.path) %}open{% endif %}>
+      <summary>
+        <a href="{{ url_for('web.cc_category_list', column_id=col_id, category_path=node.path) }}">
+          {{ node.name }} <span class="badge badge-sm">{{ node.total_count }}</span>
+        </a>
+      </summary>
+      {% if node.children %}
+        {{ render_details_tree(node.children, col_id, current_path) }}
+      {% endif %}
+    </details>
+  {% endfor %}
+{% endmacro %}

--- a/cps/themes/standard/templates/user_edit.html
+++ b/cps/themes/standard/templates/user_edit.html
@@ -79,6 +79,14 @@
         </div>
       {% endif %}
     {% endfor %}
+    {% if cc_visibility %}
+      {% for option in cc_visibility %}
+        <div class="form-group">
+          <input type="checkbox" name="show_cc_{{option.id}}" id="show_cc_{{option.id}}" {% if option.visible %}checked{% endif %}>
+          <label for="show_cc_{{option.id}}">{{_('Show %(name)s Section', name=option.name)}}</label>
+        </div>
+      {% endfor %}
+    {% endif %}
       <div class="form-group">
           <input type="checkbox" name="Show_detail_random" id="Show_detail_random" {% if content.show_detail_random() %}checked{% endif %}>
           <label for="Show_detail_random">{{_('Show Random Books in Detail View')}}</label>

--- a/cps/web.py
+++ b/cps/web.py
@@ -40,7 +40,7 @@ from werkzeug.security import generate_password_hash, check_password_hash
 
 from . import constants, logger, isoLanguages, services, limiter
 from . import db, ub, config, app
-from . import calibre_db, kobo_sync_status
+from . import calibre_db, kobo_sync_status, hierarchy
 from .search import render_search_results, render_adv_search_results
 from .gdriveutils import getFileFromEbooksFolder, do_gdrive_download
 from .helper import check_valid_domain, check_email, check_username, \
@@ -53,7 +53,7 @@ from .redirect import get_redirect_location
 from .cw_babel import get_available_locale
 from .usermanagement import login_required_if_no_ano
 from .kobo_sync_status import remove_synced_book
-from .render_template import render_title_template
+from .render_template import render_title_template, get_custom_column_visibility_options
 from .kobo_sync_status import change_archived_books
 from .services.worker import WorkerThread
 from .tasks_status import render_task_status
@@ -400,6 +400,13 @@ def render_books_list(data, sort_param, book_id, page):
         return render_formats_books(page, book_id, order)
     elif data == "category":
         return render_category_books(page, book_id, order)
+    elif data.startswith("cc_"):
+        # Hierarchical custom column browse view (data == "cc_<column_id>")
+        try:
+            col_id = int(data[3:])
+        except ValueError:
+            abort(404)
+        return render_cc_category(page, col_id, book_id or '', order)
     elif data == "language":
         return render_language_books(page, book_id, order)
     elif data == "archived":
@@ -1148,6 +1155,86 @@ def category_list():
         abort(404)
 
 
+@web.route("/custom_column/<int:column_id>", defaults={'category_path': ''},
+           strict_slashes=False)
+@web.route("/custom_column/<int:column_id>/<path:category_path>",
+           strict_slashes=False)
+@login_required_if_no_ano
+def cc_category_list(column_id, category_path):
+    """Tree/list view for one hierarchical custom column.
+
+    /custom_column/5                     -> top-level nodes of column #5
+    /custom_column/5/Computers           -> books under 'Computers' (+ descendants)
+    /custom_column/5/Computers/DB        -> books under 'Computers.DB'
+    """
+    if column_id not in db.cc_classes:
+        abort(404)
+    col = calibre_db.session.query(db.CustomColumns).filter(
+        db.CustomColumns.id == column_id).first()
+    if not col or col.datatype not in ('text', 'enumeration'):
+        abort(404)
+    order = get_sort_function(request.args.get('sort_param', 'stored'), 'cc_%d' % column_id)
+    return render_cc_category(request.args.get('page', 1), column_id,
+                              category_path, order)
+
+
+def render_cc_category(page, col_id, path, order):
+    """Render either the tree overview (no path) or the filtered book list
+    for one node of a hierarchical custom column."""
+    if col_id not in db.cc_classes:
+        abort(404)
+    col = calibre_db.session.query(db.CustomColumns).filter(
+        db.CustomColumns.id == col_id).first()
+    if not col or col.datatype not in ('text', 'enumeration'):
+        abort(404)
+
+    # Flask's <path:...> converter captures slashes; our separator is '.'
+    path = (path or '').replace('/', hierarchy.SEPARATOR)
+    path = hierarchy.join_path([path])
+
+    try:
+        page = int(page)
+    except (TypeError, ValueError):
+        page = 1
+
+    if path:
+        node = hierarchy.get_node_by_path(
+            calibre_db.get_hierarchical_tree(col_id), path)
+        if node is None:
+            abort(404)
+        cc_rel = getattr(db.Books, 'custom_column_' + str(col_id))
+        entries, random, pagination = calibre_db.fill_indexpage(
+            page, 0,
+            db.Books,
+            cc_rel.any(calibre_db.hierarchical_cc_filter(col_id, path)),
+            [order[0][0], db.Series.name, db.Books.series_index],
+            True, config.config_read_column,
+            db.books_series_link,
+            db.Books.id == db.books_series_link.c.book,
+            db.Series)
+        # Prepend the column root as first crumb so every level can step back
+        # up to /custom_column/<id>
+        return render_title_template(
+            'index.html', random=random, entries=entries, pagination=pagination,
+            id=path,
+            title=_("%(column)s: %(name)s", column=col.name, name=path),
+            page="category", order=order[1],
+            breadcrumbs=[[ (col.name, '') ] + hierarchy.breadcrumb_trail(path)],
+            subcategories=node['children'], col_id=col_id)
+
+    # Root behaviour: show top-level nodes with aggregated child counts
+    tree = calibre_db.get_hierarchical_tree(col_id)
+    entries = []
+    for n in tree:
+        cat = db.Category(n['name'], n['path'], path=n['path'])
+        cat.count = n['total_count']
+        cat.children = n['children']
+        entries.append(cat)
+    return render_title_template(
+        'cc_list.html', entries=entries, folder='web.books_list',
+        charlist=list(), title=col.name, page="cclist",
+        data='cc_%d' % col_id, order=1, col_id=col_id, hierarchical=True)
+
 
 
 # ################################### Download/Send ##################################################################
@@ -1491,6 +1578,15 @@ def change_profile(kobo_support, local_oauth_check, oauth_status, translations, 
                 current_user.name = check_username(to_save.get("name"))
         current_user.random_books = 1 if to_save.get("show_random") == "on" else 0
         current_user.default_language = to_save.get("default_language", "all")
+        # Per-custom-column sidebar visibility (independent of the built-in
+        # section bitflags); stored in User.view_settings as 'cc_sidebar'
+        try:
+            for option in get_custom_column_visibility_options():
+                key = 'show_cc_%d' % option['id']
+                current_user.set_view_property('cc_sidebar', key,
+                                               to_save.get(key) == 'on')
+        except Exception:
+            log.error("Could not save custom column sidebar visibility", exc_info=True)
         current_user.locale = to_save.get("locale", "en")
         old_state = current_user.kobo_only_shelves_sync
         # 1 -> 0: nothing has to be done
@@ -1558,6 +1654,7 @@ def profile():
                                  content=current_user,
                                  config=config,
                                  kobo_support=kobo_support,
+                                 cc_visibility=get_custom_column_visibility_options(),
                                  title=_("%(name)s's Profile", name=current_user.name),
                                  page="me",
                                  registered_oauth=local_oauth_check,

--- a/test/hierarchy_template_test.py
+++ b/test/hierarchy_template_test.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+
+#  This file is part of the Calibre-Web (https://github.com/janeczku/calibre-web)
+#    Copyright (C) 2024 Calibre-Web contributors
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Render tests for the hierarchy Jinja macros.
+
+Guards the `breadcrumbs` data shape contract: the macro expects a *list of
+trails*, where each trail is a list of (name, path) tuples. Regression test
+for the "too many values to unpack" 500 errors.
+"""
+
+import os
+import unittest
+
+from jinja2 import Environment, FileSystemLoader
+
+TEMPLATE_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), os.pardir)
+# Forward slashes are mandatory: Jinja treats "\t" in a template name as a tab
+MACROS = 'cps/themes/standard/templates/macros/hierarchy.html'
+
+
+def fake_url_for(endpoint, **kwargs):
+    parts = [endpoint] + ['%s=%s' % (k, v) for k, v in sorted(kwargs.items())]
+    return '/' + '/'.join(parts)
+
+
+def render_breadcrumbs(trails, col_id=1):
+    env = Environment(loader=FileSystemLoader(TEMPLATE_ROOT))
+    env.globals['url_for'] = fake_url_for
+    tpl = env.from_string(
+        "{%% from '%s' import hierarchy_breadcrumbs %%}"
+        "{{ hierarchy_breadcrumbs(breadcrumbs, col_id) }}" % MACROS)
+    return tpl.render(breadcrumbs=trails, col_id=col_id)
+
+
+class TestBreadcrumbMacro(unittest.TestCase):
+
+    def test_single_trail_wrapped_in_list(self):
+        """Shape used by web.render_cc_category(): [[...one trail...]]"""
+        html = render_breadcrumbs([[('Genre', ''), ('Computers', 'Computers')]])
+        self.assertEqual(html.count('<nav'), 1)
+        self.assertIn('>Genre</a>', html)
+        self.assertIn('>Computers</a>', html)
+        # root crumb links to the column root (category_path='')
+        self.assertIn('category_path=', html)
+
+    def test_multiple_trails(self):
+        """Shape used for books with several hierarchical values."""
+        trails = [
+            [('Genre', ''), ('Computers', 'Computers')],
+            [('Genre', ''), ('Fiction', 'Fiction')],
+        ]
+        html = render_breadcrumbs(trails)
+        self.assertEqual(html.count('<nav'), 2)
+
+    def test_bare_pairs_degrade_gracefully(self):
+        """A bare list of (name, path) pairs (wrong shape) must not raise;
+        the macro degrades to rendering each pair as a single-crumb trail."""
+        html = render_breadcrumbs([('Genre', ''), ('Computers', 'Computers')])
+        self.assertIn('>Genre</a>', html)
+        self.assertIn('>Computers</a>', html)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/hierarchy_test.py
+++ b/test/hierarchy_test.py
@@ -1,0 +1,160 @@
+# -*- coding: utf-8 -*-
+
+#  This file is part of the Calibre-Web (https://github.com/janeczku/calibre-web)
+#    Copyright (C) 2024 Calibre-Web contributors
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for cps/hierarchy.py (no Flask/DB required).
+
+The module is loaded directly from its file path so the test can run even in
+environments where the optional Calibre-Web dependencies (Flask etc.) are not
+installed and ``cps/__init__.py`` cannot be imported.
+"""
+
+import importlib.util
+import os
+import unittest
+
+try:
+    from cps import hierarchy
+except ImportError:  # pragma: no cover - depends on environment
+    _spec = importlib.util.spec_from_file_location(
+        'hierarchy',
+        os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                     os.pardir, 'cps', 'hierarchy.py'))
+    hierarchy = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(hierarchy)
+
+
+class TestParseTagHierarchy(unittest.TestCase):
+
+    def test_basic_tree(self):
+        tree = hierarchy.parse_tag_hierarchy(
+            ['Computers.DB.Oracle', 'Computers.DB', 'Fiction'])
+        self.assertEqual(len(tree), 2)
+        computers = tree[0]
+        fiction = tree[1]
+        # sorted case-insensitively: Computers < Fiction
+        self.assertEqual(computers['name'], 'Computers')
+        self.assertEqual(fiction['name'], 'Fiction')
+        self.assertEqual(computers['path'], 'Computers')
+        self.assertEqual(computers['count'], 0)          # no direct hits
+        self.assertEqual(computers['total_count'], 2)    # DB + DB.Oracle
+        db_node = computers['children'][0]
+        self.assertEqual(db_node['name'], 'DB')
+        self.assertEqual(db_node['path'], 'Computers.DB')
+        self.assertEqual(db_node['count'], 1)
+        oracle = db_node['children'][0]
+        self.assertEqual(oracle['path'], 'Computers.DB.Oracle')
+        self.assertEqual(oracle['children'], [])
+
+    def test_empty_and_blank_values(self):
+        self.assertEqual(hierarchy.parse_tag_hierarchy([]), [])
+        self.assertEqual(hierarchy.parse_tag_hierarchy(['', None, '   ']), [])
+
+    def test_whitespace_is_stripped(self):
+        tree = hierarchy.parse_tag_hierarchy([' A . B '])
+        self.assertEqual(tree[0]['name'], 'A')
+        self.assertEqual(tree[0]['children'][0]['name'], 'B')
+
+    def test_duplicate_values_aggregate_counts(self):
+        tree = hierarchy.parse_tag_hierarchy(['X.Y', 'X.Y', 'X'])
+        x = tree[0]
+        self.assertEqual(x['count'], 1)
+        self.assertEqual(x['total_count'], 3)
+        self.assertEqual(x['children'][0]['count'], 2)
+
+    def test_sorting_case_insensitive(self):
+        tree = hierarchy.parse_tag_hierarchy(['banana', 'Apple', 'cherry'])
+        names = [n['name'] for n in tree]
+        self.assertEqual(names, ['Apple', 'banana', 'cherry'])
+
+
+class TestGetNodeByPath(unittest.TestCase):
+
+    def setUp(self):
+        self.tree = hierarchy.parse_tag_hierarchy(
+            ['Computers.DB.Oracle', 'Fiction'])
+
+    def test_existing_path(self):
+        node = hierarchy.get_node_by_path(self.tree, 'Computers.DB')
+        self.assertIsNotNone(node)
+        self.assertEqual(node['name'], 'DB')
+
+    def test_root_level(self):
+        node = hierarchy.get_node_by_path(self.tree, 'Fiction')
+        self.assertIsNotNone(node)
+
+    def test_missing_branch_returns_none(self):
+        self.assertIsNone(hierarchy.get_node_by_path(self.tree, 'Computers.Bogus'))
+        self.assertIsNone(hierarchy.get_node_by_path(self.tree, 'Bogus'))
+        self.assertIsNone(hierarchy.get_node_by_path(self.tree, ''))
+
+
+class TestBreadcrumbTrail(unittest.TestCase):
+
+    def test_trail(self):
+        self.assertEqual(
+            hierarchy.breadcrumb_trail('Computers.DB'),
+            [('Computers', 'Computers'), ('DB', 'Computers.DB')])
+
+    def test_single_element(self):
+        self.assertEqual(hierarchy.breadcrumb_trail('Fiction'),
+                         [('Fiction', 'Fiction')])
+
+
+class TestIsHierarchicalValueSet(unittest.TestCase):
+
+    def test_true_hierarchy_detected(self):
+        self.assertTrue(hierarchy.is_hierarchical_value_set(
+            ['Computers', 'Computers.DB', 'Computers.DB.Oracle', 'Fiction']))
+
+    def test_dot_but_flat_not_hierarchical(self):
+        # Dewey/LCC-style values contain dots but no prefix relations
+        self.assertFalse(hierarchy.is_hierarchical_value_set(
+            ['778.3', '775', '891.73', 'QA76.76.C68']))
+
+    def test_empty_and_single_values(self):
+        self.assertFalse(hierarchy.is_hierarchical_value_set([]))
+        self.assertFalse(hierarchy.is_hierarchical_value_set(['Computers']))
+        self.assertFalse(hierarchy.is_hierarchical_value_set([None, '']))
+
+    def test_prefix_collision_is_not_hierarchy(self):
+        # 'ComputersX' does not make 'Computers' a hierarchy root
+        self.assertFalse(hierarchy.is_hierarchical_value_set(
+            ['Computers', 'ComputersX']))
+
+
+class TestLikeEscaping(unittest.TestCase):
+
+    def test_escape_like_wildcards(self):
+        self.assertEqual(hierarchy.escape_like('100%'), r'100\%')
+        self.assertEqual(hierarchy.escape_like('a_b'), r'a\_b')
+        self.assertEqual(hierarchy.escape_like(r'a\b'), r'a\\b')
+
+    def test_like_pattern_guards_prefix_collisions(self):
+        # '.' is not a LIKE wildcard, so no escaping required; the trailing
+        # dot guards against 'ComputersX' matching prefix 'Computers'.
+        pattern = hierarchy.like_pattern('Computers')
+        self.assertEqual(pattern, 'Computers.%')
+        self.assertNotEqual(pattern, 'ComputersX%')
+
+    def test_like_pattern_escapes_wildcards_in_path(self):
+        # A node literally named '100%' must not match '1000...'
+        self.assertEqual(hierarchy.like_pattern('100%'), r'100\%.%')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Add hierarchical custom-column browsing

## Overview

Calibre supports subgroups via custom columns. ref: https://manual.calibre-ebook.com/sub_groups.html
This PR adds support for browsing Calibre custom columns containing hierarchical values using Calibre's `.` separator convention.

For example:

```text
Computers
Computers.DB
Computers.DB.Oracle
Computers.DB.PostgreSQL
Computers.Programming
Science.Physics
Science.Physics.Quantum
```

<img width="826" height="822" alt="genre_cc" src="https://github.com/user-attachments/assets/c7ce2d6f-e730-47bd-b0f6-9f47eafbbd20" />

<img width="354" height="816" alt="admin" src="https://github.com/user-attachments/assets/f7b216fc-4379-43b4-8dca-9324f6bedd99" />

The implementation is intentionally **generic and does not hard-code a column such as `Genre`**. Users can have multiple custom metadata columns, and any suitable text/enumeration column can be presented as a hierarchy.

## Motivation

Calibre supports hierarchical values using the `.` separator, but Calibre-Web currently treats these values as flat strings.

This makes libraries using hierarchical custom metadata difficult to browse, particularly when the hierarchy is used as the primary classification system.

This relates to existing requests including:

- #2449 — Custom columns in the sidebar
- #1185 — Custom columns as categories
- #2019 — Hierarchical tag parsing
- #3097 — Categories / Hierarchy

## Implementation

The change introduces:

- Generic hierarchical custom-column detection
- Hierarchy parsing and tree construction
- Detection of actual hierarchical value sets rather than assuming every dotted value is hierarchical
- Hierarchical descendant filtering
- Hierarchical search semantics
- Tree-based browsing in the web UI
- Breadcrumb navigation
- Per-user sidebar visibility for custom columns
- OPDS navigation for hierarchical custom columns
- Expand/collapse state persistence in the browser
- Support for arbitrary text/enumeration custom columns

A column is considered hierarchical only when stored values demonstrate a parent/descendant relationship, for example:

```text
Computers
Computers.DB
```

This is intended to avoid incorrectly interpreting values such as:

```text
778.3
QA76.76.C68
```
as hierarchical values merely because they contain periods.

## Technical details 

## 1. Change details

Calibre stores hierarchical categories in tag-like custom columns using dot
notation (`Computers.DB.Oracle`). Calibre-Web previously treated these as flat
strings. After this change:

| Capability | Where |
|---|---|
| Sidebar entry per browsable custom column (tree for hierarchies, flat list otherwise) | left "Browse" navigation |
| Tree view with collapse/expand, Expand all / Collapse all, state persisted per session | `/custom_column/<id>` |
| Node browsing with drill-down: breadcrumbs up to the root, subcategory links down | `/custom_column/<id>/<path>` |
| Prefix filtering: clicking `Computers` returns books tagged `Computers` **and** all descendants (`Computers.DB`, `Computers.DB.Oracle`) | book list under any node |
| Breadcrumb navigation on book detail pages for dotted values | `#genre` values on `/book/<id>` |
| Calibre-style search semantics in advanced search (`Computers` matches exact node + descendants, not substrings) | advanced search form |
| OPDS feeds exposing the hierarchy level-by-level | `/opds/custom_column/<id>[/<path>]` |
| Per-user, per-column sidebar visibility with named checkboxes | profile page `/me` |

Example URLs (library with `Genre` as custom column id 1):

```
/custom_column/1                      → root tree of #genre
/custom_column/1/Computers            → books under Computers (+ descendants)
/custom_column/1/Computers/Photoshop  → deeper level
/opds/custom_column/1                 → OPDS navigation feed
```

---

## 2. New files

| File | Purpose |
|---|---|
| [`cps/hierarchy.py`](cps/hierarchy.py) | Pure-Python helpers, no Flask/SQLAlchemy dependencies: `parse_tag_hierarchy()` (flat dot-notation values → nested `{name, path, count, total_count, children}` nodes), `get_node_by_path()`, `breadcrumb_trail()`, `split_path()`/`join_path()`, LIKE escaping (`escape_like()`, `like_pattern()`), and `is_hierarchical_value_set()` (hierarchy detection predicate) |
| [`cps/static/js/hierarchy.js`](cps/static/js/hierarchy.js) | Persists `<details>` open/closed state in `sessionStorage` keyed by column id + dotted path; wires Expand/Collapse-all buttons |
| [`cps/themes/standard/templates/macros/hierarchy.html`](cps/themes/standard/templates/macros/hierarchy.html) (+ caliblur copy) | Shared Jinja macros: `render_tree_nodes` (nested `<ul>`), `render_details_tree` (`<details>/<summary>`), `hierarchy_breadcrumbs` |
| [`cps/themes/standard/templates/cc_list.html`](cps/themes/standard/templates/cc_list.html) (+ caliblur copy) | Root tree view page for a custom column |
| [`test/hierarchy_test.py`](test/hierarchy_test.py) | 20 unit tests: tree building, count aggregation, path lookup, breadcrumbs, LIKE escaping, hierarchy-detection predicate |
| [`test/hierarchy_template_test.py`](test/hierarchy_template_test.py) | 3 render tests executing the breadcrumb macro through Jinja (with stubbed `url_for`) to lock down the data-shape contract |

## 3. Changed files

| File | Change |
|---|---|
| [`cps/db.py`](cps/db.py) | `CalibreDB.hierarchical_cc_filter(col_id, path)` — SQLAlchemy filter matching a node plus descendants; `CalibreDB.get_hierarchical_tree(col_id)` — one DISTINCT query joined through `Books` so `common_filters()` apply; `CalibreDB.get_hierarchical_column_ids(ttl=300)` — process-wide TTL-cached hierarchy detection;  `CalibreDB.hierarchical_cc_search_filter(col_id, term)` — exact-or-descendant search filter; `Category` DTO extended with `path` and `children`;  added `import time`, `from . import hierarchy` |
| [`cps/web.py`](cps/web.py) | Routes `/custom_column/<int:column_id>[/<path:category_path>]` (`strict_slashes=False`) + `render_cc_category()`; dispatch hook in `render_books_list()` for `data="cc_<id>"`; `profile()` passes `cc_visibility` options; `change_profile()` persists `show_cc_<id>` checkboxes into `User.view_settings` |
| [`cps/search.py`](cps/search.py) | `adv_search_custom_columns()` routes text/enumeration searches on detected hierarchical columns through the prefix filter; other columns keep fuzzy substring behaviour |
| [`cps/opds.py`](cps/opds.py) | Feed `/opds/custom_column/<int:column_id>[/<path:category_path>]`: navigation entries per child node, acquisition feed at leaves |
| [`cps/render_template.py`](cps/render_template.py) | `get_custom_column_sidebar_entries()` — sidebar entry per visible text/enumeration column, honouring per-user visibility; `get_custom_column_visibility_options()` — full option list (including disabled columns) for the profile page |
| [`cps/templates/feed.xml`](cps/templates/feed.xml) | New `hierarchyelements` block rendering subsection links for hierarchy feeds |
| [`cps/themes/*/templates/layout.html`](cps/themes/standard/templates/layout.html) | Sidebar loop: entries carrying `cc_id` bypass the `check_visibility(SIDEBAR_CATEGORY)` gate (independence from Categories); optional precomputed `element['href']` support |
| [`cps/themes/*/templates/index.html`](cps/themes/standard/templates/index.html) | Breadcrumb trail + "Subcategories" drill-down panel (plain list links, not buttons) when rendering a hierarchy node |
| [`cps/themes/*/templates/detail.html`](cps/themes/standard/templates/detail.html) | Dotted text-column values render as clickable per-level links (breadcrumb-style) |
| [`cps/themes/*/templates/user_edit.html`](cps/themes/standard/templates/user_edit.html) | Named checkbox group ("Show `<column>` Section") driven by `cc_visibility` |
| [`cps/static/css/style.css`](cps/static/css/style.css) | Styles for tree nodes, `<details>` trees, badges, breadcrumbs, subcategory lists |

---   


## Example

A custom column containing:

```text
Computers.DB.Oracle
Computers.DB.PostgreSQL
Computers.Programming.Python
Science.Physics.Quantum
```

is presented approximately as:

```text
Computers
├── DB
│   ├── Oracle
│   └── PostgreSQL
└── Programming
    └── Python

Science
└── Physics
    └── Quantum
```

Selecting `Computers.DB` displays books assigned to `Computers.DB` as well as books assigned to descendants such as `Computers.DB.Oracle`.




## Request for review

This implementation is working for me, as I am using hierarchies quite a lot to classify my library. It would be nice to hear from other people if it is working for them as well.

