### PR TITLE
Google Books: retry transient errors, and report a failed search instead of "No results found"

### DIFF
--- a/cps/metadata_provider/google.py
+++ b/cps/metadata_provider/google.py
@@ -22,12 +22,21 @@ from urllib.parse import quote
 from datetime import datetime
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 from cps import logger, config
 from cps.isoLanguages import get_lang3, get_language_name
 from cps.services.Metadata import MetaRecord, MetaSourceInfo, Metadata
 
 log = logger.create()
+
+# Google answers a share of requests with a transient 5xx, which is otherwise
+# indistinguishable from "not found". raise_on_status lets the last response
+# through so it is logged with its status instead of as a MaxRetryError.
+RETRY = Retry(total=3, backoff_factor=0.3, status_forcelist=(500, 502, 503, 504),
+              raise_on_status=False)
+TIMEOUT = (5, 15)
 
 
 class Google(Metadata):
@@ -38,7 +47,6 @@ class Google(Metadata):
     BOOK_URL = "https://books.google.com/books?id="
     SEARCH_URL = "https://www.googleapis.com/books/v1/volumes?q="
     ISBN_TYPE = "ISBN_13"
-    API_KEY = "&key=" + config.config_googlebooks_api_key 
 
     def search(
         self, query: str, generic_cover: str = "", locale: str = "en"
@@ -50,12 +58,21 @@ class Google(Metadata):
             if title_tokens:
                 tokens = [quote(t.encode("utf-8")) for t in title_tokens]
                 query = "+".join(tokens)
+            # Read per search, so a key saved in the admin page takes effect
+            # without a restart.
+            key = config.config_googlebooks_api_key
             try:
-                results = requests.get(Google.SEARCH_URL + query + Google.API_KEY)
+                # A session per call: Session is not thread-safe and the
+                # providers are searched in a thread pool.
+                session = requests.Session()
+                session.mount("https://", HTTPAdapter(max_retries=RETRY))
+                results = session.get(
+                    Google.SEARCH_URL + query + ("&key=" + key if key else ""),
+                    timeout=TIMEOUT)
                 results.raise_for_status()
             except Exception as e:
                 log.warning(e)
-                return []
+                return None      # None is a failed search, [] is an empty one
             for result in results.json().get("items", []):
                 val.append(
                     self._parse_search_result(

--- a/cps/search_metadata.py
+++ b/cps/search_metadata.py
@@ -157,6 +157,7 @@ def metadata_search():
     data = list()
     active = current_user.view_settings.get("metadata", {})
     locale = get_locale()
+    asked = failed = 0
     if query:
         static_cover = url_for("static", filename="generic_cover.jpg")
         # ret = cl[0].search(query, static_cover, locale)
@@ -166,6 +167,20 @@ def metadata_search():
                 for c in cl
                 if active.get(c.__id__, True)
             }
+            asked = len(meta)
             for future in concurrent.futures.as_completed(meta):
-                data.extend(_serialize_metadata_records(future.result()))
+                try:
+                    records = future.result()
+                except Exception as e:
+                    # One provider raising used to fail the whole request.
+                    log.warning("Metadata provider %s failed: %s", meta[future].__id__, e)
+                    records = None
+                if records is None:     # failed, as opposed to found nothing
+                    failed += 1
+                    continue
+                data.extend(_serialize_metadata_records(records))
+    # Nothing to say about the keyword if every source failed, so 502 makes the
+    # client show "Search error!" rather than "No Result(s) found!".
+    if asked and failed == asked:
+        return make_response(jsonify(data), 502)
     return make_response(jsonify(data))


### PR DESCRIPTION
### Problem

A Google Books metadata search that **fails** is shown to the user as
`No Result(s) found! Please try another keyword.` — the same message as a
search that genuinely found nothing. So a user whose search errored is sent
looking for a keyword problem that does not exist.

`Google.search()` catches every exception and returns `[]`, and
`/metadata/search` cannot tell that from a real empty result. Three ways it
happens today:

**1. No API key configured — which is the default.** An unkeyed Books call is
billed to a shared anonymous Google project whose daily quota is permanently
exhausted:

```
$ curl -s 'https://www.googleapis.com/books/v1/volumes?q=dune'
429  RESOURCE_EXHAUSTED
"Quota exceeded for quota metric 'Queries' and limit 'Queries per day' of
 service 'books.googleapis.com' for consumer 'project_number:<redacted>'."
```

That consumer is not the caller's project — it is the anonymous one Google
bills an unkeyed call to. The response names the *same* project number from
two unrelated networks (a datacentre and a home connection), so it is one
shared project, exhausted for everybody, rather than per-IP throttling. Any
`curl` like the one above will show you the number.

So a stock install with no key gets nothing from Google Books on any search,
and is told its keyword is wrong. That may account for some of the recurring
"Google metadata returns no results" reports.

**2. Transient 5xx, even with a valid key.** Over 12 single-shot keyed
requests just now, 2 answered `503`. There is no retry anywhere in `cps/`
(`grep -rniE 'Retry\(|backoff_factor|max_retries|status_forcelist' cps/ --include='*.py'`
matches nothing on Develop).

**3. No request timeout at all.** A stalled connection holds the search thread
until the client gives up, and `/metadata/search` waits on every provider
before it answers.

### Solution

- **Retry + timeout.** `google.py` mounts an `HTTPAdapter` with a urllib3
  `Retry` (3 retries, 0.3 backoff, on 500/502/503/504) and passes a `(5, 15)`
  timeout. `429` is deliberately **not** retried — an exhausted daily quota
  does not clear, so it should fail fast rather than stall the user.

- **`None` means failed, `[]` means empty.** The signature is already
  `Optional[List[MetaRecord]]`, and every caller already handles `None` via
  `_serialize_metadata_records(records or [])`, so this needs no interface
  change.

- **The route reports it.** `metadata_search` counts the providers that
  failed and answers `502` when *every* provider it asked failed. If some
  succeeded, the user gets those results and no error, as before.
  `get_meta.js` already distinguishes `msg.search_error` from
  `msg.no_result` — it simply had no way to know which had happened. So the
  user now sees **"Search error!"**, an existing string already translated in
  every locale. **No new text, no translation work, no JS change.**

- **One broken provider no longer fails the whole request.**
  `future.result()` re-raised, so a single provider throwing took down the
  results of every other provider with it.

- **The API key is read per search** rather than built into the `API_KEY`
  class attribute at import, so saving a key in the admin page takes effect
  without a restart. (It also removes an accidental dependency on
  `load_configuration` having run before the provider module is imported.)

### Behaviour change to be aware of

The `Google.API_KEY` class attribute is gone; the key is read inline in
`search()`. Nothing in the tree referenced it, but a downstream fork patching
that attribute would notice.

### Testing

Verified against Develop with a local venv from `requirements.txt`:

| case | before | after |
|---|---|---|
| 3 × 503 then 200 | 1 attempt, search returns `[]` | 4 attempts over 1.8s, 200, results |
| persistent 503 | `[]` → "No Result(s) found" | `None` → 502 → "Search error!" |
| no API key (429) | `[]` → "No Result(s) found" | `None` → 502 → "Search error!" |
| valid key, real query | 5/5 returned results (small sample; the 503 behaviour is covered by the stub rows above) | 5/5 |
| nonsense query | `[]` | `[]` → 200, "No Result(s) found" (unchanged) |
| one provider fails, one works | working provider's results shown | unchanged |
| one provider **raises**, one works | HTTP 500, all results lost | 200, working provider's results |
| all providers empty | 200, "No Result(s) found" | unchanged |

### Not included — happy to add if you want them

- `cps/admin.py` still sets `reboot_required` for
  `config_googlebooks_api_key`, which the change above makes unnecessary.
- The other five providers still return `[]` on failure. Each would need the
  same two lines to benefit from the new route behaviour.

Targeting `Develop` per CONTRIBUTING.md, since this touches more than a local
section.
